### PR TITLE
Reduce dictionary data copy

### DIFF
--- a/lindera-cc-cedict/src/lib.rs
+++ b/lindera-cc-cedict/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 #[cfg(feature = "cc-cedict")]
 use std::env;
 
@@ -122,10 +123,24 @@ pub fn unknown_dict() -> LinderaResult<UnknownDictionary> {
     UnknownDictionary::load(&UNKNOWN_DATA)
 }
 
-pub fn words_idx_data() -> Vec<u8> {
-    WORDS_IDX_DATA.to_vec()
+pub fn words_idx_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_IDX_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_IDX_DATA)
+    }
 }
 
-pub fn words_data() -> Vec<u8> {
-    WORDS_DATA.to_vec()
+pub fn words_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_DATA)
+    }
 }

--- a/lindera-cc-cedict/src/lib.rs
+++ b/lindera-cc-cedict/src/lib.rs
@@ -102,8 +102,14 @@ pub fn char_def() -> LinderaResult<CharacterDefinitions> {
 }
 
 pub fn connection() -> ConnectionCostMatrix {
-    #[allow(clippy::needless_borrow)]
-    ConnectionCostMatrix::load(&CONNECTION_DATA)
+    #[cfg(feature = "compress")]
+    {
+        ConnectionCostMatrix::load(&CONNECTION_DATA)
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        ConnectionCostMatrix::load_static(CONNECTION_DATA)
+    }
 }
 
 pub fn prefix_dict() -> PrefixDict {

--- a/lindera-core/src/connection.rs
+++ b/lindera-core/src/connection.rs
@@ -1,17 +1,27 @@
+use std::borrow::Cow;
+
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ConnectionCostMatrix {
-    pub costs_data: Vec<u8>,
+    pub costs_data: Cow<'static, [u8]>,
     pub backward_size: u32,
 }
 
 impl ConnectionCostMatrix {
+    pub fn load_static(conn_data: &'static [u8]) -> ConnectionCostMatrix {
+        let backward_size = LittleEndian::read_i16(&conn_data[2..4]);
+        ConnectionCostMatrix {
+            costs_data: Cow::Borrowed(&conn_data[4..]),
+            backward_size: backward_size as u32,
+        }
+    }
+
     pub fn load(conn_data: &[u8]) -> ConnectionCostMatrix {
         let backward_size = LittleEndian::read_i16(&conn_data[2..4]);
         ConnectionCostMatrix {
-            costs_data: conn_data[4..].to_vec(),
+            costs_data: Cow::Owned(conn_data[4..].to_vec()),
             backward_size: backward_size as u32,
         }
     }

--- a/lindera-core/src/dictionary.rs
+++ b/lindera-core/src/dictionary.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -12,8 +14,8 @@ pub struct Dictionary {
     pub cost_matrix: ConnectionCostMatrix,
     pub char_definitions: CharacterDefinitions,
     pub unknown_dictionary: UnknownDictionary,
-    pub words_idx_data: Vec<u8>,
-    pub words_data: Vec<u8>,
+    pub words_idx_data: Cow<'static, [u8]>,
+    pub words_data: Cow<'static, [u8]>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/lindera-dictionary/src/lib.rs
+++ b/lindera-dictionary/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fs,
     path::{Path, PathBuf},
     str::FromStr,
@@ -143,8 +144,8 @@ pub fn load_dictionary(path: PathBuf) -> LinderaResult<Dictionary> {
         cost_matrix: connection(path.clone())?,
         char_definitions: char_def(path.clone())?,
         unknown_dictionary: unknown_dict(path.clone())?,
-        words_idx_data: words_idx_data(path.clone())?,
-        words_data: words_data(path)?,
+        words_idx_data: Cow::Owned(words_idx_data(path.clone())?),
+        words_data: Cow::Owned(words_data(path)?),
     })
 }
 

--- a/lindera-ipadic-neologd/src/lib.rs
+++ b/lindera-ipadic-neologd/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 #[cfg(feature = "ipadic-neologd")]
 use std::env;
 
@@ -137,10 +138,24 @@ pub fn unknown_dict() -> LinderaResult<UnknownDictionary> {
     UnknownDictionary::load(&UNKNOWN_DATA)
 }
 
-pub fn words_idx_data() -> Vec<u8> {
-    WORDS_IDX_DATA.to_vec()
+pub fn words_idx_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_IDX_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_IDX_DATA)
+    }
 }
 
