### PR TITLE
Do not deserialize word details during tokenization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.16.0 (2022-09-11)
+- Do not deserialize word details during tokenization #211 @mosuka
+
 ## 0.15.1 (2022-09-10)
 - Use tokenize_str() in lindera-cli #210 @mosuka
 

--- a/lindera-cc-cedict-builder/Cargo.toml
+++ b/lindera-cc-cedict-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cc-cedict-builder"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Chinese morphological dictionary builder for CC-CEDICT."
 documentation = "https://docs.rs/lindera-cc-cedict-builder"
@@ -26,7 +26,7 @@ glob = "0.3.0"
 log = "0.4.17"
 yada = "0.5.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
 lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 

--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cc-cedict"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Japanese morphological dictionary for CC-CEDICT."
 documentation = "https://docs.rs/lindera-cc-cedict"
@@ -20,12 +20,12 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
 encoding = { version = "0.2.33", optional = true }
 zip = { version = "0.6.2", optional = true }
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
-lindera-cc-cedict-builder = { version = "0.13.5", path = "../lindera-cc-cedict-builder"}
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
+lindera-cc-cedict-builder = { version = "0.14.0", path = "../lindera-cc-cedict-builder"}

--- a/lindera-cli/Cargo.toml
+++ b/lindera-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cli"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 description = "A morphological analysis command line interface."
 documentation = "https://docs.rs/lindera-cli"
@@ -26,7 +26,7 @@ anyhow = "1.0.58"
 clap = { version = "3.2.8", features = ["derive", "cargo"] }
 serde_json = "1.0.82"
 
-lindera = { version = "0.15.0", path = "../lindera" }
+lindera = { version = "0.16.0", path = "../lindera" }
 
 [[bin]]
 name = "lindera"

--- a/lindera-core/Cargo.toml
+++ b/lindera-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-core"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-core"

