### PR TITLE
Use Unicode values instead of `HashMap` for performance

### DIFF
--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -26,7 +26,6 @@ anyhow = "1.0.68"
 bincode = "1.3.3"
 byteorder = "1.4.3"
 encoding = "0.2.33"
-once_cell = "1.16.0"
 regex = "1.7.0"
 serde = {version="1.0.151", features = ["derive"] }
 serde_json = "1.0.91"
@@ -48,6 +47,7 @@ lindera-unidic-builder = { version = "0.19.1", path = "../lindera-unidic-builder
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
+once_cell = "1.16.0"
 
 [[bench]]
 name = "bench"

--- a/lindera/src/character_filter/japanese_iteration_mark.rs
+++ b/lindera/src/character_filter/japanese_iteration_mark.rs
@@ -523,7 +523,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn bm_detection() {
+    fn bench_hiragana_detection() {
         let chars = HIRAGANA_DAKUON_MAP.keys().collect::<Vec<_>>();
         let iters = 100000;
 


### PR DESCRIPTION
I was using this library in a personal project and noticed a place where you can improve performance. Instead of using a static `HashMap<char, char>`, you can significantly improve performance by processing the character codes directly. Hopefully this suggestion is welcome.

A few notes:
- I noticed that the `KATAKANA_DAKUON_MAP` contains a single handakuten&rarr;dakuten conversion: パ&rarr;バ. Not sure if this was intentional, so I commented it out for now.
- There are some uncommon characters that are not covered: ゔ・ヴ, ヷ・ヸ・ヹ・ヺ. I'm assuming the exclusion of the latter four is intentional, but I wonder about the first two.

Output of `bench_hiragana_detection` test:
```text
new: 197ms 4000000
old: 4248ms 4000000
```

Output of `bench_hiragana_conversion` test:
```text
new: 129ms 4000000
old: 934ms 4000000
```