### PR TITLE
Make tokenize method immutable

### DIFF
--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> LinderaResult<()> {
     }
 
     // create tokenizer
-    let mut tokenizer = Tokenizer::with_config(config)?;
+    let tokenizer = Tokenizer::with_config(config)?;
 
     // output format
     let output_format = match args.output_format {

--- a/lindera/benches/bench.rs
+++ b/lindera/benches/bench.rs
@@ -29,7 +29,7 @@ fn bench_constructor_with_custom_dict(c: &mut Criterion) {
 }
 
 fn bench_tokenize(c: &mut Criterion) {
-    let mut tokenizer = Tokenizer::new().unwrap();
+    let tokenizer = Tokenizer::new().unwrap();
     c.bench_function("bench-tokenize-wiki", |b| {
         b.iter(|| tokenizer.tokenize("検索エンジン（けんさくエンジン、英語: search engine）は、狭義にはインターネットに存在する情報（ウェブページ、ウェブサイト、画像ファイル、ネットニュースなど）を検索する機能およびそのプログラム。"))
     });
@@ -42,7 +42,7 @@ fn bench_tokenize_with_custom_dict(c: &mut Criterion) {
         mode: Mode::Normal,
         ..TokenizerConfig::default()
     };
-    let mut tokenizer = Tokenizer::with_config(config).unwrap();
+    let tokenizer = Tokenizer::with_config(config).unwrap();
     c.bench_function("bench-tokenize-custom-dict", |b| {
         b.iter(|| tokenizer.tokenize("東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です"))
     });
@@ -52,7 +52,7 @@ fn bench_tokenize_long_text(c: &mut Criterion) {
     let mut large_file = BufReader::new(File::open("resources/bocchan.txt").unwrap());
     let mut large_text = String::new();
     let _size = large_file.read_to_string(&mut large_text).unwrap();
-    let mut tokenizer = Tokenizer::new().unwrap();
+    let tokenizer = Tokenizer::new().unwrap();
     // Using benchmark_group for changing sample_size
     let mut group = c.benchmark_group("Long text");
     group.sample_size(20);

--- a/lindera/examples/basic_example.rs
+++ b/lindera/examples/basic_example.rs
@@ -3,7 +3,7 @@ use lindera_core::LinderaResult;
 
 fn main() -> LinderaResult<()> {
     // create tokenizer
-    let mut tokenizer = Tokenizer::new()?;
+    let tokenizer = Tokenizer::new()?;
 
     // tokenize the text
     let tokens = tokenizer.tokenize("関西国際空港限定トートバッグ")?;

--- a/lindera/examples/userdic_example.rs
+++ b/lindera/examples/userdic_example.rs
@@ -11,7 +11,7 @@ fn main() -> LinderaResult<()> {
         mode: Mode::Normal,
         ..TokenizerConfig::default()
     };
-    let mut tokenizer = Tokenizer::with_config(config)?;
+    let tokenizer = Tokenizer::with_config(config)?;
 
     // tokenize the text
     let tokens = tokenizer.tokenize("東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です")?;

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -288,7 +288,7 @@ impl Tokenizer {
     /// * Vec<Token> : the list of `words` if succeeded
     /// * LinderaError : Error message with LinderaErrorKind
     ///
-    pub fn tokenize_str<'a>(&mut self, text: &'a str) -> LinderaResult<Vec<&'a str>> {
+    pub fn tokenize_str<'a>(&self, text: &'a str) -> LinderaResult<Vec<&'a str>> {
         let tokens = self
             .tokenize(text)?
             .into_iter()
@@ -317,7 +317,7 @@ mod tests {
             mode: Mode::Decompose(Penalty::default()),
             ..TokenizerConfig::default()
         };
-        let mut tokenizer = Tokenizer::with_config(config).unwrap();
+        let tokenizer = Tokenizer::with_config(config).unwrap();
         let tokens = tokenizer.tokenize_offsets("", &mut Lattice::default());
         assert_eq!(tokens, &[]);
     }
@@ -328,7 +328,7 @@ mod tests {
             mode: Mode::Decompose(Penalty::default()),
             ..TokenizerConfig::default()
         };
-        let mut tokenizer = Tokenizer::with_config(config).unwrap();
+        let tokenizer = Tokenizer::with_config(config).unwrap();
         let tokens = tokenizer.tokenize_offsets(" ", &mut Lattice::default());
         assert_eq!(tokens, &[(0, WordId(4294967295, true))]);
     }
@@ -339,7 +339,7 @@ mod tests {
             mode: Mode::Decompose(Penalty::default()),
             ..TokenizerConfig::default()
         };
-        let mut tokenizer = Tokenizer::with_config(config).unwrap();
+        let tokenizer = Tokenizer::with_config(config).unwrap();
         let tokens = tokenizer.tokenize_offsets("僕は", &mut Lattice::default());
         assert_eq!(
             tokens,
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_tokenize_sumomomomo() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("すもももももももものうち").unwrap();
         assert_eq!(
             tokens,
@@ -359,42 +359,42 @@ mod tests {
 
     #[test]
     fn test_gyoi() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("御意。 御意〜。").unwrap();
         assert_eq!(tokens, vec!["御意", "。", " ", "御意", "〜", "。"]);
     }
 
     #[test]
     fn test_demoyorokobi() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("〜でも喜び").unwrap();
         assert_eq!(tokens, vec!["〜", "でも", "喜び"]);
     }
 
     #[test]
     fn test_mukigen_normal2() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("—でも").unwrap();
         assert_eq!(tokens, vec!["—", "でも"]);
     }
 
     #[test]
     fn test_atodedenwa() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("後で").unwrap();
         assert_eq!(tokens, vec!["後で"]);
     }
 
     #[test]
     fn test_ikkagetsu() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("ーヶ月").unwrap();
         assert_eq!(tokens, vec!["ーヶ", "月"]);
     }
 
     #[test]
     fn test_mukigen_normal() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("無期限に—でもどの種を?").unwrap();
         assert_eq!(
             tokens,
@@ -404,28 +404,28 @@ mod tests {
 
     #[test]
     fn test_demo() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("――!!?").unwrap();
         assert_eq!(tokens, vec!["――!!?"]);
     }
 
     #[test]
     fn test_kaikeishi() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("ジム・コガン").unwrap();
         assert_eq!(tokens, vec!["ジム・コガン"]);
     }
 
     #[test]
     fn test_bruce() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("ブルース・モラン").unwrap();
         assert_eq!(tokens, vec!["ブルース・モラン"]);
     }
 
     #[test]
     fn test_tokenize_real() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer
             .tokenize_str(
                 "本項で解説する地方病とは、山梨県における日本住血吸虫症の呼称であり、\
@@ -483,21 +483,21 @@ mod tests {
 
     #[test]
     fn test_hitobito() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("満々!").unwrap();
         assert_eq!(tokens, &["満々", "!"]);
     }
 
     #[test]
     fn test_tokenize_short() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("日本住").unwrap();
         assert_eq!(tokens, vec!["日本", "住"]);
     }
 
     #[test]
     fn test_tokenize_short2() {
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens: Vec<&str> = tokenizer.tokenize_str("ここでは").unwrap();
         assert_eq!(tokens, vec!["ここ", "で", "は"]);
     }
