### PR TITLE
Update CLI

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -8,12 +8,10 @@ jobs:
   test:
     name: Test
     strategy:
-      # max-parallel: 1
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # os: [ubuntu-latest, macOS-latest]
         toolchain: [stable, beta, nightly]
-        features: ["default", "ipadic", "ko-dic", "cc-cedict", "compress"]
+        features: ["ipadic", "ko-dic", "cc-cedict", "compress"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -29,11 +29,10 @@ jobs:
   test:
     name: Test
     strategy:
-      # max-parallel: 1
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         toolchain: [stable]
-        features: ["default", "ipadic", "ko-dic", "cc-cedict", "compress"]
+        features: ["ipadic", "ko-dic", "cc-cedict", "compress"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     name: Build
     strategy:
-      # max-parallel: 1
       matrix:
         target:
           - x86_64-unknown-linux-gnu
@@ -24,15 +23,11 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
         toolchain: [stable]
-        feature: ["default", "ipadic", "ko-dic", "cc-cedict"]
+        feature: ["ipadic", "ko-dic", "cc-cedict", "cjk"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # - name: Install packages for Linux
-      #   if : matrix.target == 'x86_64-unknown-linux-gnu'
-      #   run: |
-      #     sudo apt install -y liblzma-dev
       - name: Cache ~/.cargo/registry
         uses: actions/cache@v2.1.7
         with:
@@ -118,7 +113,7 @@ jobs:
           - x86_64-unknown-linux-gnu
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
-        feature: ["default", "ipadic", "ko-dic", "cc-cedict"]
+        feature: ["ipadic", "ko-dic", "cc-cedict"]
     name: Upload Release
     needs: [create-release]
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.59.0-slim-bullseye AS builder
+FROM rust:1.61.0-slim-bullseye AS builder
 
 ARG LINDERA_VERSION
 
@@ -17,9 +17,9 @@ RUN set -ex \
 
 COPY . .
 
-RUN rustup component add rustfmt --toolchain 1.59.0-x86_64-unknown-linux-gnu
+RUN rustup component add rustfmt --toolchain 1.61.0-x86_64-unknown-linux-gnu
 
-RUN cargo build --release --features="full"
+RUN cargo build --release --features="cjk"
 
 FROM debian:bullseye-slim
 

--- a/README.md
+++ b/README.md
@@ -82,16 +82,32 @@ With an user dictionary, `Tokenizer` will be created as follows:
 ```rust
 use std::path::PathBuf;
 
-use lindera::tokenizer::{Tokenizer, TokenizerConfig};
-use lindera_core::viterbi::Mode;
-use lindera_core::LinderaResult;
+use lindera::LinderaResult;
+use lindera::{
+    mode::Mode,
+    tokenizer::{
+        DictionaryConfig, DictionaryKind, DictionarySourceType, Tokenizer, TokenizerConfig,
+        UserDictionaryConfig,
+    },
+};
 
 fn main() -> LinderaResult<()> {
+    let dictionary = DictionaryConfig {
+        kind: DictionaryKind::IPADIC,
+        path: None,
+    };
+
+    let user_dictionary = Some(UserDictionaryConfig {
+        kind: DictionaryKind::IPADIC,
+        source_type: DictionarySourceType::Csv,
+        path: PathBuf::from("./resources/userdic.csv"),
+    });
+
     // create tokenizer
     let config = TokenizerConfig {
-        user_dict_path: Some(PathBuf::from("./resources/userdic.csv")),
+        dictionary,
+        user_dictionary: user_dictionary,
         mode: Mode::Normal,
-        ..TokenizerConfig::default()
     };
     let tokenizer = Tokenizer::with_config(config)?;
 

--- a/lindera-cc-cedict-builder/Cargo.toml
+++ b/lindera-cc-cedict-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cc-cedict-builder"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Chinese morphological dictionary builder for CC-CEDICT."
 documentation = "https://docs.rs/lindera-cc-cedict-builder"
@@ -15,20 +15,20 @@ license = "MIT"
 compress = ["lindera-compress"]
 
 [dependencies]
-anyhow = "1.0"
-bincode = "1.3"
-byteorder = "1.4"
-clap = { version = "3.1", features = ["derive"] }
-csv = "1.1"
-encoding = "0.2"
-env_logger = "0.9"
-glob = "0.3"
-log = "0.4"
-yada = "0.5"
+anyhow = "1.0.58"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+clap = { version = "3.2.8", features = ["derive"] }
+csv = "1.1.6"
+encoding = "0.2.33"
+env_logger = "0.9.0"
+glob = "0.3.0"
+log = "0.4.17"
+yada = "0.5.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.4", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-cc-cedict-builder"

--- a/lindera-cc-cedict-builder/README.md
+++ b/lindera-cc-cedict-builder/README.md
@@ -59,7 +59,7 @@ Downloading a dictionary source from [CC-CEDICT-MeCab](https://github.com/ueda-k
 You can tokenize text using produced dictionary with `lindera` command:
 
 ```shell script
-% echo "它可以进行日语和汉语的语态分析" | lindera -d /tmp/lindera-cc-cedict
+% echo "它可以进行日语和汉语的语态分析" | lindera -k cc-cedict -d /tmp/lindera-cc-cedict
 ```
 
 ```text

--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cc-cedict"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Japanese morphological dictionary for CC-CEDICT."
 documentation = "https://docs.rs/lindera-cc-cedict"
@@ -12,21 +12,20 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-cc-cedict = ["encoding", "ureq", "zip"]
+cc-cedict = ["encoding", "zip"]
 compress = ["lindera-cc-cedict-builder/compress", "lindera-decompress"]
 
 [dependencies]
-bincode = "1.3"
-byteorder = "1.4"
-once_cell = "1.3"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = { version = "0.2", optional = true }
-ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
-zip = { version = "0.6", optional = true }
+encoding = { version = "0.2.33", optional = true }
+zip = { version = "0.6.2", optional = true }
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-cc-cedict-builder = { version = "0.13.4", path = "../lindera-cc-cedict-builder"}
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-cc-cedict-builder = { version = "0.13.5", path = "../lindera-cc-cedict-builder"}

--- a/lindera-cli/Cargo.toml
+++ b/lindera-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cli"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A morphological analysis tool."
 documentation = "https://docs.rs/lindera-cli"
@@ -12,8 +12,9 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-default = []  # no dictionary
+default = ["ipadic"]  # ipadic is the default feature
 full = ["ipadic", "unidic", "ko-dic", "cc-cedict"]
+cjk = ["ipadic", "ko-dic", "cc-cedict"]
 ipadic = ["lindera/ipadic"]  # Japanese dictionary
 unidic = ["lindera/unidic"]  # Japanese dictionary
 ko-dic = ["lindera/ko-dic"]  # Korean dictionary
@@ -21,10 +22,10 @@ cc-cedict = ["lindera/cc-cedict"]  # Chinese dictionary
 compress = ["lindera/compress"]
 
 [dependencies]
-anyhow = "1.0"
-clap = { version = "3.1", features = ["derive", "cargo"] }
+anyhow = "1.0.58"
+clap = { version = "3.2.8", features = ["derive", "cargo"] }
 
-lindera = { version = "0.13.5", path = "../lindera" }
+lindera = { version = "0.14.0", path = "../lindera" }
 
 [[bin]]
 name = "lindera"

--- a/lindera-cli/README.md
+++ b/lindera-cli/README.md
@@ -92,7 +92,7 @@ For more information on preparing dictionaries, see the following link:
 For example, text can be tokenized using a prepared dictionary as follows:
 
 ```shell script
-% echo "日本語の形態素解析を行うことができます。" | lindera -t local -d /tmp/lindera-ipadic-2.7.0-20070801
+% echo "日本語の形態素解析を行うことができます。" | lindera -k ipadic -d /tmp/lindera-ipadic-2.7.0-20070801
 ```
 
 ```text
@@ -141,7 +141,7 @@ If you had a built-in IPADIC, it is also possible to switch to the self-containe
 The following example uses the self-contained IPADIC to tokenize:
 
 ```shell script
-% echo "日本語の形態素解析を行うことができます。" | lindera -t ipadic
+% echo "日本語の形態素解析を行うことができます。" | lindera -k ipadic
 ```
 
 ```text
@@ -164,7 +164,7 @@ EOS
 If UniDic were built in, it could also be tokenized by switching to a self-contained dictionary in the same way:
 
 ```shell script
-% echo "日本語の形態素解析を行うことができます。" | lindera -t unidic
+% echo "日本語の形態素解析を行うことができます。" | lindera -k unidic
 ```
 
 ```text
@@ -189,7 +189,7 @@ EOS
 If ko-dic were built in, it could also be tokenized by switching to a self-contained dictionary in the same way:
 
 ```shell script
-% echo "한국어의형태해석을실시할수있습니다." | lindera -t ko-dic
+% echo "한국어의형태해석을실시할수있습니다." | lindera -k ko-dic
 ```
 
 ```text
@@ -212,7 +212,7 @@ EOS
 If CC-CEDICT were built in, it could also be tokenized by switching to a self-contained dictionary in the same way:
 
 ```shell script
-% echo "可以进行中文形态学分析。" | lindera -t cc-cedict
+% echo "可以进行中文形态学分析。" | lindera -k cc-cedict
 ```
 
 ```text
@@ -235,7 +235,7 @@ Lindera supports two types of user dictionaries, one in CSV format and the other
 This will parse the given CSV file at runtime, build a dictionary, and then run the text tokenization.
 
 ```shell script
-% echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera -t ipadic -D ./resources/userdic.csv
+% echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera -k ipadic -u ./resources/userdic.csv -t csv
 ```
 
 ```text
@@ -254,7 +254,7 @@ This will read the given pre-built user dictionary file and perform text tokeniz
 Please check the repository of each dictionary builder for the configuration of the user dictionary binary files.
 
 ```shell script
-% echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera -t ipadic -D ./resources/userdic.bin -t bin
+% echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera -k ipadic -u ./resources/userdic.bin -t binary
 ```
 
 ```text
@@ -274,7 +274,7 @@ Lindera provides two tokenization modes: `normal` and `decompose`.
 `normal` mode tokenizes faithfully based on words registered in the dictionary. (Default):
 
 ```shell script
-% echo "関西国際空港限定トートバッグ" | lindera -t ipadic -m normal
+% echo "関西国際空港限定トートバッグ" | lindera -k ipadic -m normal
 ```
 
 ```text
@@ -287,7 +287,7 @@ EOS
 `decopose` mode tokenizes a compound noun words additionally:
 
 ```shell script
-% echo "関西国際空港限定トートバッグ" | lindera -t ipadic -m decompose
+% echo "関西国際空港限定トートバッグ" | lindera -k ipadic -m decompose
 ```
 
 ```text
@@ -306,7 +306,7 @@ Lindera provides three output formats: `mecab`, `wakati` and `json`.
 `mecab` outputs results in a format like MeCab:
 
 ```shell script
-% echo "お待ちしております。" | lindera -t ipadic -O mecab
+% echo "お待ちしております。" | lindera -k ipadic -O mecab
 ```
 
 ```text
@@ -322,7 +322,7 @@ EOS
 `wakati` outputs the token text separated by spaces:
 
 ```shell script
-% echo "お待ちしております。" | lindera -t ipadic -O wakati
+% echo "お待ちしております。" | lindera -k ipadic -O wakati
 ```
 
 ```text
@@ -332,7 +332,7 @@ EOS
 `json` outputs the token information in JSON format:
 
 ```shell script
-% echo "お待ちしております。" | lindera -t ipadic -O json
+% echo "お待ちしております。" | lindera -k ipadic -O json
 ```
 
 ```json

--- a/lindera-compress/Cargo.toml
+++ b/lindera-compress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-compress"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-compress"
@@ -12,15 +12,15 @@ categories = ["text-processing"]
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.58"
 
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
 
 [target.'cfg(windows)'.dependencies]
-lzma-rs = "0.2"
+lzma-rs = "0.2.0"
 
 [target.'cfg(not(windows))'.dependencies]
-rust-lzma = { version = "0.5"}
+rust-lzma = { version = "0.5.1"}
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.8.5"

--- a/lindera-core/Cargo.toml
+++ b/lindera-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-core"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-core"
@@ -12,11 +12,11 @@ categories = ["text-processing"]
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0"
-bincode = "1.3"
-byteorder = "1.4"
-encoding = "0.2"
-log = "0.4"
-serde = {version="1.0", features = ["derive"] }
-thiserror = "1.0"
-yada = "0.5"
+anyhow = "1.0.58"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+encoding = "0.2.33"
+log = "0.4.17"
+serde = {version="1.0.138", features = ["derive"] }
+thiserror = "1.0.31"
+yada = "0.5.0"

--- a/lindera-core/src/error.rs
+++ b/lindera-core/src/error.rs
@@ -15,8 +15,8 @@ pub enum LinderaErrorKind {
     DictionaryNotFound,
     DictionaryLoadError,
     DictionaryBuildError,
-    DictionaryTypeError,
-    UserDictionaryTypeError,
+    DictionaryKindError,
+    DictionarySourceTypeError,
     ModeError,
 }
 

--- a/lindera-decompress/Cargo.toml
+++ b/lindera-decompress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-decompress"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-decompress"
@@ -12,6 +12,6 @@ categories = ["text-processing"]
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0"
-lzma-rs = "0.2"
-serde = { version = "1.0", features = ["derive"]}
+anyhow = "1.0.58"
+lzma-rs = "0.2.0"
+serde = { version = "1.0.138", features = ["derive"]}

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-dictionary"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Japanese morphological dictionary."
 documentation = "https://docs.rs/lindera-dictionary"
@@ -12,8 +12,8 @@ categories = ["text-processing"]
 license = "MIT"
 
 [dependencies]
-anyhow = "1.0"
-bincode = "1.3"
-byteorder = "1.4"
+anyhow = "1.0.58"
+bincode = "1.3.3"
+byteorder = "1.4.3"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }

--- a/lindera-ipadic-builder/Cargo.toml
+++ b/lindera-ipadic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic-builder"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Japanese morphological dictionary builder for IPADIC."
 documentation = "https://docs.rs/lindera-ipadic-builder"
@@ -15,20 +15,20 @@ license = "MIT"
 compress = ["lindera-compress"]
 
 [dependencies]
-anyhow = "1.0"
-bincode = "1.3"
-byteorder = "1.4"
-clap = { version = "3.1", features = ["derive"] }
-encoding = "0.2"
-env_logger = "0.9"
-glob = "0.3"
-log = "0.4"
-serde = "1.0"
-yada = "0.5"
+anyhow = "1.0.58"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+clap = { version = "3.2.8", features = ["derive"] }
+encoding = "0.2.33"
+env_logger = "0.9.0"
+glob = "0.3.0"
+log = "0.4.17"
+serde = "1.0.138"
+yada = "0.5.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.4", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-ipadic-builder"

--- a/lindera-ipadic-builder/README.md
+++ b/lindera-ipadic-builder/README.md
@@ -101,7 +101,7 @@ Detailed version
 You can tokenize text using produced dictionary with `lindera` command:
 
 ```shell script
-% echo "羽田空港限定トートバッグ" | lindera -d /tmp/lindera-ipadic-2.7.0-20070801
+% echo "羽田空港限定トートバッグ" | lindera -k ipadic -d /tmp/lindera-ipadic-2.7.0-20070801
 ```
 
 ```text
@@ -117,7 +117,7 @@ EOS
 You can tokenize text using produced dictionary with `lindera` command:
 
 ```shell script
-% echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera -D ./resources/userdic.bin -t bin
+% echo "東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です" | lindera -k ipadic -d /tmp/lindera-ipadic-2.7.0-20070801 -u ./resources/userdic.bin -t binary
 ```
 
 ```text

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Japanese morphological dictionary for IPADIC."
 documentation = "https://docs.rs/lindera-ipadic"
@@ -12,22 +12,21 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ipadic = ["encoding", "flate2", "tar", "ureq"]
+ipadic = ["encoding", "flate2", "tar"]
 compress = ["lindera-ipadic-builder/compress", "lindera-decompress"]
 
 [dependencies]
-bincode = "1.3"
-byteorder = "1.4"
-once_cell = "1.3"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = { version = "0.2", optional = true }
-flate2 = { version = "1.0", optional = true }
-tar = { version = "0.4", optional = true }
-ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
+encoding = { version = "0.2.33", optional = true }
+flate2 = { version = "1.0.24", optional = true }
+tar = { version = "0.4.38", optional = true }
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-ipadic-builder = { version = "0.13.4", path = "../lindera-ipadic-builder"}
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-ipadic-builder = { version = "0.13.5", path = "../lindera-ipadic-builder"}

--- a/lindera-ko-dic-builder/Cargo.toml
+++ b/lindera-ko-dic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ko-dic-builder"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Korean morphological dictionary builder for ko-dic."
 documentation = "https://docs.rs/lindera-ko-dic-builder"
@@ -15,20 +15,20 @@ license = "MIT"
 compress = ["lindera-compress"]
 
 [dependencies]
-anyhow = "1.0"
-bincode = "1.3"
-byteorder = "1.4"
-clap = { version = "3.1", features = ["derive"] }
-csv = "1.1"
-encoding = "0.2"
-env_logger = "0.9"
-glob = "0.3"
-log = "0.4"
-yada = "0.5"
+anyhow = "1.0.58"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+clap = { version = "3.2.8", features = ["derive"] }
+csv = "1.1.6"
+encoding = "0.2.33"
+env_logger = "0.9.0"
+glob = "0.3.0"
+log = "0.4.17"
+yada = "0.5.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.4", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-ko-dic-builder"

--- a/lindera-ko-dic-builder/README.md
+++ b/lindera-ko-dic-builder/README.md
@@ -83,7 +83,7 @@ The dictionary format is specified fully (in Korean) in tab `사전 형식 v2.0`
 You can tokenize text using produced dictionary with `lindera` command:
 
 ```shell script
-% echo "하네다공항한정토트백" | lindera -d /tmp/lindera-ko-dic-2.1.1-20180720
+% echo "하네다공항한정토트백" | lindera -k ko-dic -d /tmp/lindera-ko-dic-2.1.1-20180720
 ```
 
 ```text

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ko-dic"
-version = "0.13.5"
+version = "0.13.6"
 edition = "2021"
 description = "A Japanese morphological dictionary for ko-dic."
 documentation = "https://docs.rs/lindera-ko-dic"
@@ -12,22 +12,21 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ko-dic = ["encoding", "flate2", "tar", "ureq"]
+ko-dic = ["encoding", "flate2", "tar"]
 compress = ["lindera-ko-dic-builder/compress", "lindera-decompress"]
 
 [dependencies]
-bincode = "1.3"
-byteorder = "1.4"
-once_cell = "1.3"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = { version = "0.2", optional = true }
-flate2 = { version = "1.0", optional = true }
-tar = { version = "0.4", optional = true }
-ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
+encoding = { version = "0.2.33", optional = true }
+flate2 = { version = "1.0.24", optional = true }
+tar = { version = "0.4.38", optional = true }
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-ko-dic-builder = { version = "0.13.4", path = "../lindera-ko-dic-builder"}
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-ko-dic-builder = { version = "0.13.5", path = "../lindera-ko-dic-builder"}

--- a/lindera-unidic-builder/Cargo.toml
+++ b/lindera-unidic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-unidic-builder"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Japanese morphological dictionary builder for UniDic."
 documentation = "https://docs.rs/lindera-unidic-builder"
@@ -15,20 +15,20 @@ license = "MIT"
 compress = ["lindera-compress"]
 
 [dependencies]
-anyhow = "1.0"
-bincode = "1.3"
-byteorder = "1.4"
-clap = { version = "3.1", features = ["derive"] }
-csv = "1.1"
-encoding = "0.2"
-env_logger = "0.9"
-glob = "0.3"
-log = "0.4"
-yada = "0.5"
+anyhow = "1.0.58"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+clap = { version = "3.2.8", features = ["derive"] }
+csv = "1.1.6"
+encoding = "0.2.33"
+env_logger = "0.9.0"
+glob = "0.3.0"
+log = "0.4.17"
+yada = "0.5.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress" }
-lindera-compress = { version = "0.13.4", path = "../lindera-compress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
+lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 
 [[bin]]
 name = "lindera-unidic-builder"

--- a/lindera-unidic-builder/README.md
+++ b/lindera-unidic-builder/README.md
@@ -70,7 +70,7 @@ Refer to the [manual](ftp://ftp.jaist.ac.jp/pub/sourceforge.jp/unidic/57618/unid
 You can tokenize text using produced dictionary with `lindera` command:
 
 ```shell script
-% echo "羽田空港限定トートバッグ" | lindera -d /tmp/lindera-unidic-2.1.2
+% echo "羽田空港限定トートバッグ" | lindera -k unidic -d /tmp/lindera-unidic-2.1.2
 ```
 
 ```text

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-unidic"
-version = "0.13.4"
+version = "0.13.5"
 edition = "2021"
 description = "A Japanese morphological dictionary for UniDic."
 documentation = "https://docs.rs/lindera-unidic"
@@ -16,17 +16,17 @@ unidic = ["encoding", "zip", "ureq"]
 compress = ["lindera-unidic-builder/compress", "lindera-decompress"]
 
 [dependencies]
-bincode = "1.3"
-byteorder = "1.4"
-once_cell = "1.3"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-decompress = { version = "0.13.4", path = "../lindera-decompress", optional = true }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
-encoding = { version = "0.2", optional = true }
-zip = { version = "0.6", optional = true }
-ureq = { version = "2.4", default-features = false, features = ["tls"], optional = true }
+encoding = { version = "0.2.33", optional = true }
+zip = { version = "0.6.2", optional = true }
+ureq = { version = "2.4.0", default-features = false, features = ["tls"], optional = true }
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-unidic-builder = { version = "0.13.4", path = "../lindera-unidic-builder"}
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-unidic-builder = { version = "0.13.5", path = "../lindera-unidic-builder"}

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera"
@@ -12,7 +12,8 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-default = []  # no dictionary
+default = ["ipadic"]  # ipadic is the default feature
+cjk = ["ipadic", "ko-dic", "cc-cedict"]
 full = ["ipadic", "unidic", "ko-dic", "cc-cedict"]
 ipadic = ["lindera-ipadic/ipadic"]  # Japanese dictionary
 unidic = ["lindera-unidic/unidic"]  # Japanese dictionary
@@ -21,27 +22,27 @@ cc-cedict = ["lindera-cc-cedict/cc-cedict"]  # Chinese dictionary
 compress = ["lindera-ipadic/compress", "lindera-unidic/compress"]
 
 [dependencies]
-anyhow = "1.0"
-bincode = "1.3"
-byteorder = "1.4"
-encoding = "0.2"
-serde = {version="1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
+anyhow = "1.0.58"
+bincode = "1.3.3"
+byteorder = "1.4.3"
+encoding = "0.2.33"
+serde = {version="1.0.138", features = ["derive"] }
+serde_json = "1.0.82"
+thiserror = "1.0.31"
 
-lindera-core = { version = "0.13.4", path = "../lindera-core" }
-lindera-dictionary = { version = "0.13.4", path = "../lindera-dictionary" }
-lindera-ipadic = { version = "0.13.4", path = "../lindera-ipadic", optional = true }
-lindera-ipadic-builder = { version = "0.13.4", path = "../lindera-ipadic-builder" }
-lindera-unidic = { version = "0.13.4", path = "../lindera-unidic", optional = true }
-lindera-unidic-builder = { version = "0.13.4", path = "../lindera-unidic-builder" }
-lindera-ko-dic = { version = "0.13.5", path = "../lindera-ko-dic", optional = true }
-lindera-ko-dic-builder = { version = "0.13.4", path = "../lindera-ko-dic-builder" }
-lindera-cc-cedict = { version = "0.13.4", path = "../lindera-cc-cedict", optional = true }
-lindera-cc-cedict-builder = { version = "0.13.4", path = "../lindera-cc-cedict-builder" }
+lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-dictionary = { version = "0.13.5", path = "../lindera-dictionary" }
+lindera-ipadic = { version = "0.13.5", path = "../lindera-ipadic", optional = true }
+lindera-ipadic-builder = { version = "0.13.5", path = "../lindera-ipadic-builder" }
+lindera-unidic = { version = "0.13.5", path = "../lindera-unidic", optional = true }
+lindera-unidic-builder = { version = "0.13.5", path = "../lindera-unidic-builder" }
+lindera-ko-dic = { version = "0.13.6", path = "../lindera-ko-dic", optional = true }
+lindera-ko-dic-builder = { version = "0.13.5", path = "../lindera-ko-dic-builder" }
+lindera-cc-cedict = { version = "0.13.5", path = "../lindera-cc-cedict", optional = true }
+lindera-cc-cedict-builder = { version = "0.13.5", path = "../lindera-cc-cedict-builder" }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.5"
 
 [[bench]]
 name = "bench"

--- a/lindera/benches/bench.rs
+++ b/lindera/benches/bench.rs
@@ -6,7 +6,10 @@ use criterion::Criterion;
 use criterion::{criterion_group, criterion_main};
 
 use lindera::mode::Mode;
-use lindera::tokenizer::{Tokenizer, TokenizerConfig, UserDictionaryType};
+use lindera::tokenizer::{
+    DictionaryConfig, DictionaryKind, DictionarySourceType, Tokenizer, TokenizerConfig,
+    UserDictionaryConfig,
+};
 
 fn bench_constructor(c: &mut Criterion) {
     c.bench_function("bench-constructor", |b| {
@@ -17,11 +20,21 @@ fn bench_constructor(c: &mut Criterion) {
 fn bench_constructor_with_custom_dict(c: &mut Criterion) {
     c.bench_function("bench-constructor-custom-dict", |b| {
         b.iter(|| {
+            let dictionary = DictionaryConfig {
+                kind: DictionaryKind::IPADIC,
+                path: None,
+            };
+
+            let user_dictionary = Some(UserDictionaryConfig {
+                kind: DictionaryKind::IPADIC,
+                source_type: DictionarySourceType::Csv,
+                path: PathBuf::from("./resources/userdic.csv"),
+            });
+
             let config = TokenizerConfig {
-                user_dict_path: Some(PathBuf::from("../resources/userdic.csv")),
-                user_dict_type: UserDictionaryType::Csv,
+                dictionary,
+                user_dictionary,
                 mode: Mode::Normal,
-                ..TokenizerConfig::default()
             };
             Tokenizer::with_config(config).unwrap()
         })
@@ -36,12 +49,23 @@ fn bench_tokenize(c: &mut Criterion) {
 }
 
 fn bench_tokenize_with_custom_dict(c: &mut Criterion) {
-    let config = TokenizerConfig {
-        user_dict_path: Some(PathBuf::from("../resources/userdic.csv")),
-        user_dict_type: UserDictionaryType::Csv,
-        mode: Mode::Normal,
-        ..TokenizerConfig::default()
+    let dictionary = DictionaryConfig {
+        kind: DictionaryKind::IPADIC,
+        path: None,
     };
+
+    let user_dictionary = Some(UserDictionaryConfig {
+        kind: DictionaryKind::IPADIC,
+        source_type: DictionarySourceType::Csv,
+        path: PathBuf::from("./resources/userdic.csv"),
+    });
+
+    let config = TokenizerConfig {
+        dictionary,
+        user_dictionary,
+        mode: Mode::Normal,
+    };
+
     let tokenizer = Tokenizer::with_config(config).unwrap();
     c.bench_function("bench-tokenize-custom-dict", |b| {
         b.iter(|| tokenizer.tokenize("東京スカイツリーの最寄り駅はとうきょうスカイツリー駅です"))

--- a/lindera/examples/basic_example.rs
+++ b/lindera/examples/basic_example.rs
@@ -8,22 +8,51 @@ use lindera::tokenizer::Tokenizer;
 use lindera::LinderaResult;
 
 fn main() -> LinderaResult<()> {
-    #[cfg(any(
-        feature = "ipadic",
-        feature = "unidic",
-        feature = "ko-dic",
-        feature = "cc-cedict"
-    ))]
+    #[cfg(feature = "ipadic")]
     {
         // create tokenizer
         let tokenizer = Tokenizer::new()?;
 
         // tokenize the text
-        #[cfg(any(feature = "ipadic", feature = "unidic",))]
         let tokens = tokenizer.tokenize("日本語の形態素解析を行うことができます。")?;
 
-        #[cfg(feature = "ko-dic")]
+        // output the tokens
+        for token in tokens {
+            println!("{}", token.text);
+        }
+    }
+
+    #[cfg(feature = "unidic")]
+    {
+        // create tokenizer
+        let tokenizer = Tokenizer::new()?;
+
+        // tokenize the text
+        let tokens = tokenizer.tokenize("日本語の形態素解析を行うことができます。")?;
+
+        // output the tokens
+        for token in tokens {
+            println!("{}", token.text);
+        }
+    }
+
+    #[cfg(feature = "ko-dic")]
+    {
+        // create tokenizer
+        let tokenizer = Tokenizer::new()?;
+
         let tokens = tokenizer.tokenize("한국어의형태해석을실시할수있습니다.")?;
+
+        // output the tokens
+        for token in tokens {
+            println!("{}", token.text);
+        }
+    }
+
+    #[cfg(feature = "cc-cedict")]
+    {
+        // create tokenizer
+        let tokenizer = Tokenizer::new()?;
 
         #[cfg(feature = "cc-cedict")]
         let tokens = tokenizer.tokenize("可以进行中文形态学分析。")?;

--- a/lindera/examples/userdic_example.rs
+++ b/lindera/examples/userdic_example.rs
@@ -1,20 +1,35 @@
 #[cfg(feature = "ipadic")]
 use std::path::PathBuf;
 
-#[cfg(feature = "ipadic")]
-use lindera::mode::Mode;
-#[cfg(feature = "ipadic")]
-use lindera::tokenizer::{Tokenizer, TokenizerConfig};
 use lindera::LinderaResult;
+#[cfg(feature = "ipadic")]
+use lindera::{
+    mode::Mode,
+    tokenizer::{
+        DictionaryConfig, DictionaryKind, DictionarySourceType, Tokenizer, TokenizerConfig,
+        UserDictionaryConfig,
+    },
+};
 
 fn main() -> LinderaResult<()> {
     #[cfg(feature = "ipadic")]
     {
+        let dictionary = DictionaryConfig {
+            kind: DictionaryKind::IPADIC,
+            path: None,
+        };
+
+        let user_dictionary = Some(UserDictionaryConfig {
+            kind: DictionaryKind::IPADIC,
+            source_type: DictionarySourceType::Csv,
+            path: PathBuf::from("./resources/userdic.csv"),
+        });
+
         // create tokenizer
         let config = TokenizerConfig {
-            user_dict_path: Some(PathBuf::from("./resources/userdic.csv")),
+            dictionary,
+            user_dictionary: user_dictionary,
             mode: Mode::Normal,
-            ..TokenizerConfig::default()
         };
         let tokenizer = Tokenizer::with_config(config)?;
 


### PR DESCRIPTION
Update CLI options.

```
lindera-cli 0.14.0
A morphological analysis tool.

USAGE:
    lindera [OPTIONS] [INPUT_FILE]

ARGS:
    <INPUT_FILE>    The input file path that contains the text for morphological analysis

OPTIONS:
    -k, --dictionary-kind <DICTIONARY_KIND>
            The dictionary type [default: ipadic]

    -d, --dictionary-path <DICTIONARY_PATH>
            Directory path of the dictionary. If specified, loads the specified directory as the
            specified dictionary kind. If omitted, the self-contained dictionary specified by
            dictionary kind is loaded

    -u, --user-dictionary-path <USER_DICTIONARY_PATH>
            The user dictionary file path. If specified, loads the specified file as a user
            dictionary

    -t, --user-dictionary-source-type <USER_DICTIONARY_SOURCE_TYPE>
            The user dictionary source type. Enabled when a user dictionary is specified. Default is
            "csv" [default: csv]

    -m, --mode <MODE>
            The tokenization mode. normal, search and decompose are available [default: normal]

    -O, --output-format <OUTPUT_FORMAT>
            The output format. mecab, wakati or json can be specified. If not specified, use the
            default output format [default: mecab]

    -h, --help
            Print help information

    -V, --version
            Print version information
```

Also, fix #196 .
