### PR TITLE
Analyzer.analyze doesn't require mutable reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ fn main() -> LinderaResult<()> {
     println!("text: {}", text);
 
     // tokenize the text
-    let tokens = analyzer.analyze(&mut text)?;
+    let tokens = analyzer.analyze(&text)?;
 
     // output the tokens
     for token in tokens {


### PR DESCRIPTION
https://github.com/lindera-morphology/lindera/blob/main/lindera-analyzer/src/analyzer.rs#L316C9-L316C19