### PR TITLE
Optimize built dict.words file size

### DIFF
--- a/lindera-ipadic-builder/src/ipadic_builder.rs
+++ b/lindera-ipadic-builder/src/ipadic_builder.rs
@@ -262,15 +262,23 @@ impl DictionaryBuilder for IpadicBuilder {
         let mut words_buffer = Vec::new();
         let mut words_idx_buffer = Vec::new();
         for row in normalized_rows.iter() {
-            let mut word_detail = Vec::new();
-            for item in row.iter().skip(4) {
-                word_detail.push(item.to_string());
-            }
             let offset = words_buffer.len();
             words_idx_buffer
                 .write_u32::<LittleEndian>(offset as u32)
                 .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-            bincode::serialize_into(&mut words_buffer, &word_detail)
+
+            let mut word_details = Vec::new();
+            for item in row.iter().skip(4) {
+                word_details.push(item.as_str());
+            }
+            let joined_details = word_details.join("\0");
+            let joined_details_len = u32::try_from(joined_details.as_bytes().len())
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_u32::<LittleEndian>(joined_details_len)
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_all(&joined_details.as_bytes())
                 .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
         }
 

--- a/lindera-ipadic-neologd-builder/src/ipadic_neologd_builder.rs
+++ b/lindera-ipadic-neologd-builder/src/ipadic_neologd_builder.rs
@@ -255,15 +255,23 @@ impl DictionaryBuilder for IpadicNeologdBuilder {
         let mut words_buffer = Vec::new();
         let mut words_idx_buffer = Vec::new();
         for row in normalized_rows.iter() {
-            let mut word_detail = Vec::new();
-            for item in row.iter().skip(4) {
-                word_detail.push(item.to_string());
-            }
             let offset = words_buffer.len();
             words_idx_buffer
                 .write_u32::<LittleEndian>(offset as u32)
                 .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-            bincode::serialize_into(&mut words_buffer, &word_detail)
+
+            let mut word_details = Vec::new();
+            for item in row.iter().skip(4) {
+                word_details.push(item.as_str());
+            }
+            let joined_details = word_details.join("\0");
+            let joined_details_len = u32::try_from(joined_details.as_bytes().len())
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_u32::<LittleEndian>(joined_details_len)
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_all(&joined_details.as_bytes())
                 .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
         }
 

--- a/lindera-ko-dic-builder/src/ko_dic_builder.rs
+++ b/lindera-ko-dic-builder/src/ko_dic_builder.rs
@@ -246,15 +246,23 @@ impl DictionaryBuilder for KoDicBuilder {
         let mut words_buffer = Vec::new();
         let mut words_idx_buffer = Vec::new();
         for row in rows.iter() {
-            let mut word_detail = Vec::new();
-            for item in row.iter().skip(4) {
-                word_detail.push(item.to_string());
-            }
             let offset = words_buffer.len();
             words_idx_buffer
                 .write_u32::<LittleEndian>(offset as u32)
                 .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-            bincode::serialize_into(&mut words_buffer, &word_detail)
+
+            let mut word_details = Vec::new();
+            for item in row.iter().skip(4) {
+                word_details.push(item);
+            }
+            let joined_details = word_details.join("\0");
+            let joined_details_len = u32::try_from(joined_details.as_bytes().len())
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_u32::<LittleEndian>(joined_details_len)
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_all(&joined_details.as_bytes())
                 .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
         }
 

--- a/lindera-unidic-builder/src/unidic_builder.rs
+++ b/lindera-unidic-builder/src/unidic_builder.rs
@@ -246,15 +246,23 @@ impl DictionaryBuilder for UnidicBuilder {
         let mut words_buffer = Vec::new();
         let mut words_idx_buffer = Vec::new();
         for row in rows.iter() {
-            let mut word_detail = Vec::new();
-            for item in row.iter().skip(4) {
-                word_detail.push(item.to_string());
-            }
             let offset = words_buffer.len();
             words_idx_buffer
                 .write_u32::<LittleEndian>(offset as u32)
                 .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-            bincode::serialize_into(&mut words_buffer, &word_detail)
+
+            let mut word_details = Vec::new();
+            for item in row.iter().skip(4) {
+                word_details.push(item);
+            }
+            let joined_details = word_details.join("\0");
+            let joined_details_len = u32::try_from(joined_details.as_bytes().len())
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_u32::<LittleEndian>(joined_details_len)
+                .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
+            words_buffer
+                .write_all(&joined_details.as_bytes())
                 .map_err(|err| LinderaErrorKind::Serialize.with_error(anyhow::anyhow!(err)))?;
         }
 


### PR DESCRIPTION
Closes #374

The problem is detailed in the issue above. 

In short, instead of storing each word details as the first line format, it is saved as the second line format below:
```
<details_len: u64> <details[0]_len: u64> <details[0]: [u8]> <details[1]_len: u64> ...
<details_len: u32> <details[0]: [u8]> NULL("\0") <details[1]: [u8]> NULL ...
```

For lex dictionaries of N items with M details, this saves (N*(4 + 7\*M + 1)) bytes.

In practice, `dict.words` size is generally halved. For `unidic`, `dict.words` size is decreased from 200.1MB to 106.3MB. For `ipadic`, 59.3MB to 32.7MB.