### PR TITLE
Include the IPADIC dictionary in the repository

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.13.3 (2022-05-08)
+- Include the IPADIC dictionary in the repository #188 @mosuka
+
 ## 0.13.2 (2022-04-08)
 - Remove unnecessary code #178 @mosuka
 

--- a/lindera-cc-cedict-builder/Cargo.toml
+++ b/lindera-cc-cedict-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cc-cedict-builder"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Chinese morphological dictionary builder for CC-CEDICT."
 documentation = "https://docs.rs/lindera-cc-cedict-builder"
@@ -26,9 +26,9 @@ glob = "0.3"
 log = "0.4"
 yada = "0.5"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.2", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.3", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-cc-cedict-builder"

--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cc-cedict"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Japanese morphological dictionary for CC-CEDICT."
 documentation = "https://docs.rs/lindera-cc-cedict"
@@ -20,13 +20,13 @@ bincode = "1.3"
 byteorder = "1.4"
 once_cell = "1.3"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
 encoding = { version = "0.2", optional = true }
 ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
 zip = { version = "0.6", optional = true }
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-cc-cedict-builder = { version = "0.13.2", path = "../lindera-cc-cedict-builder"}
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-cc-cedict-builder = { version = "0.13.3", path = "../lindera-cc-cedict-builder"}

--- a/lindera-cli/Cargo.toml
+++ b/lindera-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cli"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A morphological analysis tool."
 documentation = "https://docs.rs/lindera-cli"
@@ -24,7 +24,7 @@ compress = ["lindera/compress"]
 anyhow = "1.0"
 clap = { version = "3.1", features = ["derive", "cargo"] }
 
-lindera = { version = "0.13.2", path = "../lindera" }
+lindera = { version = "0.13.3", path = "../lindera" }
 
 [[bin]]
 name = "lindera"

