### PR TITLE
Remove the Tokio dependency

### DIFF
--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -25,9 +25,8 @@ lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optio
 
 [build-dependencies]
 encoding = "0.2"
-reqwest = "0.11"
+ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
 zip = "0.6"
-tokio = { version = "1.9", features = ["full"] }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-cc-cedict-builder = { version = "0.12.0", path = "../lindera-cc-cedict-builder"}

--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-cc-cedict = []
+cc-cedict = ["encoding", "ureq", "zip"]
 compress = ["lindera-cc-cedict-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,9 +24,9 @@ lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = "0.2"
-ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
-zip = "0.6"
+encoding = { version = "0.2", optional = true }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"], optional = true }
+zip = { version = "0.6", optional = true }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-cc-cedict-builder = { version = "0.12.0", path = "../lindera-cc-cedict-builder"}

--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -1,14 +1,10 @@
 use std::error::Error;
 
 #[cfg(feature = "cc-cedict")]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     use std::env;
-    use std::fs;
-    use std::fs::File;
-    use std::fs::{create_dir, rename};
-    use std::io;
-    use std::io::Write;
+    use std::fs::{self, create_dir, rename, File};
+    use std::io::{self, Write};
     use std::path::Path;
 
     use encoding::all::UTF_8;
@@ -66,13 +62,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // Download a tarball
             let download_url =
                 "https://github.com/ueda-keisuke/CC-CEDICT-MeCab/archive/refs/heads/master.zip";
-            let mut resp = reqwest::get(download_url).await?;
-
-            // Save a ttarball
+            let resp = ureq::get(download_url).call()?;
             let mut dest = File::create(&tmp_path)?;
-            while let Some(chunk) = resp.chunk().await? {
-                dest.write_all(&chunk)?;
-            }
+
+            io::copy(&mut resp.into_reader(), &mut dest)?;
+            dest.flush()?;
+
             rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
         }
 
@@ -129,7 +124,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[cfg(not(feature = "cc-cedict"))]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -26,9 +26,8 @@ lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optio
 [build-dependencies]
 encoding = "0.2"
 flate2 = "1.0"
-reqwest = "0.11"
 tar = "0.4"
-tokio = { version = "1.9", features = ["full"] }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-ipadic-builder = { version = "0.12.0", path = "../lindera-ipadic-builder"}

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ipadic = []
+ipadic = ["encoding", "flate2", "tar", "ureq"]
 compress = ["lindera-ipadic-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,10 +24,10 @@ lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = "0.2"
-flate2 = "1.0"
-tar = "0.4"
-ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
+encoding = { version = "0.2", optional = true }
+flate2 = { version = "1.0", optional = true }
+tar = { version = "0.4", optional = true }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"], optional = true }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-ipadic-builder = { version = "0.12.0", path = "../lindera-ipadic-builder"}

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -1,19 +1,16 @@
 use std::error::Error;
 
 #[cfg(feature = "ipadic")]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     use std::env;
-    use std::fs::{create_dir, rename};
-    use std::io::Cursor;
+    use std::fs::{create_dir, rename, File};
+    use std::io::{self, Cursor, Read, Write};
     use std::path::Path;
 
     use encoding::all::EUC_JP;
     use encoding::{EncoderTrap, Encoding};
     use flate2::read::GzDecoder;
     use tar::Archive;
-    use tokio::fs::File;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use lindera_core::dictionary_builder::DictionaryBuilder;
     use lindera_ipadic_builder::ipadic_builder::IpadicBuilder;
@@ -37,24 +34,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Use dummy data in docs.rs.
         create_dir(&input_dir)?;
 
-        let mut dummy_char_def = File::create(input_dir.join("char.def")).await?;
-        dummy_char_def.write_all(b"DEFAULT 0 1 0\n").await?;
+        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
+        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
 
-        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv")).await?;
-        dummy_dict_csv
-            .write_all(
-                &EUC_JP
-                    .encode(
-                        "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
-                        EncoderTrap::Ignore,
-                    )
-                    .unwrap(),
-            )
-            .await?;
+        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
+        dummy_dict_csv.write_all(
+            &EUC_JP
+                .encode(
+                    "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
+                    EncoderTrap::Ignore,
+                )
+                .unwrap(),
+        )?;
 
-        File::create(input_dir.join("unk.def")).await?;
-        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def")).await?;
-        dummy_matrix_def.write_all(b"0 1 0\n").await?;
+        File::create(input_dir.join("unk.def"))?;
+        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
+        dummy_matrix_def.write_all(b"0 1 0\n")?;
     } else {
         // Source file path for build package
         let source_path_for_build = Path::new(&build_dir).join(&file_name);
@@ -67,20 +62,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // Download a tarball
             let download_url =
                 "http://jaist.dl.sourceforge.net/project/mecab/mecab-ipadic/2.7.0-20070801/mecab-ipadic-2.7.0-20070801.tar.gz";
-            let mut resp = reqwest::get(download_url).await?;
+            let resp = ureq::get(download_url).call()?;
+            let mut dest = File::create(&tmp_path)?;
 
-            // Save a ttarball
-            let mut dest = File::create(&tmp_path).await?;
-            while let Some(chunk) = resp.chunk().await? {
-                dest.write_all(&chunk).await?;
-            }
+            io::copy(&mut resp.into_reader(), &mut dest)?;
+            dest.flush()?;
+
             rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
         }
 
         // Decompress a tarball
-        let mut tar_gz = File::open(&source_path_for_build).await?;
+        let mut tar_gz = File::open(&source_path_for_build)?;
         let mut buffer = Vec::new();
-        tar_gz.read_to_end(&mut buffer).await?;
+        tar_gz.read_to_end(&mut buffer)?;
         let cursor = Cursor::new(buffer);
         let gzdecoder = GzDecoder::new(cursor);
         let mut archive = Archive::new(gzdecoder);