-pub fn words_data() -> Vec<u8> {
-    WORDS_DATA.to_vec()
+pub fn words_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_DATA)
+    }
 }

--- a/lindera-ipadic-neologd/src/lib.rs
+++ b/lindera-ipadic-neologd/src/lib.rs
@@ -117,8 +117,14 @@ pub fn char_def() -> LinderaResult<CharacterDefinitions> {
 }
 
 pub fn connection() -> ConnectionCostMatrix {
-    #[allow(clippy::needless_borrow)]
-    ConnectionCostMatrix::load(&CONNECTION_DATA)
+    #[cfg(feature = "compress")]
+    {
+        ConnectionCostMatrix::load(&CONNECTION_DATA)
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        ConnectionCostMatrix::load_static(CONNECTION_DATA)
+    }
 }
 
 pub fn prefix_dict() -> PrefixDict {

--- a/lindera-ipadic/src/lib.rs
+++ b/lindera-ipadic/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 #[cfg(feature = "ipadic")]
 use std::env;
 
@@ -122,10 +123,24 @@ pub fn unknown_dict() -> LinderaResult<UnknownDictionary> {
     UnknownDictionary::load(&UNKNOWN_DATA)
 }
 
-pub fn words_idx_data() -> Vec<u8> {
-    WORDS_IDX_DATA.to_vec()
+pub fn words_idx_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_IDX_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_IDX_DATA)
+    }
 }
 
-pub fn words_data() -> Vec<u8> {
-    WORDS_DATA.to_vec()
+pub fn words_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_DATA)
+    }
 }

--- a/lindera-ipadic/src/lib.rs
+++ b/lindera-ipadic/src/lib.rs
@@ -102,8 +102,14 @@ pub fn char_def() -> LinderaResult<CharacterDefinitions> {
 }
 
 pub fn connection() -> ConnectionCostMatrix {
-    #[allow(clippy::needless_borrow)]
-    ConnectionCostMatrix::load(&CONNECTION_DATA)
+    #[cfg(feature = "compress")]
+    {
+        ConnectionCostMatrix::load(&CONNECTION_DATA)
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        ConnectionCostMatrix::load_static(CONNECTION_DATA)
+    }
 }
 
 pub fn prefix_dict() -> PrefixDict {

--- a/lindera-ko-dic/src/lib.rs
+++ b/lindera-ko-dic/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 #[cfg(feature = "ko-dic")]
 use std::env;
 
@@ -122,10 +123,24 @@ pub fn unknown_dict() -> LinderaResult<UnknownDictionary> {
     UnknownDictionary::load(&UNKNOWN_DATA)
 }
 
-pub fn words_idx_data() -> Vec<u8> {
-    WORDS_IDX_DATA.to_vec()
+pub fn words_idx_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_IDX_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_IDX_DATA)
+    }
 }
 
-pub fn words_data() -> Vec<u8> {
-    WORDS_DATA.to_vec()
+pub fn words_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_DATA)
+    }
 }

