### PR TITLE
Add Japanese iteration mark character filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Add Japanese iteration mark character filter #277 @mosuka
+- Add Japanese number token filter #276 @mosuka
 - Add Send trait to dynamic filters #275 @higumachan
 - Add Japanese compound word token filter #273 @mosuka
 - Added a function to return a name for each filter #272 @mosuka

--- a/lindera-core/src/character_definition.rs
+++ b/lindera-core/src/character_definition.rs
@@ -91,7 +91,7 @@ impl CharacterDefinitions {
     }
 
     pub fn category_name(&self, category_id: CategoryId) -> &str {
-        &self.category_names[category_id.0 as usize]
+        &self.category_names[category_id.0]
     }
 
     pub fn lookup_categories(&self, c: char) -> &[CategoryId] {

--- a/lindera-core/src/viterbi.rs
+++ b/lindera-core/src/viterbi.rs
@@ -189,7 +189,7 @@ impl Lattice {
         for start in 0..len {
             // No arc is ending here.
             // No need to check if a valid word starts here.
-            if self.ends_at[start as usize].is_empty() {
+            if self.ends_at[start].is_empty() {
                 continue;
             }
 

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1.0.58"
 bincode = "1.3.3"
 byteorder = "1.4.3"
 encoding = "0.2.33"
+once_cell = "1.16.0"
 regex = "1.6.0"
 serde = {version="1.0.138", features = ["derive"] }
 serde_json = "1.0.82"

--- a/lindera/src/analyzer.rs
+++ b/lindera/src/analyzer.rs
@@ -9,6 +9,9 @@ use lindera_core::{
 
 use crate::{
     character_filter::{
+        japanese_iteration_mark::{
+            JapaneseIterationMarkCharacterFilter, JAPANESE_ITERATION_MARK_CHARACTER_FILTER_NAME,
+        },
         mapping::{MappingCharacterFilter, MAPPING_CHARACTER_FILTER_NAME},
         regex::{RegexCharacterFilter, REGEX_CHARACTER_FILTER_NAME},
         unicode_normalize::{
@@ -104,6 +107,11 @@ impl Analyzer {
                         .map_err(|err| LinderaErrorKind::Deserialize.with_error(err))?;
 
                     match character_filter_name {
+                        JAPANESE_ITERATION_MARK_CHARACTER_FILTER_NAME => {
+                            character_filters.push(Box::new(
+                                JapaneseIterationMarkCharacterFilter::from_slice(&arg_bytes)?,
+                            ));
+                        }
                         MAPPING_CHARACTER_FILTER_NAME => {
                             character_filters
                                 .push(Box::new(MappingCharacterFilter::from_slice(&arg_bytes)?));
@@ -390,6 +398,13 @@ mod tests {
                     }
                 },
                 {
+                    "kind": "japanese_iteration_mark",
+                    "args": {
+                        "normalize_kanji": true,
+                        "normalize_kana": true
+                    }
+                },
+                {
                     "kind": "mapping",
                     "args": {
                         "mapping": {
@@ -517,6 +532,16 @@ mod tests {
             assert_eq!(
                 tokens.iter().map(|t| t.text.as_ref()).collect::<Vec<_>>(),
                 vec!["お釣り", "百三十四円"]
+            );
+        }
+
+        {
+            let text = "ここは騒々しい".to_string();
+            let mut analyze_text = text.clone();
+            let tokens = analyzer.analyze(&mut analyze_text).unwrap();
+            assert_eq!(
+                tokens.iter().map(|t| t.text.as_ref()).collect::<Vec<_>>(),
+                vec!["ここ", "騒騒しい"]
             );
         }
     }

--- a/lindera/src/analyzer.rs
+++ b/lindera/src/analyzer.rs
@@ -207,7 +207,7 @@ impl Analyzer {
                             )?));
                         }
                         KOREAN_READING_FORM_TOKEN_FILTER_NAME => {
-                            token_filters.push(Box::new(KoreanReadingFormTokenFilter::default()));
+                            token_filters.push(Box::<KoreanReadingFormTokenFilter>::default());
                         }
                         KOREAN_STOP_TAGS_TOKEN_FILTER_NAME => {
                             token_filters.push(Box::new(KoreanStopTagsTokenFilter::from_slice(
@@ -219,14 +219,14 @@ impl Analyzer {
                                 .push(Box::new(LengthTokenFilter::from_slice(&args_bytes)?));
                         }
                         LOWERCASE_TOKEN_FILTER_NAME => {
-                            token_filters.push(Box::new(LowercaseTokenFilter::default()));
+                            token_filters.push(Box::<LowercaseTokenFilter>::default());
                         }
                         STOP_WORDS_TOKEN_FILTER_NAME => {
                             token_filters
                                 .push(Box::new(StopWordsTokenFilter::from_slice(&args_bytes)?));
                         }
                         UPPERCASE_TOKEN_FILTER_NAME => {
-                            token_filters.push(Box::new(UppercaseTokenFilter::default()));
+                            token_filters.push(Box::<UppercaseTokenFilter>::default());
                         }
                         _ => {
                             return Err(LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(

--- a/lindera/src/character_filter.rs
+++ b/lindera/src/character_filter.rs
@@ -1,3 +1,4 @@
+pub mod japanese_iteration_mark;
 pub mod mapping;
 pub mod regex;
 pub mod unicode_normalize;

--- a/lindera/src/character_filter/japanese_iteration_mark.rs
+++ b/lindera/src/character_filter/japanese_iteration_mark.rs
@@ -388,5 +388,13 @@ mod tests {
             assert!(offsets.is_empty());
             assert!(diffs.is_empty());
         }
+
+        {
+            let text = "ところゞゝゝ馬鹿々々しく騒々しい";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("ところどころ馬鹿馬鹿しく騒騒しい", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
     }
 }

--- a/lindera/src/character_filter/japanese_iteration_mark.rs
+++ b/lindera/src/character_filter/japanese_iteration_mark.rs
@@ -1,0 +1,377 @@
+use std::collections::{BTreeMap, HashMap};
+
+use lindera_core::character_filter::CharacterFilter;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+use crate::{error::LinderaErrorKind, LinderaResult};
+
+pub const JAPANESE_ITERATION_MARK_CHARACTER_FILTER_NAME: &str = "japanese_iteration_mark";
+
+const KANJI_ITERATION_MARK: char = '々';
+const HIRAGANA_ITERATION_MARK: char = 'ゝ';
+const HIRAGANA_DAKUON_ITERATION_MARK: char = 'ゞ';
+const KATAKANA_ITERATION_MARK: char = 'ヽ';
+const KATAKANA_DAKUON_ITERATION_MARK: char = 'ヾ';
+
+static HIRAGANA_DAKUON_MAP: Lazy<HashMap<char, char>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert('か', 'が');
+    m.insert('が', 'が');
+    m.insert('き', 'ぎ');
+    m.insert('ぎ', 'ぎ');
+    m.insert('く', 'ぐ');
+    m.insert('ぐ', 'ぐ');
+    m.insert('け', 'げ');
+    m.insert('げ', 'げ');
+    m.insert('こ', 'ご');
+    m.insert('ご', 'ご');
+    m.insert('さ', 'ざ');
+    m.insert('ざ', 'ざ');
+    m.insert('し', 'じ');
+    m.insert('じ', 'じ');
+    m.insert('す', 'ず');
+    m.insert('ず', 'ず');
+    m.insert('せ', 'ぜ');
+    m.insert('ぜ', 'ぜ');
+    m.insert('そ', 'ぞ');
+    m.insert('ぞ', 'ぞ');
+    m.insert('た', 'だ');
+    m.insert('だ', 'だ');
+    m.insert('ち', 'ぢ');
+    m.insert('ぢ', 'ぢ');
+    m.insert('つ', 'づ');
+    m.insert('づ', 'づ');
+    m.insert('て', 'で');
+    m.insert('で', 'で');
+    m.insert('と', 'ど');
+    m.insert('ど', 'ど');
+    m.insert('は', 'ば');
+    m.insert('ば', 'ば');
+    m.insert('ひ', 'び');
+    m.insert('び', 'び');
+    m.insert('ふ', 'ぶ');
+    m.insert('ぶ', 'ぶ');
+    m.insert('へ', 'べ');
+    m.insert('べ', 'べ');
+    m.insert('ほ', 'ぼ');
+    m.insert('ぼ', 'ぼ');
+    m
+});
+
+static KATAKANA_DAKUON_MAP: Lazy<HashMap<char, char>> = Lazy::new(|| {
+    let mut m = HashMap::new();
+    m.insert('カ', 'ガ');
+    m.insert('ガ', 'ガ');
+    m.insert('キ', 'ギ');
+    m.insert('ギ', 'ギ');
+    m.insert('ク', 'グ');
+    m.insert('グ', 'グ');
+    m.insert('ケ', 'ゲ');
+    m.insert('ゲ', 'ゲ');
+    m.insert('コ', 'ゴ');
+    m.insert('ゴ', 'ゴ');
+    m.insert('サ', 'ザ');
+    m.insert('ザ', 'ザ');
+    m.insert('シ', 'ジ');
+    m.insert('ジ', 'ジ');
+    m.insert('ス', 'ズ');
+    m.insert('ズ', 'ズ');
+    m.insert('セ', 'ゼ');
+    m.insert('ゼ', 'ゼ');
+    m.insert('ソ', 'ゾ');
+    m.insert('ゾ', 'ゾ');
+    m.insert('タ', 'ダ');
+    m.insert('ダ', 'ダ');
+    m.insert('チ', 'ヂ');
+    m.insert('ヂ', 'ヂ');
+    m.insert('ツ', 'ヅ');
+    m.insert('ヅ', 'ヅ');
+    m.insert('テ', 'デ');
+    m.insert('デ', 'デ');
+    m.insert('ト', 'ド');
+    m.insert('ド', 'ド');
+    m.insert('ハ', 'バ');
+    m.insert('バ', 'バ');
+    m.insert('パ', 'バ');
+    m.insert('ヒ', 'ビ');
+    m.insert('ビ', 'ビ');
+    m.insert('フ', 'ブ');
+    m.insert('ブ', 'ブ');
+    m.insert('ヘ', 'ベ');
+    m.insert('ベ', 'ベ');
+    m.insert('ホ', 'ボ');
+    m.insert('ボ', 'ボ');
+    m
+});
+
+fn is_hiragana_dakuon(c: char) -> bool {
+    HIRAGANA_DAKUON_MAP.values().any(|&v| v == c)
+}
+
+fn is_katakana_dakuon(c: char) -> bool {
+    KATAKANA_DAKUON_MAP.values().any(|&v| v == c)
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct JapaneseIterationMarkCharacterFilterConfig {
+    pub normalize_kanji: bool,
+    pub normalize_kana: bool,
+}
+
+impl JapaneseIterationMarkCharacterFilterConfig {
+    pub fn new(normalize_kanji: bool, normalize_kana: bool) -> Self {
+        Self {
+            normalize_kanji,
+            normalize_kana,
+        }
+    }
+
+    pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
+        serde_json::from_slice(data).map_err(|err| LinderaErrorKind::Deserialize.with_error(err))
+    }
+}
+
+#[derive(Clone)]
+pub struct JapaneseIterationMarkCharacterFilter {
+    config: JapaneseIterationMarkCharacterFilterConfig,
+}
+
+impl JapaneseIterationMarkCharacterFilter {
+    pub fn new(config: JapaneseIterationMarkCharacterFilterConfig) -> LinderaResult<Self> {
+        Ok(Self { config })
+    }
+
+    pub fn from_slice(data: &[u8]) -> LinderaResult<Self> {
+        let config = JapaneseIterationMarkCharacterFilterConfig::from_slice(data)?;
+
+        Self::new(config)
+    }
+
+    fn normalize(&self, iter_marks: &BTreeMap<usize, &char>, text_chars: &Vec<char>) -> String {
+        let mut normalized_str = String::new();
+
+        for (iter_mark_pos, iter_mark) in iter_marks.iter() {
+            let iter_mark_index = *iter_mark_pos - iter_marks.len();
+            match *iter_mark {
+                &KANJI_ITERATION_MARK if self.config.normalize_kanji => {
+                    let replacement = text_chars.get(iter_mark_index).unwrap_or(iter_mark);
+                    normalized_str.push(*replacement);
+                }
+                &HIRAGANA_ITERATION_MARK if self.config.normalize_kana => {
+                    let replacement = text_chars.get(iter_mark_index).unwrap_or(iter_mark);
+                    if is_hiragana_dakuon(*replacement) {
+                        // remove dakuon
+                        let replacement =
+                            char::from_u32(*replacement as u32 - 1).unwrap_or(*replacement);
+                        normalized_str.push(replacement);
+                    } else {
+                        normalized_str.push(*replacement);
+                    }
+                }
+                &HIRAGANA_DAKUON_ITERATION_MARK if self.config.normalize_kana => {
+                    let replacement = text_chars.get(iter_mark_index).unwrap_or(iter_mark);
+                    let replacement = HIRAGANA_DAKUON_MAP.get(replacement).unwrap_or(replacement);
+                    normalized_str.push(*replacement);
+                }
+                &KATAKANA_ITERATION_MARK if self.config.normalize_kana => {
+                    let replacement = text_chars.get(iter_mark_index).unwrap_or(iter_mark);
+                    if is_katakana_dakuon(*replacement) {
+                        // remove dakuon
+                        let replacement =
+                            char::from_u32(*replacement as u32 - 1).unwrap_or(*replacement);
+                        normalized_str.push(replacement);
+                    } else {
+                        normalized_str.push(*replacement);
+                    }
+                }
+                &KATAKANA_DAKUON_ITERATION_MARK if self.config.normalize_kana => {
+                    let replacement = text_chars.get(iter_mark_index).unwrap_or(iter_mark);
+                    let replacement = KATAKANA_DAKUON_MAP.get(replacement).unwrap_or(replacement);
+                    normalized_str.push(*replacement);
+                }
+                _ => {
+                    normalized_str.push(**iter_mark);
+                }
+            }
+        }
+
+        normalized_str
+    }
+}
+
+impl CharacterFilter for JapaneseIterationMarkCharacterFilter {
+    fn name(&self) -> &'static str {
+        JAPANESE_ITERATION_MARK_CHARACTER_FILTER_NAME
+    }
+
+    fn apply(&self, text: &str) -> LinderaResult<(String, Vec<usize>, Vec<i64>)> {
+        let mut filterd_text = String::with_capacity(text.len());
+
+        let text_chars = text.chars().collect::<Vec<char>>();
+        let mut iter_marks = BTreeMap::new();
+        for (i, c) in text_chars.iter().enumerate() {
+            match c {
+                &KANJI_ITERATION_MARK if self.config.normalize_kanji => {
+                    iter_marks.insert(i, c);
+                }
+                &HIRAGANA_ITERATION_MARK
+                | &HIRAGANA_DAKUON_ITERATION_MARK
+                | &KATAKANA_ITERATION_MARK
+                | &KATAKANA_DAKUON_ITERATION_MARK
+                    if self.config.normalize_kana =>
+                {
+                    iter_marks.insert(i, c);
+                }
+                _ => {
+                    if iter_marks.len() > 0 {
+                        filterd_text.push_str(&self.normalize(&iter_marks, &text_chars));
+                        iter_marks.clear();
+                    }
+                    filterd_text.push(*c);
+                }
+            }
+        }
+
+        if iter_marks.len() > 0 {
+            filterd_text.push_str(&self.normalize(&iter_marks, &text_chars));
+        }
+
+        Ok((filterd_text, Vec::new(), Vec::new()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lindera_core::character_filter::CharacterFilter;
+
+    use crate::character_filter::japanese_iteration_mark::{
+        JapaneseIterationMarkCharacterFilter, JapaneseIterationMarkCharacterFilterConfig,
+    };
+
+    #[test]
+    fn test_japanese_iteration_mark_character_filter_config_from_slice() {
+        let config_str = r#"
+        {
+            "normalize_kanji": true,
+            "normalize_kana": true
+        }
+        "#;
+        let config =
+            JapaneseIterationMarkCharacterFilterConfig::from_slice(config_str.as_bytes()).unwrap();
+        assert!(config.normalize_kanji);
+        assert!(config.normalize_kana);
+    }
+
+    #[test]
+    fn test_japanese_iteration_mark_character_filter_from_slice() {
+        let config_str = r#"
+        {
+            "normalize_kanji": true,
+            "normalize_kana": true
+        }
+        "#;
+        let result = JapaneseIterationMarkCharacterFilter::from_slice(config_str.as_bytes());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_japanese_iteration_mark_character_filter_apply() {
+        let config_str = r#"
+        {
+            "normalize_kanji": true,
+            "normalize_kana": true
+        }
+        "#;
+        let filter =
+            JapaneseIterationMarkCharacterFilter::from_slice(config_str.as_bytes()).unwrap();
+
+        {
+            let text = "ここは騒々しい";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("ここは騒騒しい", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "祇園 さゝ木";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("祇園 ささ木", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "いすゞ自動車株式会社";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("いすず自動車株式会社", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "サヽキ印刷";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("ササキ印刷", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "愛知県岡崎市牧平町マカヾイツ";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("愛知県岡崎市牧平町マカガイツ", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "馬鹿々々しい";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("馬鹿馬鹿しい", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "ところゞゝゝ";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("ところどころ", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "じゝ";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("じし", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "じゞ";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("じじ", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "ジヽ";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("ジシ", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+
+        {
+            let text = "ジヾ";
+            let (filterd_text, offsets, diffs) = filter.apply(text).unwrap();
+            assert_eq!("ジジ", filterd_text);
+            assert!(offsets.is_empty());
+            assert!(diffs.is_empty());
+        }
+    }
+}

--- a/resources/lindera_ipadic_conf.json
+++ b/resources/lindera_ipadic_conf.json
@@ -5,6 +5,13 @@
             "args": {
                 "kind": "nfkc"
             }
+        },
+        {
+            "kind": "japanese_iteration_mark",
+            "args": {
+                "normalize_kanji": true,
+                "normalize_kana": true
+            }
         }
     ],
     "tokenizer": {


### PR DESCRIPTION
Add Japanese iteration mark character filter.

e.g.

```
{
    "character_filters": [
        {
            "kind": "unicode_normalize",
            "args": {
                "kind": "nfkc"
            }
        },
        {
            "kind": "japanese_iteration_mark",
            "args": {
                "normalize_kanji": true,
                "normalize_kana": true
            }
        }
    ],
    "tokenizer": {
        "dictionary": {
            "kind": "ipadic"
        },
        "mode": "normal"
    },
    "token_filters": [
        {
            "kind": "japanese_compound_word",
            "args": {
                "kind": "ipadic",
                "tags": [
                    "名詞,数"
                ],
                "new_tag": "名詞,数"
            }
        },
        {
            "kind": "japanese_number",
            "args": {
                "kind": "ipadic"
            }
        },
        {
            "kind": "japanese_stop_tags",
            "args": {
                "tags": [
                    "接続詞",
                    "助詞",
                    "助詞,格助詞",
                    "助詞,格助詞,一般",
                    "助詞,格助詞,引用",
                    "助詞,格助詞,連語",
                    "助詞,係助詞",
                    "助詞,副助詞",
                    "助詞,間投助詞",
                    "助詞,並立助詞",
                    "助詞,終助詞",
                    "助詞,副助詞／並立助詞／終助詞",
                    "助詞,連体化",
                    "助詞,副詞化",
                    "助詞,特殊",
                    "助動詞",
                    "記号",
                    "記号,一般",
                    "記号,読点",
                    "記号,句点",
                    "記号,空白",
                    "記号,括弧閉",
                    "その他,間投",
                    "フィラー",
                    "非言語音"
                ]
            }
        },
        {
            "kind": "japanese_katakana_stem",
            "args": {
                "min": 3
            }
        }
    ]
}
```

```
$ echo "ここは騒々しい" | cargo run --features=ipadic --bin lindera -- analyze -c ./resources/lindera_ipadic_conf.json 
ここ    名詞,代名詞,一般,*,*,*,ここ,ココ,ココ
騒騒しい        形容詞,自立,*,*,形容詞・イ段,基本形,騒騒しい,ソウゾウシイ,ソーゾーシイ
EOS
```

Close #252 