### PR TITLE
Find word entry by surface

### DIFF
--- a/lindera-core/src/dictionary.rs
+++ b/lindera-core/src/dictionary.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -18,6 +19,20 @@ pub struct Dictionary {
     pub words_data: Cow<'static, [u8]>,
 }
 
+impl Dictionary {
+    pub fn word_details(&self, word_id: usize) -> Option<Vec<String>> {
+        if 4 * word_id >= self.words_idx_data.len() {
+            return None;
+        }
+        let idx = LittleEndian::read_u32(&self.words_idx_data[4 * word_id..][..4]);
+        let data = &self.words_data[idx as usize..];
+        match bincode::deserialize_from(data) {
+            Ok(details) => Some(details),
+            Err(_err) => None,
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct UserDictionary {
     pub dict: PrefixDict<Vec<u8>>,
@@ -29,5 +44,17 @@ impl UserDictionary {
     pub fn load(user_dict_data: &[u8]) -> LinderaResult<UserDictionary> {
         bincode::deserialize(user_dict_data)
             .map_err(|err| LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err)))
+    }
+
+    pub fn word_details(&self, word_id: usize) -> Option<Vec<String>> {
+        if 4 * word_id >= self.words_idx_data.len() {
+            return None;
+        }
+        let idx = LittleEndian::read_u32(&self.words_idx_data[4 * word_id..][..4]);
+        let data = &self.words_data[idx as usize..];
+        match bincode::deserialize_from(data) {
+            Ok(details) => Some(details),
+            Err(_err) => None,
+        }
     }
 }

--- a/lindera-core/src/prefix_dict.rs
+++ b/lindera-core/src/prefix_dict.rs
@@ -52,6 +52,27 @@ impl<D: Deref<Target = [u8]>> PrefixDict<D> {
                 })
             })
     }
+
+    /// Find `WordEntry`s with surface
+    pub fn find_surface(&self, surface: &str) -> Vec<WordEntry> {
+        match self.da.exact_match_search(surface) {
+            Some(offset_len) => {
+                let offset = offset_len >> 5u32;
+                let offset_bytes = (offset as usize) * WordEntry::SERIALIZED_LEN;
+                let data: &[u8] = &self.vals_data[offset_bytes..];
+                let len = offset_len & ((1u32 << 5) - 1u32);
+                (0..len as usize)
+                    .map(|i| {
+                        WordEntry::deserialize(
+                            &data[WordEntry::SERIALIZED_LEN * i..],
+                            self.is_system,
+                        )
+                    })
+                    .collect::<Vec<WordEntry>>()
+            }
+            None => vec![],
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lindera-tokenizer/Cargo.toml
+++ b/lindera-tokenizer/Cargo.toml
@@ -26,7 +26,6 @@ cc-cedict-compress = ["lindera-dictionary/cc-cedict-compress"]  # Compress CC-CE
 
 [dependencies]
 bincode.workspace = true
-byteorder.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/lindera-tokenizer/src/tokenizer.rs
+++ b/lindera-tokenizer/src/tokenizer.rs
@@ -173,13 +173,13 @@ impl<'de> Deserialize<'de> for TokenizerConfig {
 /// Tokenizer
 pub struct Tokenizer {
     /// The dictionary to be used for tokenization.
-    dictionary: Dictionary,
+    pub dictionary: Dictionary,
 
     /// The user dictionary to be used for tokenization. (Optional)
-    user_dictionary: Option<UserDictionary>,
+    pub user_dictionary: Option<UserDictionary>,
 
     /// The tokenization mode.
-    mode: Mode,
+    pub mode: Mode,
 }
 
 impl Tokenizer {


### PR DESCRIPTION
Adds a way to search for word entry by surface text and retrieve entry details.

## Use case

Tokenizers are quite inaccurate. It often returns the wrong word entry that shares the same surface text. So for my dictionary application, below the most likely word entry given by the tokenizer I'd like to display the other word entries for that surface as well.

Example: 
```rust
let tokens = tokenizer.tokenize("日本語です。").unwrap();
for token in tokens {
  let ids = token.dictionary.dict.find_surface(&token.text);
  let detail = tokenizer.dictionary.word_details(ids[0].word_id.0 as usize);
  println!("{:?}", detail);
}
```