@@ -513,7 +513,7 @@ mod tests {
             mode: Mode::Normal,
             ..TokenizerConfig::default()
         };
-        let mut tokenizer = Tokenizer::with_config(config).unwrap();
+        let tokenizer = Tokenizer::with_config(config).unwrap();
         assert!(tokenizer.user_dict.is_some());
         assert!(tokenizer.user_dict_words_idx_data.is_some());
         assert!(tokenizer.user_dict_words_data.is_some());
@@ -561,7 +561,7 @@ mod tests {
             mode: Mode::Normal,
             ..TokenizerConfig::default()
         };
-        let mut tokenizer = Tokenizer::with_config(config).unwrap();
+        let tokenizer = Tokenizer::with_config(config).unwrap();
         assert!(tokenizer.user_dict.is_some());
         assert!(tokenizer.user_dict_words_idx_data.is_some());
         assert!(tokenizer.user_dict_words_data.is_some());
@@ -608,7 +608,7 @@ mod tests {
             mode: Mode::Normal,
             ..TokenizerConfig::default()
         };
-        let mut tokenizer = Tokenizer::with_config(config).unwrap();
+        let tokenizer = Tokenizer::with_config(config).unwrap();
         assert!(tokenizer.user_dict.is_some());
         assert!(tokenizer.user_dict_words_idx_data.is_some());
         assert!(tokenizer.user_dict_words_data.is_some());
@@ -697,7 +697,7 @@ mod tests {
         );
         let mut large_text = String::new();
         let _size = large_file.read_to_string(&mut large_text).unwrap();
-        let mut tokenizer = Tokenizer::new().unwrap();
+        let tokenizer = Tokenizer::new().unwrap();
         let tokens = tokenizer.tokenize(large_text.as_str()).unwrap();
         assert!(!tokens.is_empty());
     }


### PR DESCRIPTION
## Issue

Lindera needs a mutable reference on `self` to call `tokenize` and `tokenize_str` methods (1), in another hand, Lindera `Tokenizer` loads dictionaries during initialization (2).
1) means that, if we want to have several instances of Lindera (in each thread), we have to clone Lindera
2) means that `clone` is time-consuming

## What does this PR do?

This PR makes `tokenize` and `tokenize_str` methods immutable.
This allows users to share a common reference on the same Lindera `Tokenizer` instance between threads and avoid loading/cloning dictionaries several times.

## Performances
### Lindera `bench-tokenize-wiki` (1 Lindera instance)
```
time:   [30.416 us 30.441 us 30.466 us]
change: [+14.769% +15.003% +15.266%] (p = 0.00 < 0.05)
Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```
### Meilisearch benchmarks on Lindera (several Lindera instances)
(⚠️ Logarithmic scale)
![Capture d’écran 2022-02-24 à 14 20 15](https://user-images.githubusercontent.com/6482087/155536440-2aa1812b-cce0-42f4-8ea0-312048804614.png)
