### PR TITLE
Use split_inclusive() to split text into sentences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Use split_inclusive() to split text into sentences #213 @mosuka
+
 ## 0.16.0 (2022-09-11)
 - Do not deserialize word details during tokenization #211 @mosuka
 

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -518,15 +518,11 @@ impl Tokenizer {
     /// * Vec<Token> : the list of `Token` if succeeded
     /// * LinderaError : Error message with LinderaErrorKind
     ///
-    pub fn tokenize<'a>(&self, mut text: &'a str) -> LinderaResult<Vec<Token<'a>>> {
+    pub fn tokenize<'a>(&self, text: &'a str) -> LinderaResult<Vec<Token<'a>>> {
         let mut lattice = Lattice::default();
         let mut tokens = Vec::new();
-        while let Some(split_idx) = text.find(|c| c == '。' || c == '、') {
-            self.tokenize_without_split(&text[..split_idx + 3], &mut tokens, &mut lattice)?;
-            text = &text[split_idx + 3..];
-        }
-        if !text.is_empty() {
-            self.tokenize_without_split(text, &mut tokens, &mut lattice)?;
+        for sub_str in text.split_inclusive(&['。',  '、']) {
+            self.tokenize_without_split(sub_str, &mut tokens, &mut lattice)?;
         }
 
         Ok(tokens)

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -521,7 +521,7 @@ impl Tokenizer {
     pub fn tokenize<'a>(&self, text: &'a str) -> LinderaResult<Vec<Token<'a>>> {
         let mut lattice = Lattice::default();
         let mut tokens = Vec::new();
-        for sub_str in text.split_inclusive(&['。',  '、']) {
+        for sub_str in text.split_inclusive(&['。', '、']) {
             self.tokenize_without_split(sub_str, &mut tokens, &mut lattice)?;
         }
 


### PR DESCRIPTION
Use split_inclusive() to split text into sentences.

See https://github.com/lindera-morphology/lindera/pull/211#pullrequestreview-1103729216
