### PR TITLE
docs(readme): update the code example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ use lindera_core::LinderaResult;
 fn main() -> LinderaResult<()> {
     // create tokenizer
     let config = TokenizerConfig {
-        dict_path: None,
         user_dict_path: Some(&Path::new("resources/userdic.csv")),
         mode: Mode::Normal,
+        ..TokenizerConfig::default()
     };
     let mut tokenizer = Tokenizer::with_config(config)?;
 


### PR DESCRIPTION
The code example in README has been fixed because it gives an error.
(This is due to a change in https://github.com/lindera-morphology/lindera/pull/114.)