### PR TITLE
Speed up build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,14 @@ resolver = "2"
 
 [profile.release]
 lto = true
+
+# Make sure that the build scripts and proc-macros are compiled with
+# all the optimizations. It speeds up the zip crate that we use in the build.rs.
+[profile.dev.build-override]
+opt-level = 3
+[profile.release.build-override]
+opt-level = 3
+[profile.bench.build-override]
+opt-level = 3
+[profile.test.build-override]
+opt-level = 3


### PR DESCRIPTION
See https://github.com/lindera-morphology/lindera/issues/182 .

In my environment, the script execution time was reduced from about 42 seconds to about 7 seconds.