### PR TITLE
Do not perform strict checks on left context id and right context id in unk.def

### DIFF
--- a/lindera-core/Cargo.toml
+++ b/lindera-core/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 bincode = "1.3"
 byteorder = "1.4"
 encoding = "0.2"
+log = "0.4"
 serde = {version="1.0", features = ["derive"] }
 thiserror = "1.0"
 yada = "0.5"

--- a/lindera-core/src/unknown_dictionary.rs
+++ b/lindera-core/src/unknown_dictionary.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 use std::u32;
 
-use serde::{Deserialize, Serialize};
 use log::warn;
+use serde::{Deserialize, Serialize};
 
 use crate::character_definition::CategoryId;
 use crate::error::LinderaErrorKind;

--- a/lindera-core/src/unknown_dictionary.rs
+++ b/lindera-core/src/unknown_dictionary.rs
@@ -96,7 +96,12 @@ fn make_costs_array(entries: &[UnknownDictionaryEntry]) -> Vec<WordEntry> {
     entries
         .iter()
         .map(|e| {
-            assert_eq!(e.left_id, e.right_id);
+            // Do not perform strict checks on left context id and right context id in unk.def.
+            // Just output a warning.
+            //assert_eq!(e.left_id, e.right_id);
+            if e.left_id != e.right_id {
+                println!("Warning: left id and right id are not same: {:?}", e);
+            }
             WordEntry {
                 word_id: WordId(std::u32::MAX, true),
                 cost_id: e.left_id as u16,

--- a/lindera-core/src/unknown_dictionary.rs
+++ b/lindera-core/src/unknown_dictionary.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 use std::u32;
 
 use serde::{Deserialize, Serialize};
+use log::warn;
 
 use crate::character_definition::CategoryId;
 use crate::error::LinderaErrorKind;
@@ -98,9 +99,8 @@ fn make_costs_array(entries: &[UnknownDictionaryEntry]) -> Vec<WordEntry> {
         .map(|e| {
             // Do not perform strict checks on left context id and right context id in unk.def.
             // Just output a warning.
-            //assert_eq!(e.left_id, e.right_id);
             if e.left_id != e.right_id {
-                println!("Warning: left id and right id are not same: {:?}", e);
+                warn!("left id and right id are not same: {:?}", e);
             }
             WordEntry {
                 word_id: WordId(std::u32::MAX, true),

--- a/lindera-ipadic-builder/Cargo.toml
+++ b/lindera-ipadic-builder/Cargo.toml
@@ -20,7 +20,9 @@ bincode = "1.3"
 byteorder = "1.4"
 clap = { version = "3.1", features = ["derive"] }
 encoding = "0.2"
+env_logger = "0.9"
 glob = "0.3"
+log = "0.4"
 serde = "1.0"
 yada = "0.5"
 

--- a/lindera-ipadic-builder/src/main.rs
+++ b/lindera-ipadic-builder/src/main.rs
@@ -29,6 +29,8 @@ struct Args {
 }
 
 fn main() -> LinderaResult<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     let args = Args::parse();
 
     let dict_builder = IpadicBuilder::new();


### PR DESCRIPTION
Do not perform strict checks on left context id and right context id in `unk.def`.
If the right context ID in `unk.def` is different from the left context ID, output a warning message.
ko-dic is different from IPADIC.

Here is ko-dic's unk.def:
```
DEFAULT,1801,3566,3640,SY,*,*,*,*,*,*,*
SPACE,1798,3563,996,SP,*,*,*,*,*,*,*
ALPHA,1796,3532,824,SL,*,*,*,*,*,*,*
CYRILLIC,1796,3532,824,SL,*,*,*,*,*,*,*
GREEK,1796,3532,824,SL,*,*,*,*,*,*,*
HANGUL,1803,3569,10055,UNKNOWN,*,*,*,*,*,*,*
HANJA,1795,3561,-803,SH,*,*,*,*,*,*,*
HIRAGANA,1796,3532,824,SL,*,*,*,*,*,*,*
KANJI,1796,3532,824,SL,*,*,*,*,*,*,*
HANJANUMERIC,1795,3561,-803,SH,*,*,*,*,*,*,*
KATAKANA,1796,3532,824,SL,*,*,*,*,*,*,*
NUMERIC,1797,3562,3563,SN,*,*,*,*,*,*,*
SYMBOL,1801,3566,3640,SY,*,*,*,*,*,*,*

```