--- a/lindera-ko-dic/src/lib.rs
+++ b/lindera-ko-dic/src/lib.rs
@@ -102,8 +102,14 @@ pub fn char_def() -> LinderaResult<CharacterDefinitions> {
 }
 
 pub fn connection() -> ConnectionCostMatrix {
-    #[allow(clippy::needless_borrow)]
-    ConnectionCostMatrix::load(&CONNECTION_DATA)
+    #[cfg(feature = "compress")]
+    {
+        ConnectionCostMatrix::load(&CONNECTION_DATA)
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        ConnectionCostMatrix::load_static(CONNECTION_DATA)
+    }
 }
 
 pub fn prefix_dict() -> PrefixDict {

--- a/lindera-tokenizer/src/token.rs
+++ b/lindera-tokenizer/src/token.rs
@@ -92,8 +92,8 @@ impl<'a> Token<'a> {
 
         let (words_idx_data, words_data) = if self.word_id.is_system() {
             (
-                self.dictionary.words_idx_data.as_slice(),
-                self.dictionary.words_data.as_slice(),
+                &*self.dictionary.words_idx_data,
+                &*self.dictionary.words_data,
             )
         } else {
             match self.user_dictionary {

--- a/lindera-unidic/src/lib.rs
+++ b/lindera-unidic/src/lib.rs
@@ -102,8 +102,14 @@ pub fn char_def() -> LinderaResult<CharacterDefinitions> {
 }
 
 pub fn connection() -> ConnectionCostMatrix {
-    #[allow(clippy::needless_borrow)]
-    ConnectionCostMatrix::load(&CONNECTION_DATA)
+    #[cfg(feature = "compress")]
+    {
+        ConnectionCostMatrix::load(&CONNECTION_DATA)
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        ConnectionCostMatrix::load_static(CONNECTION_DATA)
+    }
 }
 
 pub fn prefix_dict() -> PrefixDict {

--- a/lindera-unidic/src/lib.rs
+++ b/lindera-unidic/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 #[cfg(feature = "unidic")]
 use std::env;
 
@@ -122,10 +123,24 @@ pub fn unknown_dict() -> LinderaResult<UnknownDictionary> {
     UnknownDictionary::load(&UNKNOWN_DATA)
 }
 
-pub fn words_idx_data() -> Vec<u8> {
-    WORDS_IDX_DATA.to_vec()
+pub fn words_idx_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_IDX_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_IDX_DATA)
+    }
 }
 
-pub fn words_data() -> Vec<u8> {
-    WORDS_DATA.to_vec()
+pub fn words_data() -> Cow<'static, [u8]> {
+    #[cfg(feature = "compress")]
+    {
+        Cow::Owned(WORDS_DATA.to_vec())
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Cow::Borrowed(WORDS_DATA)
+    }
 }


### PR DESCRIPTION
When loading dictionary data, data are unnecessarily copied. As dictionary files are huge, this greatly increases initialization time and memory usage. Dictionary data is not mutated, so `Dictionary` does not need to own its own copy of the data.

This PR changes `Vec<u8>` into `Cow<'static, [u8]>` and uses `'static &[u8]` directly when possible. (which is when `compress` feature flag is not set)

### Notes

Performance for `compress` feature can also likely be increased in a similar way. Currently, raw bytes are decompressed into a static `Lazy<Vec<u8>>`, which is then re-copied into `Dictionary`. This doubles the required time and memory.

### Benchmark

I benchmarked the changes on `lindera-unidic`. This PR greatly reduced heap memory usage and initialization time by ~95%!

|    | Memory (heap) usage | Initialization time |
| ------------- | ------------- | ------------- |
| Original  | 306 MB  | 238 ms  |
| ConnectionCostMatrix (commit 1)  | 222 MB  |  193 ms |
| + Words Data (+ commit 2)  | 17 MB  | 10 ms  |

**Benchmark code**
```rust
use jemalloc_ctl::{epoch, stats};
use lindera_core::error::LinderaError;
use lindera_core::mode::Mode;
use lindera_dictionary::{DictionaryConfig, DictionaryKind};
use lindera_tokenizer::tokenizer::{Tokenizer as LTokenizer, TokenizerConfig};
use std::time::Instant;

#[global_allocator]
static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;

pub struct Tokenizer {
    pub tokenizer: LTokenizer,
}

impl Tokenizer {
    pub fn create() -> Tokenizer {
        let dictionary = DictionaryConfig {
            kind: Some(DictionaryKind::UniDic),
            path: None,
        };
        let config = TokenizerConfig {
            dictionary,
            user_dictionary: None,
            mode: Mode::Normal,
        };
        let tokenizer = LTokenizer::from_config(config).unwrap();

        Tokenizer { tokenizer }
    }
}

fn print_allocation() {
    epoch::advance().unwrap();
    let allocated: usize = stats::allocated::read().unwrap();
    println!("alloc: {:?} B", allocated)
}

fn main() {
    print_allocation();
    let now = Instant::now();
    let tokenizer = Tokenizer::create();
    let elapsed = now.elapsed().as_millis();
    println!("Elapsed: {:?}", elapsed);
    let mut tokens = tokenizer.tokenizer.tokenize("私は学生です。").unwrap();
    println!("{:?}", tokens[1].get_details());
    print_allocation()
}
```



