### PR TITLE
Restore to the offset before the character filter is applied like Lucene's CharFilter

### DIFF
--- a/lindera-core/src/character_filter.rs
+++ b/lindera-core/src/character_filter.rs
@@ -24,7 +24,7 @@ pub fn add_offset_diff(offsets: &mut Vec<usize>, diffs: &mut Vec<i64>, offset: u
     }
 }
 
-pub fn correct_offset(offset: usize, offsets: &[usize], diffs: &[i64]) -> usize {
+pub fn correct_offset(offset: usize, offsets: &[usize], diffs: &[i64], text_len: usize) -> usize {
     // If `offsets` is empty, the `offset` specified is the correct offset.
     if offsets.is_empty() {
         return offset;
@@ -37,6 +37,8 @@ pub fn correct_offset(offset: usize, offsets: &[usize], diffs: &[i64]) -> usize 
             if i != 0 {
                 // If `i` is greater than `0`, then `i - 1` is the `index` for the `diff` of the specified `offset`.
                 i - 1
+            } else if i >= text_len {
+                text_len
             } else {
                 // If the `offset` is not found and `i` is 0,
                 // the specified `offset` is the correct offset.
@@ -53,11 +55,38 @@ pub fn correct_offset(offset: usize, offsets: &[usize], diffs: &[i64]) -> usize 
 mod tests {
     #[test]
     fn test_correct_offset() {
+        let text = "ABCDEFG";
+        let filterd_text = "AbbbCdddFgggg";
+
+        let text_len = filterd_text.len();
         let offsets = vec![2, 3, 7, 10, 11, 12];
         let diffs = vec![-1, -2, -3, -4, -5, -6];
 
-        let offset = 2;
-        let correct_offset = super::correct_offset(offset, &offsets, &diffs);
-        assert_eq!(1, correct_offset);
+        let start_b = 1;
+        let end_b = 4;
+        assert_eq!("bbb", &filterd_text[start_b..end_b]);
+        let correct_start_b = super::correct_offset(start_b, &offsets, &diffs, text_len);
+        let correct_end_b = super::correct_offset(end_b, &offsets, &diffs, text_len);
+        assert_eq!(1, correct_start_b);
+        assert_eq!(2, correct_end_b);
+        assert_eq!("B", &text[correct_start_b..correct_end_b]);
+
+        let start_g = 9;
+        let end_g = 13;
+        assert_eq!("gggg", &filterd_text[start_g..end_g]);
+        let correct_start_g = super::correct_offset(start_g, &offsets, &diffs, text_len);
+        let correct_end_g = super::correct_offset(end_g, &offsets, &diffs, text_len);
+        assert_eq!(6, correct_start_g);
+        assert_eq!(7, correct_end_g);
+        assert_eq!("G", &text[correct_start_g..correct_end_g]);
+
+        let start = 0;
+        let end = 13;
+        assert_eq!("AbbbCdddFgggg", &filterd_text[start..end]);
+        let correct_start = super::correct_offset(start, &offsets, &diffs, text_len);
+        let correct_end = super::correct_offset(end, &offsets, &diffs, text_len);
+        assert_eq!(0, correct_start);
+        assert_eq!(7, correct_end);
+        assert_eq!("ABCDEFG", &text[correct_start..correct_end]);
     }
 }

--- a/lindera-core/src/character_filter.rs
+++ b/lindera-core/src/character_filter.rs
@@ -4,6 +4,26 @@ pub trait CharacterFilter {
     fn apply(&self, text: &mut String) -> LinderaResult<(Vec<usize>, Vec<i64>)>;
 }
 
+pub fn add_offset_diff(offsets: &mut Vec<usize>, diffs: &mut Vec<i64>, offset: usize, diff: i64) {
+    match offsets.last() {
+        Some(&last_offset) => {
+            if last_offset == offset {
+                // Replace the last diff.
+                diffs.pop();
+                diffs.push(diff);
+            } else {
+                offsets.push(offset);
+                diffs.push(diff);
+            }
+        }
+        None => {
+            // First offset.
+            offsets.push(offset);
+            diffs.push(diff);
+        }
+    }
+}
+
 pub fn correct_offset(offset: usize, offsets: &[usize], diffs: &[i64]) -> usize {
     // If `offsets` is empty, the `offset` specified is the correct offset.
     if offsets.is_empty() {

--- a/lindera-core/src/character_filter.rs
+++ b/lindera-core/src/character_filter.rs
@@ -1,5 +1,43 @@
 use crate::LinderaResult;
 
 pub trait CharacterFilter {
-    fn apply(&self, text: &mut String) -> LinderaResult<()>;
+    fn apply(&self, text: &mut String) -> LinderaResult<(Vec<usize>, Vec<i64>)>;
+}
+
+pub fn correct_offset(offset: usize, offsets: &[usize], diffs: &[i64]) -> usize {
+    // If `offsets` is empty, the `offset` specified is the correct offset.
+    if offsets.is_empty() {
+        return offset;
+    }
+
+    // Finds the `index` containing the specified `offset` from the `offsets`.
+    let index = match offsets.binary_search(&offset) {
+        Ok(i) => i,
+        Err(i) => {
+            if i != 0 {
+                // If `i` is greater than `0`, then `i - 1` is the `index` for the `diff` of the specified `offset`.
+                i - 1
+            } else {
+                // If the `offset` is not found and `i` is 0,
+                // the specified `offset` is the correct offset.
+                return offset;
+            }
+        }
+    };
+
+    // The correct offset value can be calculated by adding `diff[index]` to the given `offset`.
+    (offset as i64 + diffs[index]) as usize
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_correct_offset() {
+        let offsets = vec![2, 3, 7, 10, 11, 12];
+        let diffs = vec![-1, -2, -3, -4, -5, -6];
+
+        let offset = 2;
+        let correct_offset = super::correct_offset(offset, &offsets, &diffs);
+        assert_eq!(1, correct_offset);
+    }
 }

--- a/lindera/src/analyzer.rs
+++ b/lindera/src/analyzer.rs
@@ -199,8 +199,13 @@ impl Analyzer {
     }
 
     pub fn analyze<'a>(&self, text: &'a mut String) -> crate::LinderaResult<Vec<crate::Token<'a>>> {
+        let mut offsets_vec: Vec<Vec<usize>> = Vec::new();
+        let mut diffs_vec: Vec<Vec<i64>> = Vec::new();
+
         for character_filter in &self.character_filters {
-            character_filter.apply(text)?;
+            let (offsets, diffs) = character_filter.apply(text)?;
+            offsets_vec.insert(0, offsets);
+            diffs_vec.insert(0, diffs);
         }
 
         let mut tokens = self.tokenizer.tokenize_with_details(text.as_str())?;

--- a/lindera/src/character_filter/mapping.rs
+++ b/lindera/src/character_filter/mapping.rs
@@ -93,8 +93,8 @@ impl CharacterFilter for MappingCharacterFilter {
                             );
                         } else {
                             // Replacement is longer than matched surface.
-                            let output_start = input_offset + (-prev_diff as usize);
-                            for extra_idx in 0..-diff as usize {
+                            let output_start = (input_offset as i64 + -prev_diff) as usize;
+                            for extra_idx in 0..diff.abs() as usize {
                                 add_offset_diff(
                                     &mut offsets,
                                     &mut diffs,
@@ -255,5 +255,21 @@ mod tests {
         assert_eq!("AbEfhh", text);
         assert_eq!(vec![2, 4, 6], offsets);
         assert_eq!(vec![2, 3, 6], diffs);
+
+        let config_str = r#"
+        {
+            "mapping": {
+                "１": "1",
+                "０": "0",
+                "㍑": "リットル"
+            }
+        }
+        "#;
+        let filter = MappingCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
+        let mut text = "１０㍑".to_string();
+        let (offsets, diffs) = filter.apply(&mut text).unwrap();
+        assert_eq!("10リットル", text);
+        assert_eq!(vec![1, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13], offsets);
+        assert_eq!(vec![2, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5], diffs);
     }
 }

--- a/lindera/src/character_filter/mapping.rs
+++ b/lindera/src/character_filter/mapping.rs
@@ -118,9 +118,6 @@ impl CharacterFilter for MappingCharacterFilter {
 
         *text = result;
 
-        println!("offsets: {:?}", offsets);
-        println!("diffs: {:?}", diffs);
-
         Ok((offsets, diffs))
     }
 }
@@ -145,7 +142,6 @@ mod tests {
         }
         "#;
         let config = MappingCharacterFilterConfig::from_slice(config_str.as_bytes()).unwrap();
-
         assert_eq!("ア", config.mapping.get("ｱ").unwrap());
     }
 
@@ -163,7 +159,6 @@ mod tests {
         }
         "#;
         let result = MappingCharacterFilter::from_slice(config_str.as_bytes());
-
         assert_eq!(true, result.is_ok());
     }
 
@@ -181,10 +176,11 @@ mod tests {
         }
         "#;
         let filter = MappingCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
-
         let mut text = "ｱｲｳｴｵ".to_string();
-        filter.apply(&mut text).unwrap();
+        let (offsets, diffs) = filter.apply(&mut text).unwrap();
         assert_eq!("アイウエオ", text);
+        assert_eq!(Vec::<usize>::new(), offsets);
+        assert_eq!(Vec::<i64>::new(), diffs);
 
         let config_str = r#"
         {
@@ -195,10 +191,11 @@ mod tests {
         }
         "#;
         let filter = MappingCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
-
         let mut text = "ﾘﾝﾃﾞﾗ".to_string();
-        filter.apply(&mut text).unwrap();
+        let (offsets, diffs) = filter.apply(&mut text).unwrap();
         assert_eq!("リンデラ", text);
+        assert_eq!(vec![12], offsets);
+        assert_eq!(vec![3], diffs);
 
         let config_str = r#"
         {
@@ -209,10 +206,11 @@ mod tests {
         }
         "#;
         let filter = MappingCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
-
         let mut text = "Rust製形態素解析器ﾘﾝﾃﾞﾗで日本語を形態素解析する。".to_string();
-        filter.apply(&mut text).unwrap();
+        let (offsets, diffs) = filter.apply(&mut text).unwrap();
         assert_eq!("Rust製形態素解析器リンデラで日本語を形態素解析する。", text);
+        assert_eq!(vec![37], offsets);
+        assert_eq!(vec![3], diffs);
     }
 
     #[test]
@@ -227,7 +225,6 @@ mod tests {
         }
         "#;
         let filter = MappingCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
-
         let mut text = "ABCDEFG".to_string();
         let (offsets, diffs) = filter.apply(&mut text).unwrap();
         assert_eq!("AbbbCdddFgggg", text);
@@ -245,7 +242,6 @@ mod tests {
         }
         "#;
         let filter = MappingCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
-
         let mut text = "ABCDEFGHIJKL".to_string();
         let (offsets, diffs) = filter.apply(&mut text).unwrap();
         assert_eq!("AbEfhh", text);

--- a/lindera/src/character_filter/mapping.rs
+++ b/lindera/src/character_filter/mapping.rs
@@ -94,7 +94,7 @@ impl CharacterFilter for MappingCharacterFilter {
                         } else {
                             // Replacement is longer than matched surface.
                             let output_start = (input_offset as i64 + -prev_diff) as usize;
-                            for extra_idx in 0..diff.abs() as usize {
+                            for extra_idx in 0..diff.unsigned_abs() as usize {
                                 add_offset_diff(
                                     &mut offsets,
                                     &mut diffs,

--- a/lindera/src/character_filter/regex.rs
+++ b/lindera/src/character_filter/regex.rs
@@ -46,14 +46,17 @@ impl RegexCharacterFilter {
 }
 
 impl CharacterFilter for RegexCharacterFilter {
-    fn apply(&self, text: &mut String) -> LinderaResult<()> {
+    fn apply(&self, text: &mut String) -> LinderaResult<(Vec<usize>, Vec<i64>)> {
+        let mut offsets: Vec<usize> = Vec::new();
+        let mut diffs: Vec<i64> = Vec::new();
+
         *text = self
             .regex
             .replace_all(text, &self.config.replacement)
             .to_mut()
             .to_string();
 
-        Ok(())
+        Ok((offsets, diffs))
     }
 }
 

--- a/lindera/src/character_filter/unicode_normalize.rs
+++ b/lindera/src/character_filter/unicode_normalize.rs
@@ -66,7 +66,7 @@ impl CharacterFilter for UnicodeNormalizeCharacterFilter {
             UnicodeNormalizeKind::NFKD => text.nfkd().collect::<String>(),
         };
 
-        let mut chars = text.chars();
+        let chars = text.chars();
         let mut normalized_chars = normalized_text.chars();
 
         // loop over the characters in the string
@@ -75,7 +75,7 @@ impl CharacterFilter for UnicodeNormalizeCharacterFilter {
 
             // To compare with the replaced character,
             // the character before normalization is retrieved and normalized.
-            let tmp_c = match self.config.kind {
+            let tmp_text = match self.config.kind {
                 UnicodeNormalizeKind::NFC => c.nfc().collect::<String>(),
                 UnicodeNormalizeKind::NFD => c.nfd().collect::<String>(),
                 UnicodeNormalizeKind::NFKC => c.nfkc().collect::<String>(),
@@ -90,7 +90,7 @@ impl CharacterFilter for UnicodeNormalizeCharacterFilter {
                 replacement = normalized_text
                     [replacement_offset..replacement_offset + normalized_prefix_len]
                     .to_string();
-                if replacement == tmp_c {
+                if replacement == tmp_text {
                     replacement_offset += normalized_prefix_len;
                     break;
                 }

--- a/lindera/src/character_filter/unicode_normalize.rs
+++ b/lindera/src/character_filter/unicode_normalize.rs
@@ -134,7 +134,7 @@ impl CharacterFilter for UnicodeNormalizeCharacterFilter {
 
 #[cfg(test)]
 mod tests {
-    use lindera_core::character_filter::CharacterFilter;
+    use lindera_core::character_filter::{correct_offset, CharacterFilter};
 
     use crate::character_filter::unicode_normalize::{
         UnicodeNormalizeCharacterFilter, UnicodeNormalizeCharacterFilterConfig,
@@ -174,47 +174,141 @@ mod tests {
         "#;
         let filter = UnicodeNormalizeCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
 
-        let mut text = "ＡＢＣＤＥ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ＡＢＣＤＥ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ＡＢＣＤＥ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ＡＢＣＤＥ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 3;
+            let end = 6;
+            assert_eq!("Ｂ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(3, correct_start);
+            assert_eq!(6, correct_end);
+            assert_eq!("Ｂ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ABCDE".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ABCDE", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ABCDE".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ABCDE", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 3;
+            let end = 5;
+            assert_eq!("DE", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(3, correct_start);
+            assert_eq!(5, correct_end);
+            assert_eq!("DE", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ｱｲｳｴｵ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ｱｲｳｴｵ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ｱｲｳｴｵ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ｱｲｳｴｵ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 3;
+            let end = 9;
+            assert_eq!("ｲｳ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(3, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("ｲｳ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "アイウエオ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("アイウエオ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "アイウエオ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("アイウエオ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 12;
+            let end = 15;
+            assert_eq!("オ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(12, correct_start);
+            assert_eq!(15, correct_end);
+            assert_eq!("オ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "０１２３４５６７８９".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("０１２３４５６７８９", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "０１２３４５６７８９".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("０１２３４５６７８９", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 12;
+            let end = 15;
+            assert_eq!("４", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(12, correct_start);
+            assert_eq!(15, correct_end);
+            assert_eq!("４", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ﾘﾝﾃﾞﾗ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ﾘﾝﾃﾞﾗ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "0123456789".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("0123456789", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 5;
+            let end = 6;
+            assert_eq!("5", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(5, correct_start);
+            assert_eq!(6, correct_end);
+            assert_eq!("5", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "１０㌎".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("１０㌎", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ﾘﾝﾃﾞﾗ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ﾘﾝﾃﾞﾗ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 12;
+            assert_eq!("ﾃﾞ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ﾃﾞ", &text[correct_start..correct_end]);
+        }
+
+        {
+            let text = "１０㌎".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("１０㌎", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 9;
+            assert_eq!("㌎", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("㌎", &text[correct_start..correct_end]);
+        }
     }
 
     #[test]
@@ -226,47 +320,141 @@ mod tests {
         "#;
         let filter = UnicodeNormalizeCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
 
-        let mut text = "ＡＢＣＤＥ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ＡＢＣＤＥ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ＡＢＣＤＥ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ＡＢＣＤＥ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 3;
+            let end = 6;
+            assert_eq!("Ｂ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(3, correct_start);
+            assert_eq!(6, correct_end);
+            assert_eq!("Ｂ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ABCDE".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ABCDE", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ABCDE".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ABCDE", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 3;
+            let end = 5;
+            assert_eq!("DE", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(3, correct_start);
+            assert_eq!(5, correct_end);
+            assert_eq!("DE", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ｱｲｳｴｵ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ｱｲｳｴｵ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ｱｲｳｴｵ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ｱｲｳｴｵ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 3;
+            let end = 9;
+            assert_eq!("ｲｳ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(3, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("ｲｳ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "アイウエオ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("アイウエオ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "アイウエオ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("アイウエオ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 12;
+            let end = 15;
+            assert_eq!("オ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(12, correct_start);
+            assert_eq!(15, correct_end);
+            assert_eq!("オ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "０１２３４５６７８９".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("０１２３４５６７８９", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "０１２３４５６７８９".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("０１２３４５６７８９", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 12;
+            let end = 15;
+            assert_eq!("４", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(12, correct_start);
+            assert_eq!(15, correct_end);
+            assert_eq!("４", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ﾘﾝﾃﾞﾗ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ﾘﾝﾃﾞﾗ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "0123456789".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("0123456789", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 5;
+            let end = 6;
+            assert_eq!("5", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(5, correct_start);
+            assert_eq!(6, correct_end);
+            assert_eq!("5", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "１０㌎".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("１０㌎", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ﾘﾝﾃﾞﾗ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ﾘﾝﾃﾞﾗ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 12;
+            assert_eq!("ﾃﾞ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ﾃﾞ", &text[correct_start..correct_end]);
+        }
+
+        {
+            let text = "１０㌎".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("１０㌎", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 9;
+            assert_eq!("㌎", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("㌎", &text[correct_start..correct_end]);
+        }
     }
 
     #[test]
@@ -278,47 +466,141 @@ mod tests {
         "#;
         let filter = UnicodeNormalizeCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
 
-        let mut text = "ＡＢＣＤＥ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ABCDE", text);
-        assert_eq!(vec![1, 2, 3, 4, 5], offsets);
-        assert_eq!(vec![2, 4, 6, 8, 10], diffs);
+        {
+            let text = "ＡＢＣＤＥ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ABCDE", filterd_text);
+            assert_eq!(vec![1, 2, 3, 4, 5], offsets);
+            assert_eq!(vec![2, 4, 6, 8, 10], diffs);
+            let start = 2;
+            let end = 4;
+            assert_eq!("CD", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ＣＤ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ABCDE".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ABCDE", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ABCDE".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ABCDE", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 2;
+            let end = 4;
+            assert_eq!("CD", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(2, correct_start);
+            assert_eq!(4, correct_end);
+            assert_eq!("CD", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ｱｲｳｴｵ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("アイウエオ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ｱｲｳｴｵ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("アイウエオ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 12;
+            assert_eq!("ウエ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ｳｴ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "アイウエオ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("アイウエオ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "アイウエオ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("アイウエオ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 12;
+            assert_eq!("ウエ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ウエ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "０１２３４５６７８９".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("0123456789", text);
-        assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offsets);
-        assert_eq!(vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20], diffs);
+        {
+            let text = "０１２３４５６７８９".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("0123456789", filterd_text);
+            assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offsets);
+            assert_eq!(vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20], diffs);
+            let start = 6;
+            let end = 9;
+            assert_eq!("678", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(18, correct_start);
+            assert_eq!(27, correct_end);
+            assert_eq!("６７８", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ﾘﾝﾃﾞﾗ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("リンデラ", text);
-        assert_eq!(vec![9, 10, 11, 12], offsets);
-        assert_eq!(vec![-1, -2, -3, 3], diffs);
+        {
+            let text = "0123456789".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("0123456789", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 9;
+            assert_eq!("678", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("678", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "１０㌎".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("10ガロン", text);
-        assert_eq!(vec![1, 2, 5, 6, 7, 8, 9, 10], offsets);
-        assert_eq!(vec![2, 4, 3, 2, 1, 0, -1, -2], diffs);
+        {
+            let text = "ﾘﾝﾃﾞﾗ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("リンデラ", filterd_text);
+            assert_eq!(vec![9, 10, 11, 12], offsets);
+            assert_eq!(vec![-1, -2, -3, 3], diffs);
+            let start = 6;
+            let end = 12;
+            assert_eq!("デラ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(15, correct_end);
+            assert_eq!("ﾃﾞﾗ", &text[correct_start..correct_end]);
+        }
+
+        {
+            let text = "１０㌎".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("10ガロン", filterd_text);
+            assert_eq!(vec![1, 2, 5, 6, 7, 8, 9, 10], offsets);
+            assert_eq!(vec![2, 4, 3, 2, 1, 0, -1, -2], diffs);
+            let start = 2;
+            let end = 11;
+            assert_eq!("ガロン", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("㌎", &text[correct_start..correct_end]);
+        }
     }
 
     #[test]
@@ -330,46 +612,140 @@ mod tests {
         "#;
         let filter = UnicodeNormalizeCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
 
-        let mut text = "ＡＢＣＤＥ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ABCDE", text);
-        assert_eq!(vec![1, 2, 3, 4, 5], offsets);
-        assert_eq!(vec![2, 4, 6, 8, 10], diffs);
+        {
+            let text = "ＡＢＣＤＥ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ABCDE", filterd_text);
+            assert_eq!(vec![1, 2, 3, 4, 5], offsets);
+            assert_eq!(vec![2, 4, 6, 8, 10], diffs);
+            let start = 2;
+            let end = 4;
+            assert_eq!("CD", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ＣＤ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ABCDE".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("ABCDE", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ABCDE".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("ABCDE", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 2;
+            let end = 4;
+            assert_eq!("CD", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(2, correct_start);
+            assert_eq!(4, correct_end);
+            assert_eq!("CD", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ｱｲｳｴｵ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("アイウエオ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "ｱｲｳｴｵ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("アイウエオ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 12;
+            assert_eq!("ウエ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ｳｴ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "アイウエオ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("アイウエオ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "アイウエオ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("アイウエオ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 12;
+            assert_eq!("ウエ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(12, correct_end);
+            assert_eq!("ウエ", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "０１２３４５６７８９".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("0123456789", text);
-        assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offsets);
-        assert_eq!(vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20], diffs);
+        {
+            let text = "０１２３４５６７８９".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("0123456789", filterd_text);
+            assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offsets);
+            assert_eq!(vec![2, 4, 6, 8, 10, 12, 14, 16, 18, 20], diffs);
+            let start = 6;
+            let end = 9;
+            assert_eq!("678", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(18, correct_start);
+            assert_eq!(27, correct_end);
+            assert_eq!("６７８", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "ﾘﾝﾃﾞﾗ".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("リンテ\u{3099}ラ", text);
-        assert_eq!(Vec::<usize>::new(), offsets);
-        assert_eq!(Vec::<i64>::new(), diffs);
+        {
+            let text = "0123456789".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("0123456789", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 9;
+            assert_eq!("678", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("678", &text[correct_start..correct_end]);
+        }
 
-        let mut text = "１０㌎".to_string();
-        let (offsets, diffs) = filter.apply(&mut text).unwrap();
-        assert_eq!("10カ\u{3099}ロン", text);
-        assert_eq!(vec![1, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13], offsets);
-        assert_eq!(vec![2, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5], diffs);
+        {
+            let text = "ﾘﾝﾃﾞﾗ".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("リンテ\u{3099}ラ", filterd_text);
+            assert_eq!(Vec::<usize>::new(), offsets);
+            assert_eq!(Vec::<i64>::new(), diffs);
+            let start = 6;
+            let end = 15;
+            assert_eq!("テ\u{3099}ラ", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(15, correct_end);
+            assert_eq!("ﾃﾞﾗ", &text[correct_start..correct_end]);
+        }
+
+        {
+            let text = "１０㌎".to_string();
+            let mut filterd_text = text.clone();
+            let (offsets, diffs) = filter.apply(&mut filterd_text).unwrap();
+            assert_eq!("10カ\u{3099}ロン", filterd_text);
+            assert_eq!(vec![1, 2, 5, 6, 7, 8, 9, 10, 11, 12, 13], offsets);
+            assert_eq!(vec![2, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5], diffs);
+            let start = 2;
+            let end = 14;
+            assert_eq!("カ\u{3099}ロン", &filterd_text[start..end]);
+            let correct_start = correct_offset(start, &offsets, &diffs, filterd_text.len());
+            let correct_end = correct_offset(end, &offsets, &diffs, filterd_text.len());
+            assert_eq!(6, correct_start);
+            assert_eq!(9, correct_end);
+            assert_eq!("㌎", &text[correct_start..correct_end]);
+        }
     }
 }

--- a/lindera/src/character_filter/unicode_normalize.rs
+++ b/lindera/src/character_filter/unicode_normalize.rs
@@ -52,7 +52,10 @@ impl UnicodeNormalizeCharacterFilter {
 }
 
 impl CharacterFilter for UnicodeNormalizeCharacterFilter {
-    fn apply(&self, text: &mut String) -> LinderaResult<()> {
+    fn apply(&self, text: &mut String) -> LinderaResult<(Vec<usize>, Vec<i64>)> {
+        let mut offsets: Vec<usize> = Vec::new();
+        let mut diffs: Vec<i64> = Vec::new();
+
         *text = match self.config.kind {
             UnicodeNormalizeKind::NFC => text.nfc().collect::<String>(),
             UnicodeNormalizeKind::NFD => text.nfd().collect::<String>(),
@@ -60,7 +63,7 @@ impl CharacterFilter for UnicodeNormalizeCharacterFilter {
             UnicodeNormalizeKind::NFKD => text.nfkd().collect::<String>(),
         };
 
-        Ok(())
+        Ok((offsets, diffs))
     }
 }
 

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -61,7 +61,12 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
         tokens.retain(|token| {
             if let Some(details) = &token.details {
-                !self.config.stop_tags.contains(&details[0..4].join(","))
+                let mut formatted_tags = vec!["*", "*", "*", "*"];
+                let tags_len = if details.len() >= 4 { 4 } else { 1 };
+                for (i, j) in details[0..tags_len].iter().enumerate() {
+                    formatted_tags[i] = j;
+                }
+                !self.config.stop_tags.contains(&formatted_tags.join(","))
             } else {
                 false
             }


### PR DESCRIPTION
The offset of the substituted character and its difference is recorded so that the offset of the token resulting from the morphological analysis can be restored to the offset before the character filter is applied like Lucene's CharFilter.