--- a/lindera-cli/README.md
+++ b/lindera-cli/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A morphological analysis command-line interface for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+A morphological analysis command-line interface for [Lindera](https://github.com/lindera-morphology/lindera).
 
 ## Install
 

--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -65,13 +65,12 @@ struct Args {
 fn main() -> LinderaResult<()> {
     let args = Args::parse();
 
-    let mut config = TokenizerConfig::default();
-
-    // dictionary type
-    config.dict_type = DictionaryType::from_str(args.dict_type.as_str())?;
-
-    // user dictionary path
-    config.user_dict_path = args.user_dict;
+    // let mut config = TokenizerConfig::default();
+    let mut config = TokenizerConfig {
+        dict_type: DictionaryType::from_str(&args.dict_type)?,
+        user_dict_path: args.user_dict,
+        ..Default::default()
+    };
 
     // user dictionary type
     match args.user_dict_type {

--- a/lindera-compress/Cargo.toml
+++ b/lindera-compress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-compress"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-compress"
@@ -14,7 +14,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0"
 
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress" }
 
 [target.'cfg(windows)'.dependencies]
 lzma-rs = "0.2"

--- a/lindera-compress/README.md
+++ b/lindera-compress/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A morphological analysis library in Rust. This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+A morphological analysis library in Rust.
 
 Lindera aims to build a library which is easy to install and provides concise APIs for various Rust applications.
 

--- a/lindera-compress/README.md
+++ b/lindera-compress/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A morphological analysis library in Rust. This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+A morphological analysis library in Rust. This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
 
 Lindera aims to build a library which is easy to install and provides concise APIs for various Rust applications.
 

--- a/lindera-core/Cargo.toml
+++ b/lindera-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-core"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-core"

--- a/lindera-core/README.md
+++ b/lindera-core/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A morphological analysis core library for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+A morphological analysis core library for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
 
 This package contains dictionary structures and the viterbi algorithm.
 

--- a/lindera-decompress/Cargo.toml
+++ b/lindera-decompress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-decompress"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-decompress"

--- a/lindera-decompress/README.md
+++ b/lindera-decompress/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A morphological analysis library in Rust. This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+A morphological analysis library in Rust.
 
 Lindera aims to build a library which is easy to install and provides concise APIs for various Rust applications.
 

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-dictionary"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Japanese morphological dictionary."
 documentation = "https://docs.rs/lindera-dictionary"
@@ -16,4 +16,4 @@ anyhow = "1.0"
 bincode = "1.3"
 byteorder = "1.4"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }

--- a/lindera-dictionary/README.md
+++ b/lindera-dictionary/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A morphological dictionary loader for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+A morphological dictionary loader for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
 
 ## Build
 

--- a/lindera-ipadic-builder/Cargo.toml
+++ b/lindera-ipadic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic-builder"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Japanese morphological dictionary builder for IPADIC."
 documentation = "https://docs.rs/lindera-ipadic-builder"
@@ -26,9 +26,9 @@ log = "0.4"
 serde = "1.0"
 yada = "0.5"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.2", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.3", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-ipadic-builder"

--- a/lindera-ipadic-builder/README.md
+++ b/lindera-ipadic-builder/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-IPADIC dictionary builder for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+IPADIC dictionary builder for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
 
 
 ## Install

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Japanese morphological dictionary for IPADIC."
 documentation = "https://docs.rs/lindera-ipadic"
@@ -20,8 +20,8 @@ bincode = "1.3"
 byteorder = "1.4"
 once_cell = "1.3"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
 encoding = { version = "0.2", optional = true }
@@ -29,5 +29,5 @@ flate2 = { version = "1.0", optional = true }
 tar = { version = "0.4", optional = true }
 ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-ipadic-builder = { version = "0.13.2", path = "../lindera-ipadic-builder"}
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-ipadic-builder = { version = "0.13.3", path = "../lindera-ipadic-builder"}

--- a/lindera-ipadic/README.md
+++ b/lindera-ipadic/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-IPADIC dictionary loader for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+IPADIC dictionary loader for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
 
 ## Build
 

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 #[cfg(feature = "ipadic")]
 fn main() -> Result<(), Box<dyn Error>> {
     use std::env;
-    use std::fs::{create_dir, rename, File};
-    use std::io::{self, Cursor, Read, Write};
+    use std::fs::{create_dir, File};
+    use std::io::{Cursor, Read, Write};
     use std::path::Path;
 
     use encoding::all::EUC_JP;
@@ -21,22 +21,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Directory path for build package
     let build_dir = env::var_os("OUT_DIR").unwrap(); // ex) target/debug/build/<pkg>/out
 
-    // Dictionary file name
-    let file_name = "mecab-ipadic-2.7.0-20070801.tar.gz";
-
     // MeCab IPADIC directory
     let input_dir = Path::new(&build_dir).join("mecab-ipadic-2.7.0-20070801");
 
-    // Lindera IPADIC directory
-    let output_dir = Path::new(&build_dir).join("lindera-ipadic");
-
     if std::env::var("DOCS_RS").is_ok() {
-        // Use dummy data in docs.rs.
+        // Create directory for dummy input directory for build docs
         create_dir(&input_dir)?;
 
+        // Create dummy char.def
         let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
         dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
 
+        // Create dummy CSV file
         let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
         dummy_dict_csv.write_all(
             &EUC_JP
@@ -47,32 +43,22 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .unwrap(),
         )?;
 
+        // Create dummy unk.def
         File::create(input_dir.join("unk.def"))?;
         let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
         dummy_matrix_def.write_all(b"0 1 0\n")?;
     } else {
-        // Source file path for build package
-        let source_path_for_build = Path::new(&build_dir).join(&file_name);
+        // Resources directory
+        let resources_dir_path = Path::new("resources");
 
-        // Download source file to build directory
-        if !source_path_for_build.exists() {
-            // copy(&source_path, &source_path_for_build)?;
-            let tmp_path = Path::new(&build_dir).join(file_name.to_owned() + ".download");
+        // Dictionary file name
+        let dict_file_name = "mecab-ipadic-2.7.0-20070801.tar.gz";
 
-            // Download a tarball
-            let download_url =
-                "http://jaist.dl.sourceforge.net/project/mecab/mecab-ipadic/2.7.0-20070801/mecab-ipadic-2.7.0-20070801.tar.gz";
-            let resp = ureq::get(download_url).call()?;
-            let mut dest = File::create(&tmp_path)?;
+        // Source dictionary file path
+        let source_dict_file_path = resources_dir_path.join(dict_file_name);
 
-            io::copy(&mut resp.into_reader(), &mut dest)?;
-            dest.flush()?;
-
-            rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
-        }
-
-        // Decompress a tarball
-        let mut tar_gz = File::open(&source_path_for_build)?;
+        // Decompress a tar.gz file
+        let mut tar_gz = File::open(&source_dict_file_path)?;
         let mut buffer = Vec::new();
         tar_gz.read_to_end(&mut buffer)?;
         let cursor = Cursor::new(buffer);
@@ -80,6 +66,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         let mut archive = Archive::new(gzdecoder);
         archive.unpack(&build_dir)?;
     }
+
+    // Lindera IPADIC directory
+    let output_dir = Path::new(&build_dir).join("lindera-ipadic");
 
     // Build a dictionary
     let builder = IpadicBuilder::new();

--- a/lindera-ko-dic-builder/Cargo.toml
+++ b/lindera-ko-dic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ko-dic-builder"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Korean morphological dictionary builder for ko-dic."
 documentation = "https://docs.rs/lindera-ko-dic-builder"
@@ -26,9 +26,9 @@ glob = "0.3"
 log = "0.4"
 yada = "0.5"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.2", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.3", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-ko-dic-builder"

--- a/lindera-ko-dic-builder/README.md
+++ b/lindera-ko-dic-builder/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-ko-dic dictionary builder for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+ko-dic dictionary builder for [Lindera](https://github.com/lindera-morphology/lindera).
 
 
 ## Install

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ko-dic"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Japanese morphological dictionary for ko-dic."
 documentation = "https://docs.rs/lindera-ko-dic"
@@ -20,8 +20,8 @@ bincode = "1.3"
 byteorder = "1.4"
 once_cell = "1.3"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
 encoding = { version = "0.2", optional = true }
@@ -29,5 +29,5 @@ flate2 = { version = "1.0", optional = true }
 tar = { version = "0.4", optional = true }
 ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-ko-dic-builder = { version = "0.13.2", path = "../lindera-ko-dic-builder"}
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-ko-dic-builder = { version = "0.13.3", path = "../lindera-ko-dic-builder"}

--- a/lindera-unidic-builder/Cargo.toml
+++ b/lindera-unidic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-unidic-builder"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Japanese morphological dictionary builder for UniDic."
 documentation = "https://docs.rs/lindera-unidic-builder"
@@ -26,9 +26,9 @@ glob = "0.3"
 log = "0.4"
 yada = "0.5"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.2", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.3", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-unidic-builder"

--- a/lindera-unidic-builder/README.md
+++ b/lindera-unidic-builder/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-UniDic builder for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+UniDic builder for [Lindera](https://github.com/lindera-morphology/lindera).
 
 
 ## Install

--- a/lindera-unidic-builder/README.md
+++ b/lindera-unidic-builder/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Join the chat at https://gitter.im/lindera-morphology/lindera](https://badges.gitter.im/lindera-morphology/lindera.svg)](https://gitter.im/lindera-morphology/lindera?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-UniDic builder for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from fulmicoton's [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+UniDic builder for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
 
 
 ## Install

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-unidic"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A Japanese morphological dictionary for UniDic."
 documentation = "https://docs.rs/lindera-unidic"
@@ -20,13 +20,13 @@ bincode = "1.3"
 byteorder = "1.4"
 once_cell = "1.3"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.2", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.3", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
 encoding = { version = "0.2", optional = true }
 zip = { version = "0.6", optional = true }
 ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-unidic-builder = { version = "0.13.2", path = "../lindera-unidic-builder"}
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-unidic-builder = { version = "0.13.3", path = "../lindera-unidic-builder"}

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera"
@@ -29,16 +29,16 @@ serde = {version="1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 
-lindera-core = { version = "0.13.2", path = "../lindera-core" }
-lindera-dictionary = { version = "0.13.2", path = "../lindera-dictionary" }
-lindera-ipadic = { version = "0.13.2", path = "../lindera-ipadic", optional = true }
-lindera-ipadic-builder = { version = "0.13.2", path = "../lindera-ipadic-builder" }
-lindera-unidic = { version = "0.13.2", path = "../lindera-unidic", optional = true }
-lindera-unidic-builder = { version = "0.13.2", path = "../lindera-unidic-builder" }
-lindera-ko-dic = { version = "0.13.2", path = "../lindera-ko-dic", optional = true }
-lindera-ko-dic-builder = { version = "0.13.2", path = "../lindera-ko-dic-builder" }
-lindera-cc-cedict = { version = "0.13.2", path = "../lindera-cc-cedict", optional = true }
-lindera-cc-cedict-builder = { version = "0.13.2", path = "../lindera-cc-cedict-builder" }
+lindera-core = { version = "0.13.3", path = "../lindera-core" }
+lindera-dictionary = { version = "0.13.3", path = "../lindera-dictionary" }
+lindera-ipadic = { version = "0.13.3", path = "../lindera-ipadic", optional = true }
+lindera-ipadic-builder = { version = "0.13.3", path = "../lindera-ipadic-builder" }
+lindera-unidic = { version = "0.13.3", path = "../lindera-unidic", optional = true }
+lindera-unidic-builder = { version = "0.13.3", path = "../lindera-unidic-builder" }
+lindera-ko-dic = { version = "0.13.3", path = "../lindera-ko-dic", optional = true }
+lindera-ko-dic-builder = { version = "0.13.3", path = "../lindera-ko-dic-builder" }
+lindera-cc-cedict = { version = "0.13.3", path = "../lindera-cc-cedict", optional = true }
+lindera-cc-cedict-builder = { version = "0.13.3", path = "../lindera-cc-cedict-builder" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -18,7 +18,7 @@ use lindera_core::dictionary::Dictionary;
 use lindera_core::dictionary_builder::DictionaryBuilder;
 use lindera_core::file_util::read_file;
 use lindera_core::user_dictionary::UserDictionary;
-use lindera_core::viterbi::{Lattice, Mode as LinderaCoreMode};
+use lindera_core::viterbi::Lattice;
 use lindera_core::word_entry::WordId;
 #[cfg(feature = "ipadic")]
 use lindera_ipadic_builder::ipadic_builder::IpadicBuilder;
@@ -198,12 +198,10 @@ impl<'de> Deserialize<'de> for TokenizerConfig {
                 let dict_type = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let dict_path = seq.next_element()?.unwrap_or_else(|| None);
-                let user_dict_path = seq.next_element()?.unwrap_or_else(|| None);
-                let user_dict_type = seq
-                    .next_element()?
-                    .unwrap_or_else(|| UserDictionaryType::Csv);
-                let mode = seq.next_element()?.unwrap_or_else(|| Mode::Normal);
+                let dict_path = seq.next_element()?.unwrap_or(None);
+                let user_dict_path = seq.next_element()?.unwrap_or(None);
+                let user_dict_type = seq.next_element()?.unwrap_or(UserDictionaryType::Csv);
+                let mode = seq.next_element()?.unwrap_or(Mode::Normal);
 
                 Ok(TokenizerConfig {
                     dict_type,
@@ -258,10 +256,10 @@ impl<'de> Deserialize<'de> for TokenizerConfig {
                     }
                 }
                 let dict_type = dict_type.ok_or_else(|| de::Error::missing_field("dict_type"))?;
-                let dict_path = dict_path.unwrap_or_else(|| None);
-                let user_dict_path = user_dict_path.unwrap_or_else(|| None);
-                let user_dict_type = user_dict_type.unwrap_or_else(|| UserDictionaryType::Csv);
-                let mode = mode.unwrap_or_else(|| Mode::Normal);
+                let dict_path = dict_path.unwrap_or(None);
+                let user_dict_path = user_dict_path.unwrap_or(None);
+                let user_dict_type = user_dict_type.unwrap_or(UserDictionaryType::Csv);
+                let mode = mode.unwrap_or(Mode::Normal);
                 Ok(TokenizerConfig {
                     dict_type,
                     dict_path,
@@ -272,7 +270,7 @@ impl<'de> Deserialize<'de> for TokenizerConfig {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &[
+        const FIELDS: &[&str] = &[
             "dict_type",
             "dict_path",
             "user_dict_path",
@@ -419,7 +417,7 @@ impl Tokenizer {
             return Vec::new();
         }
 
-        let mode = LinderaCoreMode::from(self.mode.clone());
+        let mode = self.mode.clone();
 
         lattice.set_text(
             &self.dictionary.dict,


### PR DESCRIPTION
Currently, It downloads the Japanese dictionary from a download site in build.rs and embeds the word dictionary in the library. However, it can happen that the crate cannot be built due to communication problems with the download site or the download site is down.
To solve this problem, I would like to upload the archive of the Japanese dictionary to be downloaded to crates.io along with the source code.
I already have had the lindera-ipadic crate size limit extended to 15 MiB by the crates.io team.