### PR TITLE
Fix token boundaries

### DIFF
--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -394,7 +394,7 @@ mod tests {
 
         let tokenizer = Tokenizer::from_config(config).unwrap();
         let mut tokens = tokenizer
-            .tokenize("日本語の形態素解析を行うことができます。")
+            .tokenize("日本語の形態素解析を行うことができます。テスト。")
             .unwrap();
         let mut tokens_iter = tokens.iter_mut();
         {
@@ -593,6 +593,40 @@ mod tests {
             assert_eq!(token.byte_start, 57);
             assert_eq!(token.byte_end, 60);
             assert_eq!(token.position, 10);
+            assert_eq!(token.position_length, 1);
+            assert_eq!(
+                token.get_details().unwrap(),
+                vec!["記号", "句点", "*", "*", "*", "*", "。", "。", "。"]
+            );
+        }
+        {
+            let token = tokens_iter.next().unwrap();
+            assert_eq!(token.get_text(), "テスト");
+            assert_eq!(token.byte_start, 60);
+            assert_eq!(token.byte_end, 69);
+            assert_eq!(token.position, 11);
+            assert_eq!(token.position_length, 1);
+            assert_eq!(
+                token.get_details().unwrap(),
+                vec![
+                    "名詞",
+                    "サ変接続",
+                    "*",
+                    "*",
+                    "*",
+                    "*",
+                    "テスト",
+                    "テスト",
+                    "テスト"
+                ]
+            );
+        }
+        {
+            let token = tokens_iter.next().unwrap();
+            assert_eq!(token.get_text(), "。");
+            assert_eq!(token.byte_start, 57);
+            assert_eq!(token.byte_end, 60);
+            assert_eq!(token.position, 12);
             assert_eq!(token.position_length, 1);
             assert_eq!(
                 token.get_details().unwrap(),


### PR DESCRIPTION
When the same text contains several sentences the byte positions of the token (`token_start` and `token_end`) were computed relatively from the start of each sentence, making the text `こんにちは、みのる。` split as:

| token         | start | end |
|---------------|-------|-----|
|  `こんにちは` | 0     | 15  |
| `、`          | 15    | 18  |
|  `みのる`     | 0     | 9   |
| `。`          | 9     | 12  |

This is an issue because if the end-user relies on these attributes, he expects to have the positions relative to the text passed in input and not relative to the phrases contained in it.

With this PR, we ensure recomputing the byte positions to correspond to an absolute byte position

| token         | start | end |
|---------------|-------|-----|
|  `こんにちは` | 0     | 15  |
| `、`          | 15    | 18  |
|  `みのる`     | 18     | 27   |
| `。`          | 27     | 30  |