### PR TITLE
implement binary data reading and writing for user dictionary

### DIFF
--- a/lindera-core/src/file_util.rs
+++ b/lindera-core/src/file_util.rs
@@ -7,27 +7,25 @@ use encoding::{DecoderTrap, Encoding};
 use crate::error::LinderaErrorKind;
 use crate::LinderaResult;
 
-pub fn read_euc_file(filename: &Path) -> LinderaResult<String> {
+pub fn read_file(filename: &Path) -> LinderaResult<Vec<u8>> {
     let mut input_read = File::open(filename)
         .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
     let mut buffer = Vec::new();
     input_read
         .read_to_end(&mut buffer)
         .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
+    Ok(buffer)
+}
 
+pub fn read_euc_file(filename: &Path) -> LinderaResult<String> {
+    let buffer = read_file(filename)?;
     encoding::all::EUC_JP
         .decode(&buffer, DecoderTrap::Strict)
         .map_err(|err| LinderaErrorKind::Decode.with_error(anyhow::anyhow!(err)))
 }
 
 pub fn read_utf8_file(filename: &Path) -> LinderaResult<String> {
-    let mut input_read = File::open(filename)
-        .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-    let mut buffer = Vec::new();
-    input_read
-        .read_to_end(&mut buffer)
-        .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-
+    let buffer = read_file(filename)?;
     encoding::all::UTF_8
         .decode(&buffer, DecoderTrap::Strict)
         .map_err(|err| LinderaErrorKind::Decode.with_error(anyhow::anyhow!(err)))

--- a/lindera-core/src/prefix_dict.rs
+++ b/lindera-core/src/prefix_dict.rs
@@ -1,12 +1,21 @@
 use std::ops::Deref;
 
+use serde::{Deserialize, Serialize};
 use yada::DoubleArray;
 
 use crate::word_entry::WordEntry;
 
-#[derive(Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(remote = "DoubleArray")]
+struct DoubleArrayDef<T>(pub T)
+where
+    T: Deref<Target = [u8]>;
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct PrefixDict<Data = Vec<u8>> {
+    #[serde(with = "DoubleArrayDef")]
     pub da: DoubleArray<Vec<u8>>,
+
     pub vals_data: Data,
     pub is_system: bool,
 }

--- a/lindera-core/src/user_dictionary.rs
+++ b/lindera-core/src/user_dictionary.rs
@@ -1,7 +1,19 @@
-use crate::prefix_dict::PrefixDict;
+use serde::{Deserialize, Serialize};
 
+use crate::error::LinderaErrorKind;
+use crate::prefix_dict::PrefixDict;
+use crate::LinderaResult;
+
+#[derive(Serialize, Deserialize)]
 pub struct UserDictionary {
     pub dict: PrefixDict<Vec<u8>>,
     pub words_idx_data: Vec<u8>,
     pub words_data: Vec<u8>,
+}
+
+impl UserDictionary {
+    pub fn load(user_dict_data: &[u8]) -> LinderaResult<UserDictionary> {
+        bincode::deserialize(user_dict_data)
+            .map_err(|err| LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err)))
+    }
 }

--- a/lindera-ipadic-builder/Cargo.toml
+++ b/lindera-ipadic-builder/Cargo.toml
@@ -32,3 +32,7 @@ lindera-core = { version = "0.8.0", path = "../lindera-core" }
 [[bin]]
 name = "lindera-ipadic-builder"
 path = "src/main.rs"
+
+[[bin]]
+name = "lindera-userdic-builder"
+path = "src/bin/lindera-userdic-builder/main.rs"

