### PR TITLE
CLI support for user dictionary.

### DIFF
--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -27,6 +27,14 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("USER_DICTIONARY")
+            .help("(Optional) The user dictionary file path.")
+            .short("u")
+            .long("userdic")
+            .value_name("USER_DICTIONARY")
+            .takes_value(true),
+        )
+        .arg(
             Arg::with_name("MODE")
                 .help("The tokenization mode. `normal` or` search` can be specified. If not specified, use the default mode.")
                 .short("m")
@@ -59,11 +67,21 @@ fn main() {
         dict_dir = _dict_dir;
     }
 
+    // user dictionary
+    let mut user_dict = "";
+    if let Some(_user_dict) = matches.value_of("USER_DICTIONARY") {
+        user_dict = _user_dict;
+    }
+
     // mode
     let mode_name = matches.value_of("MODE").unwrap();
 
     // create tokenizer
-    let mut tokenizer = Tokenizer::new(mode_name, dict_dir);
+    let mut tokenizer = if user_dict.len() > 0 {
+        Tokenizer::new_with_userdic(mode_name, dict_dir, user_dict)
+    } else {
+        Tokenizer::new(mode_name, dict_dir)
+    };
 
     // output format
     let output_format = matches.value_of("OUTPUT").unwrap();


### PR DESCRIPTION
Closes #66 

Added an option to support #64 in the CLI tool.

Usage:
```
$ cat userdic.csv 
東京スカイツリー,カスタム名詞,トウキョウスカイツリー
$ lindera -u userdic.csv
東京スカイツリーの高さは634mです
東京スカイツリー        カスタム名詞,*,*,*,*,*,東京スカイツリー,トウキョウスカイツリー,*
の      助詞,連体化,*,*,*,*,の,ノ,ノ
高      形容詞,自立,*,*,形容詞・アウオ段,ガル接続,高い,タカ,タカ
さ      名詞,接尾,特殊,*,*,*,さ,サ,サ
は      助詞,係助詞,*,*,*,*,は,ハ,ワ
634     UNK
m       UNK
です    助動詞,*,*,*,特殊・デス,基本形,です,デス,デス
EOS
```