### PR TITLE
Add Japanese compound word token filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Add Japanese compound word token filter #273 @mosuka
 - Added a function to return a name for each filter #272 @mosuka
 - Use flate2 for dictionary compression #271 @mosuka
 - Do not use unwrap() #269 @mosuka

--- a/lindera-cli/README.md
+++ b/lindera-cli/README.md
@@ -541,7 +541,7 @@ The `analyze` command combines character filters, tokenizer and token filters fo
 Settings for character filters, tokenizer, and token filters used in the analysis are described in JSON.
 
 ```shell script
-$ echo "すもももももももものうち" | ./target/debug/lindera analyze --config ./resources/lindera_ipadic_conf.json
+$ echo "すもももももももものうち" | lindera analyze --config ./resources/lindera_ipadic_conf.json
 ```
 
 ```text

--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -196,7 +196,7 @@ fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
 
         match output_format {
             Format::Mecab => {
-                let tokens = tokenizer.tokenize_with_details(&text)?;
+                let tokens = tokenizer.tokenize_with_details(text.trim())?;
                 for token in tokens {
                     println!(
                         "{}\t{}",
@@ -213,7 +213,7 @@ fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
                 println!("EOS");
             }
             Format::Json => {
-                let tokens = tokenizer.tokenize_with_details(&text)?;
+                let tokens = tokenizer.tokenize_with_details(text.trim())?;
                 let mut tokens_json = Vec::new();
                 for token in tokens {
                     let word_details = token.details.unwrap_or_default();
@@ -233,7 +233,7 @@ fn tokenize(args: TokenizeArgs) -> LinderaResult<()> {
                 );
             }
             Format::Wakati => {
-                let tokens = tokenizer.tokenize(&text)?;
+                let tokens = tokenizer.tokenize(text.trim())?;
                 let mut it = tokens.iter().peekable();
                 while let Some(token) = it.next() {
                     if it.peek().is_some() {
@@ -283,7 +283,7 @@ fn analyze(args: AnalyzeArgs) -> LinderaResult<()> {
             break;
         }
 
-        let tokens = analyzer.analyze(&text)?;
+        let tokens = analyzer.analyze(text.trim())?;
         match output_format {
             Format::Mecab => {
                 for token in tokens {

--- a/lindera/src/analyzer.rs
+++ b/lindera/src/analyzer.rs
@@ -293,6 +293,7 @@ impl Analyzer {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "ipadic")]
     use crate::analyzer::Analyzer;
 
     #[test]

--- a/lindera/src/analyzer.rs
+++ b/lindera/src/analyzer.rs
@@ -401,6 +401,7 @@ mod tests {
                 {
                     "kind": "japanese_compound_word",
                     "args": {
+                        "kind": "ipadic",
                         "tags": [
                             "名詞,数",
                             "名詞,接尾,助数詞"

--- a/lindera/src/analyzer.rs
+++ b/lindera/src/analyzer.rs
@@ -18,6 +18,9 @@ use crate::{
     error::LinderaErrorKind,
     token_filter::{
         japanese_base_form::{JapaneseBaseFormTokenFilter, JAPANESE_BASE_FORM_TOKEN_FILTER_NAME},
+        japanese_compound_word::{
+            JapaneseCompoundWordTokenFilter, JAPANESE_COMPOUND_WORD_TOKEN_FILTER_NAME,
+        },
         japanese_katakana_stem::{
             JapaneseKatakanaStemTokenFilter, JAPANESE_KATAKANA_STEM_TOKEN_FILTER_NAME,
         },
@@ -59,6 +62,7 @@ impl Analyzer {
             .map(|token_filter| token_filter.name())
             .any(|name| {
                 name == JAPANESE_BASE_FORM_TOKEN_FILTER_NAME
+                    || name == JAPANESE_COMPOUND_WORD_TOKEN_FILTER_NAME
                     || name == JAPANESE_KEEP_TAGS_TOKEN_FILTER_NAME
                     || name == JAPANESE_READING_FORM_TOKEN_FILTER_NAME
                     || name == JAPANESE_STOP_TAGS_TOKEN_FILTER_NAME
@@ -153,6 +157,11 @@ impl Analyzer {
                                 &args_bytes,
                             )?));
                         }
+                        JAPANESE_COMPOUND_WORD_TOKEN_FILTER_NAME => {
+                            token_filters.push(Box::new(
+                                JapaneseCompoundWordTokenFilter::from_slice(&args_bytes)?,
+                            ));
+                        }
                         JAPANESE_KATAKANA_STEM_TOKEN_FILTER_NAME => {
                             token_filters.push(Box::new(
                                 JapaneseKatakanaStemTokenFilter::from_slice(&args_bytes)?,
@@ -222,19 +231,22 @@ impl Analyzer {
         let mut text_len_vec: Vec<usize> = Vec::new();
         let mut offsets_vec: Vec<Vec<usize>> = Vec::new();
         let mut diffs_vec: Vec<Vec<i64>> = Vec::new();
-
         let mut tmp_text = text.to_string();
 
         // Appy character filters.
         for character_filter in &self.character_filters {
             let (new_text, offsets, diffs) = character_filter.apply(&tmp_text)?;
 
-            // Record the length of the text after each character filter is applied.
-            text_len_vec.insert(0, new_text.len());
-            // Record the offsets of each character filter.
-            offsets_vec.insert(0, offsets);
-            // Record the diffs of each character filter.
-            diffs_vec.insert(0, diffs);
+            if !offsets.is_empty() {
+                // Record the offsets of each character filter.
+                offsets_vec.insert(0, offsets);
+
+                // Record the diffs of each character filter.
+                diffs_vec.insert(0, diffs);
+
+                // Record the length of the text after each character filter is applied.
+                text_len_vec.insert(0, new_text.len());
+            }
 
             tmp_text = new_text;
         }
@@ -314,7 +326,7 @@ mod tests {
                 {
                     "kind": "japanese_stop_tags",
                     "args": {
-                        "stop_tags": [
+                        "tags": [
                             "接続詞",
                             "助詞",
                             "助詞,格助詞",
@@ -386,9 +398,18 @@ mod tests {
             },
             "token_filters": [
                 {
+                    "kind": "japanese_compound_word",
+                    "args": {
+                        "tags": [
+                            "名詞,数",
+                            "名詞,接尾,助数詞"
+                        ]            
+                    }
+                },
+                {
                     "kind": "japanese_stop_tags",
                     "args": {
-                        "stop_tags": [
+                        "tags": [
                             "接続詞",
                             "助詞",
                             "助詞,格助詞",
@@ -479,10 +500,20 @@ mod tests {
                 assert_eq!(&text[start..end], "ｶﾞｿﾘﾝ");
             }
         }
+
+        {
+            let text = "お釣りは百三十四円です。".to_string();
+            let mut analyze_text = text.clone();
+            let tokens = analyzer.analyze(&mut analyze_text).unwrap();
+            assert_eq!(
+                tokens.iter().map(|t| t.text.as_ref()).collect::<Vec<_>>(),
+                vec!["お釣り", "百三十四円"]
+            );
+        }
     }
 
     #[test]
-    // #[cfg(feature = "ipadic")]
+    #[cfg(feature = "ipadic")]
     fn test_analyzer_from_slice_wrong_config() {
         let config_str = r#"
         {
@@ -512,7 +543,7 @@ mod tests {
                 {
                     "kind": "japanese_stop_tags",
                     "args": {
-                        "stop_tags": [
+                        "tags": [
                             "接続詞",
                             "助詞",
                             "助詞,格助詞",

--- a/lindera/src/token_filter.rs
+++ b/lindera/src/token_filter.rs
@@ -1,4 +1,5 @@
 pub mod japanese_base_form;
+pub mod japanese_compound_word;
 pub mod japanese_katakana_stem;
 pub mod japanese_keep_tags;
 pub mod japanese_reading_form;

--- a/lindera/src/token_filter/japanese_base_form.rs
+++ b/lindera/src/token_filter/japanese_base_form.rs
@@ -9,13 +9,8 @@ use crate::{error::LinderaErrorKind, DictionaryKind, LinderaResult, Token};
 
 pub const JAPANESE_BASE_FORM_TOKEN_FILTER_NAME: &str = "japanese_base_form";
 
-fn default_kind() -> DictionaryKind {
-    DictionaryKind::IPADIC
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JapaneseBaseFormTokenFilterConfig {
-    #[serde(default = "default_kind")]
     kind: DictionaryKind,
 }
 

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -85,7 +85,17 @@ impl TokenFilter for JapaneseCompoundWordTokenFilter {
                         let compound_token = compound_token_opt.take().unwrap();
                         compound_token_opt = Some(Token {
                             text: Cow::Owned(format!("{}{}", compound_token.text, token.text)),
-                            details: compound_token.details,
+                            details: Some(vec![
+                                "複合語".to_string(),
+                                "*".to_string(),
+                                "*".to_string(),
+                                "*".to_string(),
+                                "*".to_string(),
+                                "*".to_string(),
+                                "*".to_string(),
+                                "*".to_string(),
+                                "*".to_string(),
+                            ]),
                             byte_start: compound_token.byte_start,
                             byte_end: token.byte_end,
                         });

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -92,7 +92,7 @@ impl TokenFilter for JapaneseCompoundWordTokenFilter {
             DictionaryKind::UniDic => "複合語,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*,*"
                 .split(',')
                 .collect::<Vec<&str>>(),
-            _ => "UNK".split(',').collect::<Vec<&str>>(),
+            _ => "複合語,*,*,*,*,*,*,*,*".split(',').collect::<Vec<&str>>(),
         };
 
         if let Some(new_tag_str) = &self.config.new_tag {

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -1,0 +1,293 @@
+use std::{borrow::Cow, collections::HashSet, mem};
+
+use lindera_core::token_filter::TokenFilter;
+use serde::{Deserialize, Serialize};
+
+use crate::{error::LinderaErrorKind, LinderaResult, Token};
+
+pub const JAPANESE_COMPOUND_WORD_TOKEN_FILTER_NAME: &str = "japanese_compound_word";
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct JapaneseCompoundWordTokenFilterConfig {
+    tags: HashSet<String>,
+}
+
+impl JapaneseCompoundWordTokenFilterConfig {
+    pub fn new(tags: HashSet<String>) -> Self {
+        let mut formatted_tags: HashSet<String> = HashSet::new();
+        for tag in tags.iter() {
+            let mut formatted_tag = vec!["*", "*", "*", "*"];
+
+            let tag_array: Vec<&str> = tag.split(',').collect();
+            for (i, j) in tag_array.iter().enumerate() {
+                formatted_tag[i] = j;
+            }
+
+            formatted_tags.insert(formatted_tag.join(","));
+        }
+
+        Self {
+            tags: formatted_tags,
+        }
+    }
+
+    pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
+        let tmp_config = serde_json::from_slice::<JapaneseCompoundWordTokenFilterConfig>(data)
+            .map_err(|err| LinderaErrorKind::Deserialize.with_error(err))?;
+
+        Ok(Self::new(tmp_config.tags))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct JapaneseCompoundWordTokenFilter {
+    config: JapaneseCompoundWordTokenFilterConfig,
+}
+
+impl JapaneseCompoundWordTokenFilter {
+    pub fn new(config: JapaneseCompoundWordTokenFilterConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
+        Ok(Self::new(
+            JapaneseCompoundWordTokenFilterConfig::from_slice(data)?,
+        ))
+    }
+}
+
+impl TokenFilter for JapaneseCompoundWordTokenFilter {
+    fn name(&self) -> &'static str {
+        JAPANESE_COMPOUND_WORD_TOKEN_FILTER_NAME
+    }
+
+    fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
+        let mut new_tokens = Vec::new();
+
+        let mut compound_token_opt = None;
+        for token in tokens.iter_mut() {
+            if let Some(details) = &mut token.details {
+                let mut formatted_tags = vec!["*", "*", "*", "*"];
+                let tags_len = if details.len() >= 4 { 4 } else { 1 };
+                for (i, j) in details[0..tags_len].iter().enumerate() {
+                    formatted_tags[i] = j;
+                }
+
+                if self.config.tags.contains(&formatted_tags.join(",")) {
+                    if compound_token_opt.is_none() {
+                        compound_token_opt = Some(Token {
+                            text: Cow::Owned(token.text.to_string()),
+                            details: token.details.clone(),
+                            byte_start: token.byte_start,
+                            byte_end: token.byte_end,
+                        });
+                    } else {
+                        let compound_token = compound_token_opt.take().unwrap();
+                        compound_token_opt = Some(Token {
+                            text: Cow::Owned(format!("{}{}", compound_token.text, token.text)),
+                            details: compound_token.details,
+                            byte_start: compound_token.byte_start,
+                            byte_end: token.byte_end,
+                        });
+                    }
+                } else {
+                    if compound_token_opt.is_some() {
+                        let compound_token = compound_token_opt.take().unwrap();
+                        new_tokens.push(compound_token);
+                    }
+                    new_tokens.push(Token {
+                        text: Cow::Owned(token.text.to_string()),
+                        details: token.details.clone(),
+                        byte_start: token.byte_start,
+                        byte_end: token.byte_end,
+                    });
+                }
+            }
+        }
+
+        mem::swap(tokens, &mut new_tokens);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use lindera_core::token_filter::TokenFilter;
+
+    use crate::{
+        token_filter::japanese_compound_word::{
+            JapaneseCompoundWordTokenFilter, JapaneseCompoundWordTokenFilterConfig,
+        },
+        Token,
+    };
+
+    #[test]
+    fn test_japanese_compound_word_token_filter_config_from_slice() {
+        let config_str = r#"
+        {
+            "tags": [
+                "名詞,数",
+                "名詞,接尾,助数詞"
+            ]
+        }
+        "#;
+        let config =
+            JapaneseCompoundWordTokenFilterConfig::from_slice(config_str.as_bytes()).unwrap();
+
+        assert_eq!(config.tags.len(), 2);
+    }
+
+    #[test]
+    fn test_japanese_compound_word_token_filter_from_slice() {
+        let config_str = r#"
+        {
+            "tags": [
+                "名詞,数",
+                "名詞,接尾,助数詞"
+            ]
+        }
+        "#;
+        let result = JapaneseCompoundWordTokenFilter::from_slice(config_str.as_bytes());
+
+        assert_eq!(true, result.is_ok());
+    }
+
+    #[test]
+    fn test_japanese_compound_word_token_filter_apply() {
+        let config_str = r#"
+        {
+            "tags": [
+                "名詞,数",
+                "名詞,接尾,助数詞"
+            ]
+        }
+        "#;
+        let filter = JapaneseCompoundWordTokenFilter::from_slice(config_str.as_bytes()).unwrap();
+
+        let mut tokens: Vec<Token> = vec![
+            Token {
+                text: Cow::Borrowed("１"),
+                details: Some(vec![
+                    "名詞".to_string(),
+                    "数".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "１".to_string(),
+                    "イチ".to_string(),
+                    "イチ".to_string(),
+                ]),
+                byte_start: 0,
+                byte_end: 3,
+            },
+            Token {
+                text: Cow::Borrowed("０"),
+                details: Some(vec![
+                    "名詞".to_string(),
+                    "数".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "０".to_string(),
+                    "ゼロ".to_string(),
+                    "ゼロ".to_string(),
+                ]),
+                byte_start: 3,
+                byte_end: 6,
+            },
+            Token {
+                text: Cow::Borrowed("０"),
+                details: Some(vec![
+                    "名詞".to_string(),
+                    "数".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "０".to_string(),
+                    "ゼロ".to_string(),
+                    "ゼロ".to_string(),
+                ]),
+                byte_start: 6,
+                byte_end: 9,
+            },
+            Token {
+                text: Cow::Borrowed("円"),
+                details: Some(vec![
+                    "名詞".to_string(),
+                    "接尾".to_string(),
+                    "助数詞".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "円".to_string(),
+                    "エン".to_string(),
+                    "エン".to_string(),
+                ]),
+                byte_start: 9,
+                byte_end: 12,
+            },
+            Token {
+                text: Cow::Borrowed("玉"),
+                details: Some(vec![
+                    "名詞".to_string(),
+                    "接尾".to_string(),
+                    "一般".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "玉".to_string(),
+                    "ダマ".to_string(),
+                    "ダマ".to_string(),
+                ]),
+                byte_start: 12,
+                byte_end: 15,
+            },
+            Token {
+                text: Cow::Borrowed("を"),
+                details: Some(vec![
+                    "助詞".to_string(),
+                    "格助詞".to_string(),
+                    "一般".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "を".to_string(),
+                    "ヲ".to_string(),
+                    "ヲ".to_string(),
+                ]),
+                byte_start: 27,
+                byte_end: 30,
+            },
+            Token {
+                text: Cow::Borrowed("拾う"),
+                details: Some(vec![
+                    "動詞".to_string(),
+                    "自立".to_string(),
+                    "*".to_string(),
+                    "*".to_string(),
+                    "五段・ワ行促音便".to_string(),
+                    "基本形".to_string(),
+                    "拾う".to_string(),
+                    "ヒロウ".to_string(),
+                    "ヒロウ".to_string(),
+                ]),
+                byte_start: 30,
+                byte_end: 36,
+            },
+        ];
+
+        filter.apply(&mut tokens).unwrap();
+
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(tokens[0].text, "１００円");
+        assert_eq!(tokens[1].text, "玉");
+        assert_eq!(tokens[2].text, "を");
+        assert_eq!(tokens[3].text, "拾う");
+    }
+}

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -7,13 +7,8 @@ use crate::{error::LinderaErrorKind, DictionaryKind, LinderaResult, Token};
 
 pub const JAPANESE_COMPOUND_WORD_TOKEN_FILTER_NAME: &str = "japanese_compound_word";
 
-fn default_kind() -> DictionaryKind {
-    DictionaryKind::IPADIC
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JapaneseCompoundWordTokenFilterConfig {
-    #[serde(default = "default_kind")]
     kind: DictionaryKind,
     tags: HashSet<String>,
     new_tag: Option<String>,

--- a/lindera/src/token_filter/japanese_keep_tags.rs
+++ b/lindera/src/token_filter/japanese_keep_tags.rs
@@ -70,6 +70,7 @@ impl TokenFilter for JapaneseKeepTagsTokenFilter {
                 false
             }
         });
+
         Ok(())
     }
 }

--- a/lindera/src/token_filter/japanese_keep_tags.rs
+++ b/lindera/src/token_filter/japanese_keep_tags.rs
@@ -10,13 +10,13 @@ pub const JAPANESE_KEEP_TAGS_TOKEN_FILTER_NAME: &str = "japanese_keep_tags";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JapaneseKeepTagsTokenFilterConfig {
-    keep_tags: HashSet<String>,
+    tags: HashSet<String>,
 }
 
 impl JapaneseKeepTagsTokenFilterConfig {
-    pub fn new(keep_tags: HashSet<String>) -> Self {
+    pub fn new(tags: HashSet<String>) -> Self {
         let mut formatted_tags: HashSet<String> = HashSet::new();
-        for tag in keep_tags.iter() {
+        for tag in tags.iter() {
             let mut formatted_tag = vec!["*", "*", "*", "*"];
 
             let tag_array: Vec<&str> = tag.split(',').collect();
@@ -28,7 +28,7 @@ impl JapaneseKeepTagsTokenFilterConfig {
         }
 
         Self {
-            keep_tags: formatted_tags,
+            tags: formatted_tags,
         }
     }
 
@@ -36,7 +36,7 @@ impl JapaneseKeepTagsTokenFilterConfig {
         let tmp_config = serde_json::from_slice::<JapaneseKeepTagsTokenFilterConfig>(data)
             .map_err(|err| LinderaErrorKind::Deserialize.with_error(err))?;
 
-        Ok(Self::new(tmp_config.keep_tags))
+        Ok(Self::new(tmp_config.tags))
     }
 }
 
@@ -65,7 +65,7 @@ impl TokenFilter for JapaneseKeepTagsTokenFilter {
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
         tokens.retain(|token| {
             if let Some(details) = &token.details {
-                self.config.keep_tags.contains(&details[0..4].join(","))
+                self.config.tags.contains(&details[0..4].join(","))
             } else {
                 false
             }
@@ -91,7 +91,7 @@ mod tests {
     fn test_japanese_keep_tags_token_filter_config_from_slice() {
         let config_str = r#"
         {
-            "keep_tags": [
+            "tags": [
                 "名詞",
                 "名詞,一般",
                 "名詞,固有名詞",
@@ -136,14 +136,14 @@ mod tests {
         "#;
         let config = JapaneseKeepTagsTokenFilterConfig::from_slice(config_str.as_bytes()).unwrap();
 
-        assert_eq!(config.keep_tags.len(), 39);
+        assert_eq!(config.tags.len(), 39);
     }
 
     #[test]
     fn test_japanese_keep_tagss_token_filter_from_slice() {
         let config_str = r#"
         {
-            "keep_tags": [
+            "tags": [
                 "名詞",
                 "名詞,一般",
                 "名詞,固有名詞",
@@ -195,7 +195,7 @@ mod tests {
     fn test_japanese_keep_tags_token_filter_apply() {
         let config_str = r#"
         {
-            "keep_tags": [
+            "tags": [
                 "名詞",
                 "名詞,一般",
                 "名詞,固有名詞",

--- a/lindera/src/token_filter/japanese_reading_form.rs
+++ b/lindera/src/token_filter/japanese_reading_form.rs
@@ -9,13 +9,8 @@ use crate::{error::LinderaErrorKind, DictionaryKind, LinderaResult, Token};
 
 pub const JAPANESE_READING_FORM_TOKEN_FILTER_NAME: &str = "japanese_reading_form";
 
-fn default_kind() -> DictionaryKind {
-    DictionaryKind::IPADIC
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JapaneseReadingFormTokenFilterConfig {
-    #[serde(default = "default_kind")]
     kind: DictionaryKind,
 }
 

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -10,13 +10,13 @@ pub const JAPANESE_STOP_TAGS_TOKEN_FILTER_NAME: &str = "japanese_stop_tags";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct JapaneseStopTagsTokenFilterConfig {
-    stop_tags: HashSet<String>,
+    tags: HashSet<String>,
 }
 
 impl JapaneseStopTagsTokenFilterConfig {
-    pub fn new(stop_tags: HashSet<String>) -> Self {
+    pub fn new(tags: HashSet<String>) -> Self {
         let mut formatted_tags: HashSet<String> = HashSet::new();
-        for tag in stop_tags.iter() {
+        for tag in tags.iter() {
             let mut formatted_tag = vec!["*", "*", "*", "*"];
 
             let tag_array: Vec<&str> = tag.split(',').collect();
@@ -28,7 +28,7 @@ impl JapaneseStopTagsTokenFilterConfig {
         }
 
         Self {
-            stop_tags: formatted_tags,
+            tags: formatted_tags,
         }
     }
 
@@ -36,7 +36,7 @@ impl JapaneseStopTagsTokenFilterConfig {
         let tmp_config = serde_json::from_slice::<JapaneseStopTagsTokenFilterConfig>(data)
             .map_err(|err| LinderaErrorKind::Deserialize.with_error(err))?;
 
-        Ok(Self::new(tmp_config.stop_tags))
+        Ok(Self::new(tmp_config.tags))
     }
 }
 
@@ -70,7 +70,7 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
                 for (i, j) in details[0..tags_len].iter().enumerate() {
                     formatted_tags[i] = j;
                 }
-                !self.config.stop_tags.contains(&formatted_tags.join(","))
+                !self.config.tags.contains(&formatted_tags.join(","))
             } else {
                 false
             }
@@ -96,7 +96,7 @@ mod tests {
     fn test_japanese_stop_tags_token_filter_config_from_slice() {
         let config_str = r#"
         {
-            "stop_tags": [
+            "tags": [
                 "接続詞",
                 "助詞",
                 "助詞,格助詞",
@@ -127,14 +127,14 @@ mod tests {
         "#;
         let config = JapaneseStopTagsTokenFilterConfig::from_slice(config_str.as_bytes()).unwrap();
 
-        assert_eq!(config.stop_tags.len(), 25);
+        assert_eq!(config.tags.len(), 25);
     }
 
     #[test]
     fn test_japanese_stop_tagss_token_filter_from_slice() {
         let config_str = r#"
         {
-            "stop_tags": [
+            "tags": [
                 "接続詞",
                 "助詞",
                 "助詞,格助詞",
@@ -172,7 +172,7 @@ mod tests {
     fn test_japanese_stop_tags_token_filter_apply() {
         let config_str = r#"
         {
-            "stop_tags": [
+            "tags": [
                 "接続詞",
                 "助詞",
                 "助詞,格助詞",

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -75,6 +75,7 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
                 false
             }
         });
+
         Ok(())
     }
 }

--- a/lindera/src/token_filter/keep_words.rs
+++ b/lindera/src/token_filter/keep_words.rs
@@ -44,6 +44,7 @@ impl TokenFilter for KeepWordsTokenFilter {
 
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
         tokens.retain(|token| self.config.words.contains(token.text.as_ref()));
+
         Ok(())
     }
 }

--- a/lindera/src/token_filter/keep_words.rs
+++ b/lindera/src/token_filter/keep_words.rs
@@ -9,12 +9,12 @@ use crate::{error::LinderaErrorKind, LinderaResult, Token};
 pub const KEEP_WORDS_TOKEN_FILTER_NAME: &str = "keep_words";
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct KeepWordsTokenFilterConfig {
-    keep_words: HashSet<String>,
+    words: HashSet<String>,
 }
 
 impl KeepWordsTokenFilterConfig {
-    pub fn new(keep_words: HashSet<String>) -> Self {
-        Self { keep_words }
+    pub fn new(words: HashSet<String>) -> Self {
+        Self { words }
     }
 
     pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
@@ -43,7 +43,7 @@ impl TokenFilter for KeepWordsTokenFilter {
     }
 
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
-        tokens.retain(|token| self.config.keep_words.contains(token.text.as_ref()));
+        tokens.retain(|token| self.config.words.contains(token.text.as_ref()));
         Ok(())
     }
 }
@@ -63,7 +63,7 @@ mod tests {
     fn test_keep_words_token_filter_config_from_slice() {
         let config_str = r#"
         {
-            "keep_words": [
+            "words": [
                 "Lindera",
                 "Rust"
             ]
@@ -71,14 +71,14 @@ mod tests {
         "#;
         let config = KeepWordsTokenFilterConfig::from_slice(config_str.as_bytes()).unwrap();
 
-        assert_eq!(config.keep_words.len(), 2);
+        assert_eq!(config.words.len(), 2);
     }
 
     #[test]
     fn test_keep_words_token_filter_from_slice() {
         let config_str = r#"
         {
-            "keep_words": [
+            "words": [
                 "Lindera",
                 "Rust"
             ]
@@ -93,7 +93,7 @@ mod tests {
     fn test_keep_words_token_filter_apply() {
         let config_str = r#"
         {
-            "keep_words": [
+            "words": [
                 "Lindera",
                 "Rust"
             ]

--- a/lindera/src/token_filter/korean_keep_tags.rs
+++ b/lindera/src/token_filter/korean_keep_tags.rs
@@ -10,12 +10,12 @@ pub const KOREAN_KEEP_TAGS_TOKEN_FILTER_NAME: &str = "korean_keep_tags";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct KoreanKeepTagsTokenFilterConfig {
-    keep_tags: HashSet<String>,
+    tags: HashSet<String>,
 }
 
 impl KoreanKeepTagsTokenFilterConfig {
-    pub fn new(keep_tags: HashSet<String>) -> Self {
-        Self { keep_tags }
+    pub fn new(tags: HashSet<String>) -> Self {
+        Self { tags }
     }
 
     pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
@@ -49,7 +49,7 @@ impl TokenFilter for KoreanKeepTagsTokenFilter {
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
         tokens.retain(|token| {
             if let Some(details) = &token.details {
-                self.config.keep_tags.contains(&details[0])
+                self.config.tags.contains(&details[0])
             } else {
                 false
             }
@@ -75,21 +75,21 @@ mod tests {
     fn test_korean_keep_tags_token_filter_config_from_slice() {
         let config_str = r#"
         {
-            "keep_tags": [
+            "tags": [
                 "NNG"
             ]
         }
         "#;
         let config = KoreanKeepTagsTokenFilterConfig::from_slice(config_str.as_bytes()).unwrap();
 
-        assert_eq!(config.keep_tags.len(), 1);
+        assert_eq!(config.tags.len(), 1);
     }
 
     #[test]
     fn test_korean_keep_tags_token_filter_from_slice() {
         let config_str = r#"
         {
-            "keep_tags": [
+            "tags": [
                 "NNG"
             ]
         }
@@ -103,7 +103,7 @@ mod tests {
     fn test_korean_keep_tags_token_filter_apply() {
         let config_str = r#"
         {
-            "keep_tags": [
+            "tags": [
                 "NNG"
             ]
         }

--- a/lindera/src/token_filter/korean_keep_tags.rs
+++ b/lindera/src/token_filter/korean_keep_tags.rs
@@ -54,6 +54,7 @@ impl TokenFilter for KoreanKeepTagsTokenFilter {
                 false
             }
         });
+
         Ok(())
     }
 }

--- a/lindera/src/token_filter/korean_stop_tags.rs
+++ b/lindera/src/token_filter/korean_stop_tags.rs
@@ -10,12 +10,12 @@ pub const KOREAN_STOP_TAGS_TOKEN_FILTER_NAME: &str = "korean_stop_tags";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct KoreanStopTagsTokenFilterConfig {
-    stop_tags: HashSet<String>,
+    tags: HashSet<String>,
 }
 
 impl KoreanStopTagsTokenFilterConfig {
-    pub fn new(stop_tags: HashSet<String>) -> Self {
-        Self { stop_tags }
+    pub fn new(tags: HashSet<String>) -> Self {
+        Self { tags }
     }
 
     pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
@@ -49,7 +49,7 @@ impl TokenFilter for KoreanStopTagsTokenFilter {
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
         tokens.retain(|token| {
             if let Some(details) = &token.details {
-                !self.config.stop_tags.contains(&details[0])
+                !self.config.tags.contains(&details[0])
             } else {
                 false
             }
@@ -75,7 +75,7 @@ mod tests {
     fn test_korean_stop_tags_token_filter_config_from_slice() {
         let config_str = r#"
         {
-            "stop_tags": [
+            "tags": [
                 "EP",
                 "EF",
                 "EC",
@@ -111,14 +111,14 @@ mod tests {
         "#;
         let config = KoreanStopTagsTokenFilterConfig::from_slice(config_str.as_bytes()).unwrap();
 
-        assert_eq!(config.stop_tags.len(), 30);
+        assert_eq!(config.tags.len(), 30);
     }
 
     #[test]
     fn test_korean_stop_tagss_token_filter_from_slice() {
         let config_str = r#"
         {
-            "stop_tags": [
+            "tags": [
                 "EP",
                 "EF",
                 "EC",
@@ -161,7 +161,7 @@ mod tests {
     fn test_korean_stop_tags_token_filter_apply() {
         let config_str = r#"
         {
-            "stop_tags": [
+            "tags": [
                 "EP",
                 "EF",
                 "EC",

--- a/lindera/src/token_filter/korean_stop_tags.rs
+++ b/lindera/src/token_filter/korean_stop_tags.rs
@@ -54,6 +54,7 @@ impl TokenFilter for KoreanStopTagsTokenFilter {
                 false
             }
         });
+
         Ok(())
     }
 }

--- a/lindera/src/token_filter/stop_words.rs
+++ b/lindera/src/token_filter/stop_words.rs
@@ -10,12 +10,12 @@ pub const STOP_WORDS_TOKEN_FILTER_NAME: &str = "stop_words";
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct StopWordsTokenFilterConfig {
-    stop_words: HashSet<String>,
+    words: HashSet<String>,
 }
 
 impl StopWordsTokenFilterConfig {
-    pub fn new(stop_words: HashSet<String>) -> Self {
-        Self { stop_words }
+    pub fn new(words: HashSet<String>) -> Self {
+        Self { words }
     }
 
     pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
@@ -44,7 +44,7 @@ impl TokenFilter for StopWordsTokenFilter {
     }
 
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
-        tokens.retain(|token| !self.config.stop_words.contains(token.text.as_ref()));
+        tokens.retain(|token| !self.config.words.contains(token.text.as_ref()));
         Ok(())
     }
 }
@@ -64,7 +64,7 @@ mod tests {
     fn test_stop_words_token_filter_config_from_slice() {
         let config_str = r#"
         {
-            "stop_words": [
+            "words": [
                 "a",
                 "an",
                 "and",
@@ -103,14 +103,14 @@ mod tests {
         "#;
         let config = StopWordsTokenFilterConfig::from_slice(config_str.as_bytes()).unwrap();
 
-        assert_eq!(config.stop_words.len(), 33);
+        assert_eq!(config.words.len(), 33);
     }
 
     #[test]
     fn test_stop_words_token_filter_from_slice() {
         let config_str = r#"
         {
-            "stop_words": [
+            "words": [
                 "a",
                 "an",
                 "and",
@@ -156,7 +156,7 @@ mod tests {
     fn test_stop_words_token_filter_apply() {
         let config_str = r#"
         {
-            "stop_words": [
+            "words": [
                 "a",
                 "an",
                 "and",

--- a/lindera/src/token_filter/stop_words.rs
+++ b/lindera/src/token_filter/stop_words.rs
@@ -45,6 +45,7 @@ impl TokenFilter for StopWordsTokenFilter {
 
     fn apply<'a>(&self, tokens: &mut Vec<Token<'a>>) -> LinderaResult<()> {
         tokens.retain(|token| !self.config.words.contains(token.text.as_ref()));
+
         Ok(())
     }
 }

--- a/resources/lindera_ipadic_conf.json
+++ b/resources/lindera_ipadic_conf.json
@@ -17,6 +17,7 @@
         {
             "kind": "japanese_compound_word",
             "args": {
+                "kind": "ipadic",
                 "tags": [
                     "名詞,数"
                 ],

--- a/resources/lindera_ipadic_conf.json
+++ b/resources/lindera_ipadic_conf.json
@@ -18,9 +18,9 @@
             "kind": "japanese_compound_word",
             "args": {
                 "tags": [
-                    "名詞,数",
-                    "名詞,接尾,助数詞"
-                ]
+                    "名詞,数"
+                ],
+                "new_tag": "名詞,数"
             }
         },
         {

--- a/resources/lindera_ipadic_conf.json
+++ b/resources/lindera_ipadic_conf.json
@@ -15,9 +15,18 @@
     },
     "token_filters": [
         {
+            "kind": "japanese_compound_word",
+            "args": {
+                "tags": [
+                    "名詞,数",
+                    "名詞,接尾,助数詞"
+                ]
+            }
+        },
+        {
             "kind": "japanese_stop_tags",
             "args": {
-                "stop_tags": [
+                "tags": [
                     "接続詞",
                     "助詞",
                     "助詞,格助詞",


### PR DESCRIPTION
Add Japanese compound word token filter.

```
$ cat resources/lindera_ipadic_conf.json 
{
    "character_filters": [
        {
            "kind": "unicode_normalize",
            "args": {
                "kind": "nfkc"
            }
        }
    ],
    "tokenizer": {
        "dictionary": {
            "kind": "ipadic"
        },
        "mode": "normal"
    },
    "token_filters": [
        {
            "kind": "japanese_compound_word",
            "args": {
                "tags": [
                    "名詞,数",
                    "名詞,接尾,助数詞"
                ]
            }
        },
        {
            "kind": "japanese_stop_tags",
            "args": {
                "tags": [
                    "接続詞",
                    "助詞",
                    "助詞,格助詞",
                    "助詞,格助詞,一般",
                    "助詞,格助詞,引用",
                    "助詞,格助詞,連語",
                    "助詞,係助詞",
                    "助詞,副助詞",
                    "助詞,間投助詞",
                    "助詞,並立助詞",
                    "助詞,終助詞",
                    "助詞,副助詞／並立助詞／終助詞",
                    "助詞,連体化",
                    "助詞,副詞化",
                    "助詞,特殊",
                    "助動詞",
                    "記号",
                    "記号,一般",
                    "記号,読点",
                    "記号,句点",
                    "記号,空白",
                    "記号,括弧閉",
                    "その他,間投",
                    "フィラー",
                    "非言語音"
                ]
            }
        },
        {
            "kind": "japanese_katakana_stem",
            "args": {
                "min": 3
            }
        }
    ]
}

$ echo "お釣りは百三十四円です。" | ./target/debug/lindera analyze --config ./resources/lindera_ipadic_conf.json
お釣り  名詞,一般,*,*,*,*,お釣り,オツリ,オツリ
百三十四円      複合語,*,*,*,*,*,*,*,*
EOS
```

Close #244 