--- a/lindera-core/src/viterbi.rs
+++ b/lindera-core/src/viterbi.rs
@@ -10,7 +10,7 @@ use crate::prefix_dict::PrefixDict;
 use crate::unknown_dictionary::UnknownDictionary;
 use crate::word_entry::{WordEntry, WordId};
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Penalty {
     pub kanji_penalty_length_threshold: usize,
     pub kanji_penalty_length_penalty: i32,
@@ -47,7 +47,7 @@ impl Penalty {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub enum Mode {
     #[serde(rename = "normal")]
     Normal,

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-dictionary"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Japanese morphological dictionary."
 documentation = "https://docs.rs/lindera-dictionary"
@@ -16,4 +16,4 @@ anyhow = "1.0.58"
 bincode = "1.3.3"
 byteorder = "1.4.3"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }

--- a/lindera-ipadic-builder/Cargo.toml
+++ b/lindera-ipadic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic-builder"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Japanese morphological dictionary builder for IPADIC."
 documentation = "https://docs.rs/lindera-ipadic-builder"
@@ -26,7 +26,7 @@ log = "0.4.17"
 serde = "1.0.138"
 yada = "0.5.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
 lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Japanese morphological dictionary for IPADIC."
 documentation = "https://docs.rs/lindera-ipadic"
@@ -20,7 +20,7 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
@@ -28,5 +28,5 @@ encoding = { version = "0.2.33", optional = true }
 flate2 = { version = "1.0.24", optional = true }
 tar = { version = "0.4.38", optional = true }
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
-lindera-ipadic-builder = { version = "0.13.5", path = "../lindera-ipadic-builder"}
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
+lindera-ipadic-builder = { version = "0.14.0", path = "../lindera-ipadic-builder"}

--- a/lindera-ko-dic-builder/Cargo.toml
+++ b/lindera-ko-dic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ko-dic-builder"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Korean morphological dictionary builder for ko-dic."
 documentation = "https://docs.rs/lindera-ko-dic-builder"
@@ -26,7 +26,7 @@ glob = "0.3.0"
 log = "0.4.17"
 yada = "0.5.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
 lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ko-dic"
-version = "0.13.6"
+version = "0.14.0"
 edition = "2021"
 description = "A Japanese morphological dictionary for ko-dic."
 documentation = "https://docs.rs/lindera-ko-dic"
@@ -20,7 +20,7 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
@@ -28,5 +28,5 @@ encoding = { version = "0.2.33", optional = true }
 flate2 = { version = "1.0.24", optional = true }
 tar = { version = "0.4.38", optional = true }
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
-lindera-ko-dic-builder = { version = "0.13.5", path = "../lindera-ko-dic-builder"}
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
+lindera-ko-dic-builder = { version = "0.14.0", path = "../lindera-ko-dic-builder"}

--- a/lindera-unidic-builder/Cargo.toml
+++ b/lindera-unidic-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-unidic-builder"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Japanese morphological dictionary builder for UniDic."
 documentation = "https://docs.rs/lindera-unidic-builder"
@@ -26,7 +26,7 @@ glob = "0.3.0"
 log = "0.4.17"
 yada = "0.5.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress" }
 lindera-compress = { version = "0.13.5", path = "../lindera-compress", optional = true }
 

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-unidic"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2021"
 description = "A Japanese morphological dictionary for UniDic."
 documentation = "https://docs.rs/lindera-unidic"
@@ -20,7 +20,7 @@ bincode = "1.3.3"
 byteorder = "1.4.3"
 once_cell = "1.12.0"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
 lindera-decompress = { version = "0.13.5", path = "../lindera-decompress", optional = true }
 
 [build-dependencies]
@@ -28,5 +28,5 @@ encoding = { version = "0.2.33", optional = true }
 zip = { version = "0.6.2", optional = true }
 ureq = { version = "2.4.0", default-features = false, features = ["tls"], optional = true }
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
-lindera-unidic-builder = { version = "0.13.5", path = "../lindera-unidic-builder"}
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
+lindera-unidic-builder = { version = "0.14.0", path = "../lindera-unidic-builder"}

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera"
@@ -30,16 +30,16 @@ serde = {version="1.0.138", features = ["derive"] }
 serde_json = "1.0.82"
 thiserror = "1.0.31"
 
-lindera-core = { version = "0.13.5", path = "../lindera-core" }
-lindera-dictionary = { version = "0.13.5", path = "../lindera-dictionary" }
-lindera-ipadic = { version = "0.13.5", path = "../lindera-ipadic", optional = true }
-lindera-ipadic-builder = { version = "0.13.5", path = "../lindera-ipadic-builder" }
-lindera-unidic = { version = "0.13.5", path = "../lindera-unidic", optional = true }
-lindera-unidic-builder = { version = "0.13.5", path = "../lindera-unidic-builder" }
-lindera-ko-dic = { version = "0.13.6", path = "../lindera-ko-dic", optional = true }
-lindera-ko-dic-builder = { version = "0.13.5", path = "../lindera-ko-dic-builder" }
-lindera-cc-cedict = { version = "0.13.5", path = "../lindera-cc-cedict", optional = true }
-lindera-cc-cedict-builder = { version = "0.13.5", path = "../lindera-cc-cedict-builder" }
+lindera-core = { version = "0.14.0", path = "../lindera-core" }
+lindera-dictionary = { version = "0.14.0", path = "../lindera-dictionary" }
+lindera-ipadic = { version = "0.14.0", path = "../lindera-ipadic", optional = true }
+lindera-ipadic-builder = { version = "0.14.0", path = "../lindera-ipadic-builder" }
+lindera-unidic = { version = "0.14.0", path = "../lindera-unidic", optional = true }
+lindera-unidic-builder = { version = "0.14.0", path = "../lindera-unidic-builder" }
+lindera-ko-dic = { version = "0.14.0", path = "../lindera-ko-dic", optional = true }
+lindera-ko-dic-builder = { version = "0.14.0", path = "../lindera-ko-dic-builder" }
+lindera-cc-cedict = { version = "0.14.0", path = "../lindera-cc-cedict", optional = true }
+lindera-cc-cedict-builder = { version = "0.14.0", path = "../lindera-cc-cedict-builder" }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/lindera/benches/bench.rs
+++ b/lindera/benches/bench.rs
@@ -94,20 +94,6 @@ fn bench_tokenize_long_text(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_tokenize_str_long_text(c: &mut Criterion) {
-    let mut long_text_file = BufReader::new(File::open("../resources/bocchan.txt").unwrap());
-    let mut long_text = String::new();
-    let _size = long_text_file.read_to_string(&mut long_text).unwrap();
-    let tokenizer = Tokenizer::new().unwrap();
-    // Using benchmark_group for changing sample_size
-    let mut group = c.benchmark_group("Long text");
-    group.sample_size(20);
-    group.bench_function("bench-tokenize-str-long-text", |b| {
-        b.iter(|| tokenizer.tokenize_str(long_text.as_str()));
-    });
-    group.finish();
-}
-
 criterion_group!(
     benches,
     bench_constructor,
@@ -115,6 +101,5 @@ criterion_group!(
     bench_tokenize,
     bench_tokenize_with_custom_dict,
     bench_tokenize_long_text,
-    bench_tokenize_str_long_text,
 );
 criterion_main!(benches);


### PR DESCRIPTION
Stop deserializing the part-of-speech information of words and other information during tokenization (`lindera::tokenizer::Tokenizer::tokenize()`).
As a result, the following performance improvements were observed.

![Screenshot 2022-09-11 010404](https://user-images.githubusercontent.com/970948/189491845-f4b6449f-3c5d-4d2e-883b-e5e914bff317.png)

To obtain part-of-speech information, etc., call another function (`lindera::tokenizer::Tokenizer::word_detail()`).