@@ -95,7 +89,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[cfg(not(feature = "ipadic"))]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -26,9 +26,8 @@ lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optio
 [build-dependencies]
 encoding = "0.2"
 flate2 = "1.0"
-reqwest = "0.11"
 tar = "0.4"
-tokio = { version = "1.9", features = ["full"] }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-ko-dic-builder = { version = "0.12.0", path = "../lindera-ko-dic-builder"}

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ko-dic = []
+ko-dic = ["encoding", "flate2", "tar", "ureq"]
 compress = ["lindera-ko-dic-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,10 +24,10 @@ lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = "0.2"
-flate2 = "1.0"
-tar = "0.4"
-ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
+encoding = { version = "0.2", optional = true }
+flate2 = { version = "1.0", optional = true }
+tar = { version = "0.4", optional = true }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"], optional = true }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-ko-dic-builder = { version = "0.12.0", path = "../lindera-ko-dic-builder"}

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -1,19 +1,16 @@
 use std::error::Error;
 
 #[cfg(feature = "ko-dic")]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     use std::env;
-    use std::fs::{create_dir, rename};
-    use std::io::Cursor;
+    use std::fs::{create_dir, rename, File};
+    use std::io::{self, Cursor, Read, Write};
     use std::path::Path;
 
     use encoding::all::UTF_8;
     use encoding::{EncoderTrap, Encoding};
     use flate2::read::GzDecoder;
     use tar::Archive;
-    use tokio::fs::File;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use lindera_core::dictionary_builder::DictionaryBuilder;
     use lindera_ko_dic_builder::ko_dic_builder::KodicBuilder;
@@ -37,24 +34,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Use dummy data in docs.rs.
         create_dir(&input_dir)?;
 
-        let mut dummy_char_def = File::create(input_dir.join("char.def")).await?;
-        dummy_char_def.write_all(b"DEFAULT 0 1 0\n").await?;
+        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
+        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
 
-        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv")).await?;
-        dummy_dict_csv
-            .write_all(
-                &UTF_8
-                    .encode(
-                        "테스트,1785,3543,4721,NNG,행위,F,테스트,*,*,*,*\n",
-                        EncoderTrap::Ignore,
-                    )
-                    .unwrap(),
-            )
-            .await?;
+        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
+        dummy_dict_csv.write_all(
+            &UTF_8
+                .encode(
+                    "테스트,1785,3543,4721,NNG,행위,F,테스트,*,*,*,*\n",
+                    EncoderTrap::Ignore,
+                )
+                .unwrap(),
+        )?;
 
-        File::create(input_dir.join("unk.def")).await?;
-        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def")).await?;
-        dummy_matrix_def.write_all(b"0 1 0\n").await?;
+        File::create(input_dir.join("unk.def"))?;
+        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
+        dummy_matrix_def.write_all(b"0 1 0\n")?;
     } else {
         // Source file path for build package
         let source_path_for_build = Path::new(&build_dir).join(&file_name);
@@ -67,20 +62,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
             // Download a tarball
             let download_url =
                 "https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.1.1-20180720.tar.gz";
-            let mut resp = reqwest::get(download_url).await?;
+            let resp = ureq::get(download_url).call()?;
+            let mut dest = File::create(&tmp_path)?;
 
-            // Save a ttarball
-            let mut dest = File::create(&tmp_path).await?;
-            while let Some(chunk) = resp.chunk().await? {
-                dest.write_all(&chunk).await?;
-            }
+            io::copy(&mut resp.into_reader(), &mut dest)?;
+            dest.flush()?;
+
             rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
         }
 
         // Decompress a tarball
-        let mut tar_gz = File::open(&source_path_for_build).await?;
+        let mut tar_gz = File::open(&source_path_for_build)?;
         let mut buffer = Vec::new();
-        tar_gz.read_to_end(&mut buffer).await?;
+        tar_gz.read_to_end(&mut buffer)?;
         let cursor = Cursor::new(buffer);
         let gzdecoder = GzDecoder::new(cursor);
         let mut archive = Archive::new(gzdecoder);
@@ -95,7 +89,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 #[cfg(not(feature = "ko-dic"))]
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -25,9 +25,8 @@ lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optio
 
 [build-dependencies]
 encoding = "0.2"
-reqwest = "0.11"
 zip = "0.6"
-tokio = { version = "1.9", features = ["full"] }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-unidic-builder = { version = "0.12.0", path = "../lindera-unidic-builder"}

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-unidic = []
+unidic = ["encoding", "zip", "ureq"]
 compress = ["lindera-unidic-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,9 +24,9 @@ lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.12.0", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = "0.2"
-zip = "0.6"
-ureq = { version = "2.4.0", default-features = false, features = ["tls"] }
+encoding = { version = "0.2" , optional = true }
+zip = { version = "0.6" , optional = true }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"] , optional = true }
 
 lindera-core = { version = "0.12.0", path = "../lindera-core" }
 lindera-unidic-builder = { version = "0.12.0", path = "../lindera-unidic-builder"}


### PR DESCRIPTION
This PR removes the dependency to tokio, reqwest, h2 and hyper in the build script and replaces them by [ureq](https://lib.rs/crates/ureq) which is way simpler and is largely sufficient to download one file at compile time.

Doing this shrinks down the total number of dependencies from 172 to 117 and reduces the compilation time of lindera-ipadic from _1m 24s_ to _1m 17s_ on my Macbook Pro m1.

This PR also marked the HTTP client and compression libraries as optional for when they will not be used by the build script. This shrinks down the compilation time from _12.76s_ to _10.23s_ when the feature e.g. ipadic is not set. And that is only for one sub-crate, I have done that on all of them.