--- a/lindera-ipadic-builder/src/bin/lindera-userdic-builder/main.rs
+++ b/lindera-ipadic-builder/src/bin/lindera-userdic-builder/main.rs
@@ -1,0 +1,65 @@
+use std::fs::File;
+use std::io::{self, Write};
+use std::path::Path;
+
+use clap::{crate_authors, crate_description, crate_name, crate_version, App, AppSettings, Arg};
+
+use lindera_core::dictionary_builder::DictionaryBuilder;
+use lindera_core::error::LinderaErrorKind;
+use lindera_core::user_dictionary::UserDictionary;
+use lindera_core::LinderaResult;
+use lindera_ipadic_builder::ipadic_builder::IpadicBuilder;
+
+fn write_binary_data(file_path: &Path, user_dict: &UserDictionary) -> LinderaResult<()> {
+    let mut wtr = io::BufWriter::new(
+        File::create(file_path)
+            .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?,
+    );
+    bincode::serialize_into(&mut wtr, user_dict)
+        .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+    wtr.flush()
+        .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
+
+    Ok(())
+}
+
+fn main() -> LinderaResult<()> {
+    let app = App::new(crate_name!())
+        .setting(AppSettings::DeriveDisplayOrder)
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(crate_description!())
+        .help_message("Prints help information.")
+        .version_message("Prints version information.")
+        .version_short("v")
+        .arg(
+            Arg::with_name("INPUT_CSV")
+                .help("CSV file of UserDictionary.")
+                .value_name("INPUT_CSV")
+                .required(true)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("OUTPUT_FILE")
+                .help("Binary file of the UserDictionary.")
+                .value_name("OUTPUT_FILE")
+                .required(true)
+                .takes_value(true),
+        );
+
+    let matches = app.get_matches();
+
+    let input_csv_path = Path::new(matches.value_of("INPUT_CSV").unwrap()).to_path_buf();
+    let output_file_path = Path::new(matches.value_of("OUTPUT_FILE").unwrap()).to_path_buf();
+
+    let builder = IpadicBuilder::new();
+    match builder.build_user_dict(&input_csv_path) {
+        Ok(user_dict) => {
+            write_binary_data(&output_file_path, &user_dict)?;
+            println!("done");
+        }
+        Err(msg) => println!("{}!", msg),
+    }
+
+    Ok(())
+}

--- a/lindera-ipadic-builder/src/main.rs
+++ b/lindera-ipadic-builder/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> LinderaResult<()> {
     let builder = IpadicBuilder::new();
 
     match builder.build_dictionary(&input_dir, &output_dir) {
-        Ok(()) => println!("{}", "done"),
+        Ok(()) => println!("done"),
         Err(msg) => println!("{}", msg),
     }
 

--- a/lindera/README.md
+++ b/lindera/README.md
@@ -86,9 +86,9 @@ use lindera_core::LinderaResult;
 fn main() -> LinderaResult<()> {
     // create tokenizer
     let config = TokenizerConfig {
-        dict_path: None,
         user_dict_path: Some(&Path::new("resources/userdic.csv")),
         mode: Mode::Normal,
+        ..TokenizerConfig::default()
     };
     let mut tokenizer = Tokenizer::with_config(config)?;
 

--- a/lindera/benches/bench.rs
+++ b/lindera/benches/bench.rs
@@ -18,9 +18,9 @@ fn bench_constructor_with_custom_dict(c: &mut Criterion) {
     c.bench_function("bench-constructor-custom-dict", |b| {
         b.iter(|| {
             let config = TokenizerConfig {
-                dict_path: None,
                 user_dict_path: Some(&Path::new("resources/userdic.csv")),
                 mode: Mode::Normal,
+                ..TokenizerConfig::default()
             };
             Tokenizer::with_config(config).unwrap()
         })
@@ -36,9 +36,9 @@ fn bench_tokenize(c: &mut Criterion) {
 
 fn bench_tokenize_with_custom_dict(c: &mut Criterion) {
     let config = TokenizerConfig {
-        dict_path: None,
         user_dict_path: Some(&Path::new("resources/userdic.csv")),
         mode: Mode::Normal,
+        ..TokenizerConfig::default()
     };
     let mut tokenizer = Tokenizer::with_config(config).unwrap();
     c.bench_function("bench-tokenize-custom-dict", |b| {

--- a/lindera/examples/userdic_example.rs
+++ b/lindera/examples/userdic_example.rs
@@ -7,9 +7,9 @@ use lindera_core::LinderaResult;
 fn main() -> LinderaResult<()> {
     // create tokenizer
     let config = TokenizerConfig {
-        dict_path: None,
         user_dict_path: Some(&Path::new("resources/userdic.csv")),
         mode: Mode::Normal,
+        ..TokenizerConfig::default()
     };
     let mut tokenizer = Tokenizer::with_config(config)?;
 


### PR DESCRIPTION
# Pull Request

## Problem

The more lines in `userdic.csv`, the longer it will take to create the `tokenizer`.

In my environment, with 180,000 rows of CSV, it takes about 14 seconds to run `lindera/examples/userdic_example.rs`.

## Solution

Create a binary version of the user dictionary in advance.
How about loading it in the `tokenizer`?

With the same CSV data of 180,000 rows It takes about 7 seconds to run `lindera/examples/userdic_example.rs` using the binary loading method.

The code is a proposed implementation.
Please let us know what you think of this approach.