### PR TITLE
Allow cache of intermediate data in $LINDERA_CACHE env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,6 +337,19 @@ jobs:
           fi
           sleep 20
 
+      - name: Publish lindera-assets
+        run: |
+          LINDERA_ASSETS_VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-assets") | .version')
+          LINDERA_ASSETS_VERSIONS=$(curl -s -XGET https://crates.io/api/v1/crates/lindera-assets | jq -r 'select(.versions != null) | .versions[].num')
+          if echo ${LINDERA_ASSETS_VERSIONS} | grep ${LINDERA_ASSETS_VERSION} >/dev/null; then
+            echo "lindera-assets ${LINDERA_ASSETS_VERSION} has already published"
+          else
+            pushd lindera-assets
+            cargo publish --token ${{ secrets.CRATES_TOKEN }}
+            popd
+          fi
+          sleep 20
+
       - name: Publish lindera
         run: |
           LINDERA_VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera") | .version')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "lindera",
     "lindera-analyzer",
+    "lindera-assets",
     "lindera-dictionary-builder",
     "lindera-cc-cedict",
     "lindera-cc-cedict-builder",
@@ -26,6 +27,7 @@ resolver = "2"
 [workspace.dependencies]
 lindera = { version = "0.31.0", path = "lindera" }
 lindera-analyzer = { version = "0.31.0", path = "lindera-analyzer" }
+lindera-assets = { version = "0.31.0", path = "lindera-assets" }
 lindera-dictionary-builder = { version = "0.31.0", path = "lindera-dictionary-builder" }
 lindera-cc-cedict = { version = "0.31.0", path = "lindera-cc-cedict" }
 lindera-cc-cedict-builder = { version = "0.31.0", path = "lindera-cc-cedict-builder" }

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LINDERA_DICTIONARY_VERSION ?= $(shell cargo metadata --no-deps --format-version=
 LINDERA_TOKENIZER_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-tokenizer") | .version')
 LINDERA_FILTER_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-filter") | .version')
 LINDERA_ANALYZER_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-analyzer") | .version')
+LINDERA_ASSETS_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-assets") | .version')
 LINDERA_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera") | .version')
 LINDERA_CLI_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-cli") | .version')
 
@@ -108,6 +109,10 @@ ifeq ($(shell curl -s -XGET https://crates.io/api/v1/crates/lindera-filter | jq 
 endif
 ifeq ($(shell curl -s -XGET https://crates.io/api/v1/crates/lindera-analyzer | jq -r '.versions[].num' | grep $(LINDERA_ANALYZER_VERSION)),)
 	(cd lindera-analyzer && cargo package && cargo publish)
+	sleep 10
+endif
+ifeq ($(shell curl -s -XGET https://crates.io/api/v1/crates/lindera-assets | jq -r '.versions[].num' | grep $(LINDERA_ASSETS_VERSION)),)
+	(cd lindera-assets && cargo package && cargo publish)
 	sleep 10
 endif
 ifeq ($(shell curl -s -XGET https://crates.io/api/v1/crates/lindera | jq -r '.versions[].num' | grep $(LINDERA_VERSION)),)

--- a/README.md
+++ b/README.md
@@ -311,5 +311,17 @@ token: 可能, start: 41, end: 47, details: Some(["名詞", "形容動詞語幹"
 ## API reference
 
 The API reference is available. Please see following URL:
-
 - [lindera](https://docs.rs/lindera)
+
+## Build-time cache
+
+At build time, Lindera downloads various assets from the Internet, uses them to build dictionaries, and includes the resulting
+dictionaries in the final library (possibly compressed, depending on the feature set).
+
+By default, Lindera will use the [`OUT_DIR`](https://doc.rust-lang.org/cargo/reference/environment-variables.html?highlight=OUT_DIR#environment-variables-cargo-sets-for-build-scripts) environment variable as the location where to download the assets and build the dictionaries.
+
+This means that changing the version of Rust, the build profile or the target architecture will result in multiple copies of Lindera assets being downloaded and built.
+
+Setting the `LINDERA_CACHE` environment variable changes the behavior of Lindera: it will always download and build the dictionary files inside of the directory pointed to by the `LINDERA_CACHE` variables.
+
+This may shorten build times on CI and developer machines.

--- a/lindera-assets/Cargo.toml
+++ b/lindera-assets/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "lindera-assets"
+version = "0.31.0"
+edition = "2021"
+description = "A helper crate to fetch assets and build dictionary for lindera."
+documentation = "https://docs.rs/lindera-assets"
+homepage = "https://github.com/lindera-morphology/lindera"
+repository = "https://github.com/lindera-morphology/lindera"
+readme = "README.md"
+keywords = ["japanese", "morphological", "dictionary"]
+categories = ["text-processing"]
+license = "MIT"
+
+
+[dependencies]
+encoding = { workspace = true }
+flate2 = { workspace = true }
+tar = { workspace = true }
+ureq = { workspace = true }
+
+lindera-core.workspace = true

--- a/lindera-assets/src/lib.rs
+++ b/lindera-assets/src/lib.rs
@@ -1,0 +1,132 @@
+use std::error::Error;
+
+use lindera_core::dictionary_builder::DictionaryBuilder;
+
+pub struct FetchParams {
+    /// Dictionary file name
+    pub file_name: &'static str,
+    /// MeCab directory
+    pub input_dir: &'static str,
+    /// Lindera directory
+    pub output_dir: &'static str,
+
+    /// Dummy input for docs.rs
+    pub dummy_input: &'static str,
+
+    /// URL from which to fetch the asset
+    pub download_url: &'static str,
+}
+
+/// Fetch the necessary assets and then build the dictionary using `builder`
+pub fn fetch(params: FetchParams, builder: impl DictionaryBuilder) -> Result<(), Box<dyn Error>> {
+    use std::env;
+    use std::fs::{create_dir, rename, File};
+    use std::io::{self, Cursor, Read, Write};
+    use std::path::{Path, PathBuf};
+
+    use encoding::all::UTF_8;
+    use encoding::{EncoderTrap, Encoding};
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
+    // Directory path for build package
+    // if the `LINDERA_CACHE` variable is defined, behaves like a cache, where data is invalidated only:
+    // - on new lindera-assets version
+    // - if the LINDERA_CACHE dir changed
+    // otherwise, keeps behavior of always redownloading and rebuilding
+    let (build_dir, is_cache) = if let Some(lindera_cache_dir) = env::var_os("LINDERA_CACHE") {
+        (
+            PathBuf::from(lindera_cache_dir).join(env::var_os("CARGO_PKG_VERSION").unwrap()),
+            true,
+        )
+    } else {
+        (
+            PathBuf::from(env::var_os("OUT_DIR").unwrap()), /* ex) target/debug/build/<pkg>/out */
+            false,
+        )
+    };
+
+    // environment variable passed to dependents, that will actually be used to include the dictionary in the library
+    println!("cargo::rustc-env=LINDERA_WORKDIR={}", build_dir.display());
+
+    std::fs::create_dir_all(&build_dir)?;
+
+    let input_dir = build_dir.join(params.input_dir);
+
+    let output_dir = build_dir.join(params.output_dir);
+
+    // Fast path where the data is already in cache
+    if is_cache && output_dir.is_dir() {
+        return Ok(());
+    }
+
+    if std::env::var("DOCS_RS").is_ok() {
+        // Create directory for dummy input directory for build docs
+        create_dir(&input_dir)?;
+
+        // Create dummy char.def
+        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
+        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
+
+        // Create dummy CSV file
+        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
+        dummy_dict_csv.write_all(
+            &UTF_8
+                .encode(params.dummy_input, EncoderTrap::Ignore)
+                .unwrap(),
+        )?;
+
+        // Create dummy unk.def
+        File::create(input_dir.join("unk.def"))?;
+        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
+        dummy_matrix_def.write_all(b"0 1 0\n")?;
+    } else {
+        // Source file path for build package
+        let source_path_for_build = &build_dir.join(params.file_name);
+
+        // Download source file to build directory
+        // copy(&source_path, &source_path_for_build)?;
+        let tmp_path = Path::new(&build_dir).join(params.file_name.to_owned() + ".download");
+
+        // Download a tarball
+        let resp = ureq::get(params.download_url).call()?;
+        let mut dest = File::create(&tmp_path)?;
+
+        io::copy(&mut resp.into_reader(), &mut dest)?;
+        dest.flush()?;
+
+        rename(tmp_path, source_path_for_build).expect("Failed to rename temporary file");
+
+        // Decompress a tar.gz file
+        let tmp_extract_path =
+            Path::new(&build_dir).join(format!("tmp-archive-{}", params.input_dir));
+        let tmp_extracted_path = tmp_extract_path.join(params.input_dir);
+        let _ = std::fs::remove_dir_all(&tmp_extract_path);
+        std::fs::create_dir_all(&tmp_extract_path)?;
+
+        let mut tar_gz = File::open(source_path_for_build)?;
+        let mut buffer = Vec::new();
+        tar_gz.read_to_end(&mut buffer)?;
+        let cursor = Cursor::new(buffer);
+        let decoder = GzDecoder::new(cursor);
+        let mut archive = Archive::new(decoder);
+        archive.unpack(&tmp_extract_path)?;
+        rename(tmp_extracted_path, &input_dir).expect("Failed to rename archive directory");
+        let _ = std::fs::remove_dir_all(&tmp_extract_path);
+        drop(dest);
+        let _ = std::fs::remove_file(source_path_for_build);
+    }
+
+    let tmp_path = build_dir.join(format!("tmp-output-{}", params.output_dir));
+    let _ = std::fs::remove_dir_all(&tmp_path);
+
+    builder.build_dictionary(&input_dir, &tmp_path)?;
+
+    rename(tmp_path, &output_dir).expect("Failed to rename output directory");
+    let _ = std::fs::remove_dir_all(&input_dir);
+
+    Ok(())
+}

--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-cc-cedict = ["encoding", "flate2", "tar", "ureq"]
+cc-cedict = ["lindera-assets"]
 compress = ["lindera-cc-cedict-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,10 +24,6 @@ lindera-core.workspace = true
 lindera-decompress = { workspace = true, optional = true }
 
 [build-dependencies]
-encoding = { workspace = true, optional = true }
-flate2 = { workspace = true, optional = true }
-tar = { workspace =true, optional = true }
-ureq = { workspace = true, optional = true }
+lindera-assets = { workspace = true, optional = true }
 
-lindera-core.workspace = true
 lindera-cc-cedict-builder.workspace = true

--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -2,94 +2,15 @@ use std::error::Error;
 
 #[cfg(feature = "cc-cedict")]
 fn main() -> Result<(), Box<dyn Error>> {
-    use std::env;
-    use std::fs::{create_dir, rename, File};
-    use std::io::{self, Cursor, Read, Write};
-    use std::path::Path;
-
-    use encoding::all::UTF_8;
-    use encoding::{EncoderTrap, Encoding};
-    use flate2::read::GzDecoder;
-    use tar::Archive;
-
-    use lindera_cc_cedict_builder::cc_cedict_builder::CcCedictBuilder;
-    use lindera_core::dictionary_builder::DictionaryBuilder;
-
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=Cargo.toml");
-
-    // Directory path for build package
-    let build_dir = env::var_os("OUT_DIR").unwrap(); // ex) target/debug/build/<pkg>/out
-
-    // Dictionary file name
-    let file_name = "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz";
-
-    // CC-CEDICT MeCab directory
-    let input_dir = Path::new(&build_dir).join("CC-CEDICT-MeCab-0.1.0-20200409");
-
-    // Lindera CC-CEDICT directory
-    let output_dir = Path::new(&build_dir).join("lindera-cc-cedict");
-
-    if std::env::var("DOCS_RS").is_ok() {
-        // Create directory for dummy input directory for build docs
-        create_dir(&input_dir)?;
-
-        // Create dummy char.def
-        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
-        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
-
-        // Create dummy CSV file
-        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
-        dummy_dict_csv
-            .write_all(
-                &UTF_8
-                    .encode(
-                        "测试,0,0,-1131,*,*,*,*,ce4 shi4,測試,测试,to test (machinery etc)/to test (students)/test/quiz/exam/beta (software)/\n",
-                        EncoderTrap::Ignore,
-                    )
-                    .unwrap(),
-            )?;
-
-        // Create dummy unk.def
-        File::create(input_dir.join("unk.def"))?;
-        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
-        dummy_matrix_def.write_all(b"0 1 0\n")?;
-    } else {
-        // Source file path for build package
-        let source_path_for_build = Path::new(&build_dir).join(file_name);
-
-        // Download source file to build directory
-        if !source_path_for_build.exists() {
-            // copy(&source_path, &source_path_for_build)?;
-            let tmp_path = Path::new(&build_dir).join(file_name.to_owned() + ".download");
-
-            // Download a tarball
-            let download_url =
-                "https://dlwqk3ibdg1xh.cloudfront.net/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz";
-            let resp = ureq::get(download_url).call()?;
-            let mut dest = File::create(&tmp_path)?;
-
-            io::copy(&mut resp.into_reader(), &mut dest)?;
-            dest.flush()?;
-
-            rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
-        }
-
-        // Decompress a tar.gz file
-        let mut tar_gz = File::open(source_path_for_build)?;
-        let mut buffer = Vec::new();
-        tar_gz.read_to_end(&mut buffer)?;
-        let cursor = Cursor::new(buffer);
-        let decoder = GzDecoder::new(cursor);
-        let mut archive = Archive::new(decoder);
-        archive.unpack(&build_dir)?;
-    }
-
-    // Build a dictionary
-    let builder = CcCedictBuilder::new();
-    builder.build_dictionary(&input_dir, &output_dir)?;
-
-    Ok(())
+    lindera_assets::fetch(lindera_assets::FetchParams {
+        file_name: "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz",
+        input_dir: "CC-CEDICT-MeCab-0.1.0-20200409",
+        output_dir: "lindera-cc-cedict",
+        download_url: "https://dlwqk3ibdg1xh.cloudfront.net/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz",
+        dummy_input:
+        "测试,0,0,-1131,*,*,*,*,ce4 shi4,測試,测试,to test (machinery etc)/to test (students)/test/quiz/exam/beta (software)/\n",
+    },
+    lindera_cc_cedict_builder::cc_cedict_builder::CcCedictBuilder::new())
 }
 
 #[cfg(not(feature = "cc-cedict"))]

--- a/lindera-cc-cedict/src/lib.rs
+++ b/lindera-cc-cedict/src/lib.rs
@@ -26,7 +26,10 @@ macro_rules! decompress_data {
 #[cfg(feature = "cc-cedict")]
 decompress_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-cc-cedict/char_def.bin")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-cc-cedict/char_def.bin"
+    )),
     "char_def.bin"
 );
 #[cfg(not(feature = "cc-cedict"))]
@@ -35,7 +38,10 @@ decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
 #[cfg(feature = "cc-cedict")]
 decompress_data!(
     CONNECTION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-cc-cedict/matrix.mtx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-cc-cedict/matrix.mtx"
+    )),
     "matrix.mtx"
 );
 #[cfg(not(feature = "cc-cedict"))]
@@ -44,7 +50,10 @@ decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
 #[cfg(feature = "cc-cedict")]
 decompress_data!(
     CC_CEDICT_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-cc-cedict/dict.da")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-cc-cedict/dict.da"
+    )),
     "dict.da"
 );
 #[cfg(not(feature = "cc-cedict"))]
@@ -53,7 +62,10 @@ decompress_data!(CC_CEDICT_DATA, &[], "dict.da");
 #[cfg(feature = "cc-cedict")]
 decompress_data!(
     CC_CEDICT_VALS,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-cc-cedict/dict.vals")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-cc-cedict/dict.vals"
+    )),
     "dict.vals"
 );
 #[cfg(not(feature = "cc-cedict"))]
@@ -62,7 +74,10 @@ decompress_data!(CC_CEDICT_VALS, &[], "dict.vals");
 #[cfg(feature = "cc-cedict")]
 decompress_data!(
     UNKNOWN_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-cc-cedict/unk.bin")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-cc-cedict/unk.bin"
+    )),
     "unk.bin"
 );
 #[cfg(not(feature = "cc-cedict"))]
@@ -71,7 +86,10 @@ decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
 #[cfg(feature = "cc-cedict")]
 decompress_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-cc-cedict/dict.wordsidx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-cc-cedict/dict.wordsidx"
+    )),
     "dict.wordsidx"
 );
 #[cfg(not(feature = "cc-cedict"))]
@@ -80,7 +98,10 @@ decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
 #[cfg(feature = "cc-cedict")]
 decompress_data!(
     WORDS_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-cc-cedict/dict.words")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-cc-cedict/dict.words"
+    )),
     "dict.words"
 );
 #[cfg(not(feature = "cc-cedict"))]

--- a/lindera-ipadic-neologd/Cargo.toml
+++ b/lindera-ipadic-neologd/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ipadic-neologd = ["encoding", "flate2", "tar", "ureq"]
+ipadic-neologd = ["lindera-assets"]
 compress = ["lindera-ipadic-neologd-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,10 +24,6 @@ lindera-core.workspace = true
 lindera-decompress = { workspace = true, optional = true }
 
 [build-dependencies]
-encoding = { workspace = true, optional = true }
-flate2 = { workspace = true, optional = true }
-tar = { workspace = true, optional = true }
-ureq = { workspace = true, optional = true }
+lindera-assets = { workspace = true, optional = true }
 
-lindera-core.workspace = true
 lindera-ipadic-neologd-builder.workspace = true

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -2,93 +2,17 @@ use std::error::Error;
 
 #[cfg(feature = "ipadic-neologd")]
 fn main() -> Result<(), Box<dyn Error>> {
-    use std::env;
-    use std::fs::{create_dir, rename, File};
-    use std::io::{self, Cursor, Read, Write};
-    use std::path::Path;
-
-    use encoding::all::UTF_8;
-    use encoding::{EncoderTrap, Encoding};
-    use flate2::read::GzDecoder;
-    use tar::Archive;
-
-    use lindera_core::dictionary_builder::DictionaryBuilder;
-    use lindera_ipadic_neologd_builder::ipadic_neologd_builder::IpadicNeologdBuilder;
-
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=Cargo.toml");
-
-    // Directory path for build package
-    let build_dir = env::var_os("OUT_DIR").unwrap(); // ex) target/debug/build/<pkg>/out
-
-    // Dictionary file name
-    let file_name = "mecab-ipadic-neologd-0.0.7-20200820.tar.gz";
-
-    // MeCab IPADIC NEologd directory
-    let input_dir = Path::new(&build_dir).join("mecab-ipadic-neologd-0.0.7-20200820");
-
-    // Lindera IPADIC NEologd directory
-    let output_dir = Path::new(&build_dir).join("lindera-ipadic-neologd");
-
-    if std::env::var("DOCS_RS").is_ok() {
-        // Create directory for dummy input directory for build docs
-        create_dir(&input_dir)?;
-
-        // Create dummy char.def
-        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
-        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
-
-        // Create dummy CSV file
-        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
-        dummy_dict_csv.write_all(
-            &UTF_8
-                .encode(
-                    "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
-                    EncoderTrap::Ignore,
-                )
-                .unwrap(),
-        )?;
-
-        // Create dummy unk.def
-        File::create(input_dir.join("unk.def"))?;
-        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
-        dummy_matrix_def.write_all(b"0 1 0\n")?;
-    } else {
-        // Source file path for build package
-        let source_path_for_build = Path::new(&build_dir).join(file_name);
-
-        // Download source file to build directory
-        if !source_path_for_build.exists() {
-            // copy(&source_path, &source_path_for_build)?;
-            let tmp_path = Path::new(&build_dir).join(file_name.to_owned() + ".download");
-
-            // Download a tarball
-            let download_url =
-                "https://dlwqk3ibdg1xh.cloudfront.net/mecab-ipadic-neologd-0.0.7-20200820.tar.gz";
-            let resp = ureq::get(download_url).call()?;
-            let mut dest = File::create(&tmp_path)?;
-
-            io::copy(&mut resp.into_reader(), &mut dest)?;
-            dest.flush()?;
-
-            rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
-        }
-
-        // Decompress a tar.gz file
-        let mut tar_gz = File::open(source_path_for_build)?;
-        let mut buffer = Vec::new();
-        tar_gz.read_to_end(&mut buffer)?;
-        let cursor = Cursor::new(buffer);
-        let decoder = GzDecoder::new(cursor);
-        let mut archive = Archive::new(decoder);
-        archive.unpack(&build_dir)?;
-    }
-
-    // Build a dictionary
-    let builder = IpadicNeologdBuilder::new();
-    builder.build_dictionary(&input_dir, &output_dir)?;
-
-    Ok(())
+    lindera_assets::fetch(
+        lindera_assets::FetchParams {
+            file_name: "mecab-ipadic-neologd-0.0.7-20200820.tar.gz",
+            input_dir: "mecab-ipadic-neologd-0.0.7-20200820",
+            output_dir: "lindera-ipadic-neologd",
+            download_url:
+                "https://dlwqk3ibdg1xh.cloudfront.net/mecab-ipadic-neologd-0.0.7-20200820.tar.gz",
+            dummy_input: "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
+        },
+        lindera_ipadic_neologd_builder::ipadic_neologd_builder::IpadicNeologdBuilder::new(),
+    )
 }
 
 #[cfg(not(feature = "ipadic-neologd"))]

--- a/lindera-ipadic-neologd/src/lib.rs
+++ b/lindera-ipadic-neologd/src/lib.rs
@@ -27,7 +27,7 @@ macro_rules! decompress_data {
 decompress_data!(
     CHAR_DEFINITION_DATA,
     include_bytes!(concat!(
-        env!("OUT_DIR"),
+        env!("LINDERA_WORKDIR"),
         "/lindera-ipadic-neologd/char_def.bin"
     )),
     "char_def.bin"
@@ -39,7 +39,7 @@ decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
 decompress_data!(
     CONNECTION_DATA,
     include_bytes!(concat!(
-        env!("OUT_DIR"),
+        env!("LINDERA_WORKDIR"),
         "/lindera-ipadic-neologd/matrix.mtx"
     )),
     "matrix.mtx"
@@ -50,7 +50,10 @@ decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
 #[cfg(feature = "ipadic-neologd")]
 decompress_data!(
     IPADIC_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic-neologd/dict.da")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ipadic-neologd/dict.da"
+    )),
     "dict.da"
 );
 #[cfg(not(feature = "ipadic-neologd"))]
@@ -60,7 +63,7 @@ decompress_data!(IPADIC_DATA, &[], "dict.da");
 decompress_data!(
     IPADIC_VALS,
     include_bytes!(concat!(
-        env!("OUT_DIR"),
+        env!("LINDERA_WORKDIR"),
         "/lindera-ipadic-neologd/dict.vals"
     )),
     "dict.vals"
@@ -71,7 +74,10 @@ decompress_data!(IPADIC_VALS, &[], "dict.vals");
 #[cfg(feature = "ipadic-neologd")]
 decompress_data!(
     UNKNOWN_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic-neologd/unk.bin")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ipadic-neologd/unk.bin"
+    )),
     "unk.bin"
 );
 #[cfg(not(feature = "ipadic-neologd"))]
@@ -81,7 +87,7 @@ decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
 decompress_data!(
     WORDS_IDX_DATA,
     include_bytes!(concat!(
-        env!("OUT_DIR"),
+        env!("LINDERA_WORKDIR"),
         "/lindera-ipadic-neologd/dict.wordsidx"
     )),
     "dict.wordsidx"
@@ -93,7 +99,7 @@ decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
 decompress_data!(
     WORDS_DATA,
     include_bytes!(concat!(
-        env!("OUT_DIR"),
+        env!("LINDERA_WORKDIR"),
         "/lindera-ipadic-neologd/dict.words"
     )),
     "dict.words"

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ipadic = ["encoding", "flate2", "tar", "ureq"]
+ipadic = ["lindera-assets"]
 compress = ["lindera-ipadic-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,10 +24,6 @@ lindera-core.workspace = true
 lindera-decompress = { workspace = true, optional = true }
 
 [build-dependencies]
-encoding = { workspace = true, optional = true }
-flate2 = { workspace = true, optional = true }
-tar = { workspace =true, optional = true }
-ureq = { workspace = true, optional = true }
+lindera-assets = { workspace = true, optional = true }
 
-lindera-core.workspace = true
 lindera-ipadic-builder.workspace = true

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -2,93 +2,16 @@ use std::error::Error;
 
 #[cfg(feature = "ipadic")]
 fn main() -> Result<(), Box<dyn Error>> {
-    use std::env;
-    use std::fs::{create_dir, rename, File};
-    use std::io::{self, Cursor, Read, Write};
-    use std::path::Path;
-
-    use encoding::all::EUC_JP;
-    use encoding::{EncoderTrap, Encoding};
-    use flate2::read::GzDecoder;
-    use tar::Archive;
-
-    use lindera_core::dictionary_builder::DictionaryBuilder;
-    use lindera_ipadic_builder::ipadic_builder::IpadicBuilder;
-
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=Cargo.toml");
-
-    // Directory path for build package
-    let build_dir = env::var_os("OUT_DIR").unwrap(); // ex) target/debug/build/<pkg>/out
-
-    // Dictionary file name
-    let file_name = "mecab-ipadic-2.7.0-20070801.tar.gz";
-
-    // MeCab IPADIC directory
-    let input_dir = Path::new(&build_dir).join("mecab-ipadic-2.7.0-20070801");
-
-    // Lindera IPADIC directory
-    let output_dir = Path::new(&build_dir).join("lindera-ipadic");
-
-    if std::env::var("DOCS_RS").is_ok() {
-        // Create directory for dummy input directory for build docs
-        create_dir(&input_dir)?;
-
-        // Create dummy char.def
-        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
-        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
-
-        // Create dummy CSV file
-        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
-        dummy_dict_csv.write_all(
-            &EUC_JP
-                .encode(
-                    "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
-                    EncoderTrap::Ignore,
-                )
-                .unwrap(),
-        )?;
-
-        // Create dummy unk.def
-        File::create(input_dir.join("unk.def"))?;
-        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
-        dummy_matrix_def.write_all(b"0 1 0\n")?;
-    } else {
-        // Source file path for build package
-        let source_path_for_build = Path::new(&build_dir).join(file_name);
-
-        // Download source file to build directory
-        if !source_path_for_build.exists() {
-            // copy(&source_path, &source_path_for_build)?;
-            let tmp_path = Path::new(&build_dir).join(file_name.to_owned() + ".download");
-
-            // Download a tarball
-            let download_url =
-                "https://dlwqk3ibdg1xh.cloudfront.net/mecab-ipadic-2.7.0-20070801.tar.gz";
-            let resp = ureq::get(download_url).call()?;
-            let mut dest = File::create(&tmp_path)?;
-
-            io::copy(&mut resp.into_reader(), &mut dest)?;
-            dest.flush()?;
-
-            rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
-        }
-
-        // Decompress a tar.gz file
-        let mut tar_gz = File::open(source_path_for_build)?;
-        let mut buffer = Vec::new();
-        tar_gz.read_to_end(&mut buffer)?;
-        let cursor = Cursor::new(buffer);
-        let decoder = GzDecoder::new(cursor);
-        let mut archive = Archive::new(decoder);
-        archive.unpack(&build_dir)?;
-    }
-
-    // Build a dictionary
-    let builder = IpadicBuilder::new();
-    builder.build_dictionary(&input_dir, &output_dir)?;
-
-    Ok(())
+    lindera_assets::fetch(
+        lindera_assets::FetchParams {
+            file_name: "mecab-ipadic-2.7.0-20070801.tar.gz",
+            input_dir: "mecab-ipadic-2.7.0-20070801",
+            output_dir: "lindera-ipadic",
+            download_url: "https://dlwqk3ibdg1xh.cloudfront.net/mecab-ipadic-2.7.0-20070801.tar.gz",
+            dummy_input: "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
+        },
+        lindera_ipadic_builder::ipadic_builder::IpadicBuilder::new(),
+    )
 }
 
 #[cfg(not(feature = "ipadic"))]

--- a/lindera-ipadic/src/lib.rs
+++ b/lindera-ipadic/src/lib.rs
@@ -26,7 +26,10 @@ macro_rules! decompress_data {
 #[cfg(feature = "ipadic")]
 decompress_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic/char_def.bin")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ipadic/char_def.bin"
+    )),
     "char_def.bin"
 );
 #[cfg(not(feature = "ipadic"))]
@@ -35,7 +38,10 @@ decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
 #[cfg(feature = "ipadic")]
 decompress_data!(
     CONNECTION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic/matrix.mtx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ipadic/matrix.mtx"
+    )),
     "matrix.mtx"
 );
 #[cfg(not(feature = "ipadic"))]
@@ -44,7 +50,7 @@ decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
 #[cfg(feature = "ipadic")]
 decompress_data!(
     IPADIC_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic/dict.da")),
+    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ipadic/dict.da")),
     "dict.da"
 );
 #[cfg(not(feature = "ipadic"))]
@@ -53,7 +59,10 @@ decompress_data!(IPADIC_DATA, &[], "dict.da");
 #[cfg(feature = "ipadic")]
 decompress_data!(
     IPADIC_VALS,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic/dict.vals")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ipadic/dict.vals"
+    )),
     "dict.vals"
 );
 #[cfg(not(feature = "ipadic"))]
@@ -62,7 +71,7 @@ decompress_data!(IPADIC_VALS, &[], "dict.vals");
 #[cfg(feature = "ipadic")]
 decompress_data!(
     UNKNOWN_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic/unk.bin")),
+    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ipadic/unk.bin")),
     "unk.bin"
 );
 #[cfg(not(feature = "ipadic"))]
@@ -71,7 +80,10 @@ decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
 #[cfg(feature = "ipadic")]
 decompress_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic/dict.wordsidx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ipadic/dict.wordsidx"
+    )),
     "dict.wordsidx"
 );
 #[cfg(not(feature = "ipadic"))]
@@ -80,7 +92,10 @@ decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
 #[cfg(feature = "ipadic")]
 decompress_data!(
     WORDS_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ipadic/dict.words")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ipadic/dict.words"
+    )),
     "dict.words"
 );
 #[cfg(not(feature = "ipadic"))]

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ko-dic = ["encoding", "flate2", "tar", "ureq"]
+ko-dic = ["lindera-assets"]
 compress = ["lindera-ko-dic-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,10 +24,6 @@ lindera-core.workspace = true
 lindera-decompress = { workspace = true, optional = true }
 
 [build-dependencies]
-encoding = { workspace = true, optional = true }
-flate2 = { workspace = true, optional = true }
-tar = { workspace =true, optional = true }
-ureq = { workspace = true, optional = true }
+lindera-assets = { workspace = true, optional = true }
 
-lindera-core.workspace = true
 lindera-ko-dic-builder.workspace = true

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -2,90 +2,16 @@ use std::error::Error;
 
 #[cfg(feature = "ko-dic")]
 fn main() -> Result<(), Box<dyn Error>> {
-    use std::env;
-    use std::fs::{create_dir, rename, File};
-    use std::io::{self, Cursor, Read, Write};
-    use std::path::Path;
-
-    use encoding::all::UTF_8;
-    use encoding::{EncoderTrap, Encoding};
-    use flate2::read::GzDecoder;
-    use tar::Archive;
-
-    use lindera_core::dictionary_builder::DictionaryBuilder;
-    use lindera_ko_dic_builder::ko_dic_builder::KoDicBuilder;
-
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=Cargo.toml");
-
-    // Directory path for build package
-    let build_dir = env::var_os("OUT_DIR").unwrap(); // ex) target/debug/build/<pkg>/out
-
-    // Dictionary file name
-    let file_name = "mecab-ko-dic-2.1.1-20180720.tar.gz";
-
-    // ko-dic MeCab directory
-    let input_dir = Path::new(&build_dir).join("mecab-ko-dic-2.1.1-20180720");
-
-    // Lindera ko-dic directory
-    let output_dir = Path::new(&build_dir).join("lindera-ko-dic");
-
-    if std::env::var("DOCS_RS").is_ok() {
-        // Use dummy data in docs.rs.
-        create_dir(&input_dir)?;
-
-        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
-        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
-
-        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
-        dummy_dict_csv.write_all(
-            &UTF_8
-                .encode(
-                    "테스트,1785,3543,4721,NNG,행위,F,테스트,*,*,*,*\n",
-                    EncoderTrap::Ignore,
-                )
-                .unwrap(),
-        )?;
-
-        File::create(input_dir.join("unk.def"))?;
-        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
-        dummy_matrix_def.write_all(b"0 1 0\n")?;
-    } else {
-        // Source file path for build package
-        let source_path_for_build = Path::new(&build_dir).join(file_name);
-
-        // Download source file to build directory
-        if !source_path_for_build.exists() {
-            // copy(&source_path, &source_path_for_build)?;
-            let tmp_path = Path::new(&build_dir).join(file_name.to_owned() + ".download");
-
-            // Download a tarball
-            let download_url =
-                "https://dlwqk3ibdg1xh.cloudfront.net/mecab-ko-dic-2.1.1-20180720.tar.gz";
-            let resp = ureq::get(download_url).call()?;
-            let mut dest = File::create(&tmp_path)?;
-
-            io::copy(&mut resp.into_reader(), &mut dest)?;
-            dest.flush()?;
-
-            rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
-        }
-
-        // Decompress a tar.gz file
-        let mut tar_gz = File::open(source_path_for_build)?;
-        let mut buffer = Vec::new();
-        tar_gz.read_to_end(&mut buffer)?;
-        let cursor = Cursor::new(buffer);
-        let decoder = GzDecoder::new(cursor);
-        let mut archive = Archive::new(decoder);
-        archive.unpack(&build_dir)?;
-    }
-
-    // Build a dictionary
-    let builder = KoDicBuilder::new();
-    builder.build_dictionary(&input_dir, &output_dir)?;
-
-    Ok(())
+    lindera_assets::fetch(
+        lindera_assets::FetchParams {
+            file_name: "mecab-ko-dic-2.1.1-20180720.tar.gz",
+            input_dir: "mecab-ko-dic-2.1.1-20180720",
+            output_dir: "lindera-ko-dic",
+            download_url: "https://dlwqk3ibdg1xh.cloudfront.net/mecab-ko-dic-2.1.1-20180720.tar.gz",
+            dummy_input: "테스트,1785,3543,4721,NNG,행위,F,테스트,*,*,*,*\n",
+        },
+        lindera_ko_dic_builder::ko_dic_builder::KoDicBuilder::new(),
+    )
 }
 
 #[cfg(not(feature = "ko-dic"))]

--- a/lindera-ko-dic/src/lib.rs
+++ b/lindera-ko-dic/src/lib.rs
@@ -26,7 +26,10 @@ macro_rules! decompress_data {
 #[cfg(feature = "ko-dic")]
 decompress_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ko-dic/char_def.bin")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ko-dic/char_def.bin"
+    )),
     "char_def.bin"
 );
 #[cfg(not(feature = "ko-dic"))]
@@ -35,7 +38,10 @@ decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
 #[cfg(feature = "ko-dic")]
 decompress_data!(
     CONNECTION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ko-dic/matrix.mtx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ko-dic/matrix.mtx"
+    )),
     "matrix.mtx"
 );
 #[cfg(not(feature = "ko-dic"))]
@@ -44,7 +50,7 @@ decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
 #[cfg(feature = "ko-dic")]
 decompress_data!(
     KO_DIC_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ko-dic/dict.da")),
+    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ko-dic/dict.da")),
     "dict.da"
 );
 #[cfg(not(feature = "ko-dic"))]
@@ -53,7 +59,10 @@ decompress_data!(KO_DIC_DATA, &[], "dict.da");
 #[cfg(feature = "ko-dic")]
 decompress_data!(
     KO_DIC_VALS,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ko-dic/dict.vals")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ko-dic/dict.vals"
+    )),
     "dict.vals"
 );
 #[cfg(not(feature = "ko-dic"))]
@@ -62,7 +71,7 @@ decompress_data!(KO_DIC_VALS, &[], "dict.vals");
 #[cfg(feature = "ko-dic")]
 decompress_data!(
     UNKNOWN_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ko-dic/unk.bin")),
+    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ko-dic/unk.bin")),
     "unk.bin"
 );
 #[cfg(not(feature = "ko-dic"))]
@@ -71,7 +80,10 @@ decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
 #[cfg(feature = "ko-dic")]
 decompress_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ko-dic/dict.wordsidx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ko-dic/dict.wordsidx"
+    )),
     "dict.wordsidx"
 );
 #[cfg(not(feature = "ko-dic"))]
@@ -80,7 +92,10 @@ decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
 #[cfg(feature = "ko-dic")]
 decompress_data!(
     WORDS_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-ko-dic/dict.words")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-ko-dic/dict.words"
+    )),
     "dict.words"
 );
 #[cfg(not(feature = "ko-dic"))]

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-unidic = ["encoding", "flate2", "tar", "ureq"]
+unidic = ["lindera-assets"]
 compress = ["lindera-unidic-builder/compress", "lindera-decompress"]
 
 [dependencies]
@@ -24,10 +24,6 @@ lindera-core.workspace = true
 lindera-decompress = { workspace = true, optional = true }
 
 [build-dependencies]
-encoding = { workspace = true, optional = true }
-flate2 = { workspace = true, optional = true }
-tar = { workspace =true, optional = true }
-ureq = { workspace = true, optional = true }
+lindera-assets = { workspace = true, optional = true }
 
-lindera-core.workspace = true
 lindera-unidic-builder.workspace = true

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -2,93 +2,14 @@ use std::error::Error;
 
 #[cfg(feature = "unidic")]
 fn main() -> Result<(), Box<dyn Error>> {
-    use std::env;
-    use std::fs::{create_dir, rename, File};
-    use std::io::{self, Cursor, Read, Write};
-    use std::path::Path;
-
-    use encoding::all::UTF_8;
-    use encoding::{EncoderTrap, Encoding};
-    use flate2::read::GzDecoder;
-    use tar::Archive;
-
-    use lindera_core::dictionary_builder::DictionaryBuilder;
-    use lindera_unidic_builder::unidic_builder::UnidicBuilder;
-
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=Cargo.toml");
-
-    // Directory path for build package
-    let build_dir = env::var_os("OUT_DIR").unwrap(); // ex) target/debug/build/<pkg>/out
-
-    // Dictionary file name
-    let file_name = "unidic-mecab-2.1.2.tar.gz";
-
-    // UniDic MeCab directory
-    let input_dir = Path::new(&build_dir).join("unidic-mecab-2.1.2");
-
-    // Lindera IPADIC directory
-    let output_dir = Path::new(&build_dir).join("lindera-unidic");
-
-    if std::env::var("DOCS_RS").is_ok() {
-        // Use dummy data in docs.rs.
-        create_dir(&input_dir)?;
-
-        // Create dummy char.def
-        let mut dummy_char_def = File::create(input_dir.join("char.def"))?;
-        dummy_char_def.write_all(b"DEFAULT 0 1 0\n")?;
-
-        // Create dummy CSV file
-        let mut dummy_dict_csv = File::create(input_dir.join("dummy_dict.csv"))?;
-        dummy_dict_csv
-            .write_all(
-                &UTF_8
-                    .encode(
-                        "テスト,5131,5131,767,名詞,普通名詞,サ変可能,*,*,*,テスト,テスト-test,テスト,テスト,テスト,テスト,外,*,*,*,*\n",
-                        EncoderTrap::Ignore,
-                    )
-                    .unwrap(),
-            )?;
-
-        // Create dummy unk.def
-        File::create(input_dir.join("unk.def"))?;
-        let mut dummy_matrix_def = File::create(input_dir.join("matrix.def"))?;
-        dummy_matrix_def.write_all(b"0 1 0\n")?;
-    } else {
-        // Source file path for build package
-        let source_path_for_build = Path::new(&build_dir).join(file_name);
-
-        // Download source file to build directory
-        if !source_path_for_build.exists() {
-            // copy(&source_path, &source_path_for_build)?;
-            let tmp_path = Path::new(&build_dir).join(file_name.to_owned() + ".download");
-
-            // Download a tarball
-            let download_url = "https://dlwqk3ibdg1xh.cloudfront.net/unidic-mecab-2.1.2.tar.gz";
-            let resp = ureq::get(download_url).call()?;
-            let mut dest = File::create(&tmp_path)?;
-
-            io::copy(&mut resp.into_reader(), &mut dest)?;
-            dest.flush()?;
-
-            rename(tmp_path, &source_path_for_build).expect("Failed to rename temporary file");
-        }
-
-        // Decompress a tar.gz file
-        let mut tar_gz = File::open(source_path_for_build)?;
-        let mut buffer = Vec::new();
-        tar_gz.read_to_end(&mut buffer)?;
-        let cursor = Cursor::new(buffer);
-        let decoder = GzDecoder::new(cursor);
-        let mut archive = Archive::new(decoder);
-        archive.unpack(&build_dir)?;
-    }
-
-    // Build a dictionary
-    let builder = UnidicBuilder::new();
-    builder.build_dictionary(&input_dir, &output_dir)?;
-
-    Ok(())
+    lindera_assets::fetch(lindera_assets::FetchParams {
+        file_name: "unidic-mecab-2.1.2.tar.gz",
+        input_dir: "unidic-mecab-2.1.2",
+        output_dir: "lindera-unidic",
+        download_url: "https://dlwqk3ibdg1xh.cloudfront.net/unidic-mecab-2.1.2.tar.gz",
+        dummy_input: "テスト,5131,5131,767,名詞,普通名詞,サ変可能,*,*,*,テスト,テスト-test,テスト,テスト,テスト,テスト,外,*,*,*,*\n",
+    },
+lindera_unidic_builder::unidic_builder::UnidicBuilder::new())
 }
 
 #[cfg(not(feature = "unidic"))]

--- a/lindera-unidic/src/lib.rs
+++ b/lindera-unidic/src/lib.rs
@@ -26,7 +26,10 @@ macro_rules! decompress_data {
 #[cfg(feature = "unidic")]
 decompress_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-unidic/char_def.bin")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-unidic/char_def.bin"
+    )),
     "char_def.bin"
 );
 #[cfg(not(feature = "unidic"))]
@@ -35,7 +38,10 @@ decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
 #[cfg(feature = "unidic")]
 decompress_data!(
     CONNECTION_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-unidic/matrix.mtx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-unidic/matrix.mtx"
+    )),
     "matrix.mtx"
 );
 #[cfg(not(feature = "unidic"))]
@@ -44,7 +50,7 @@ decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
 #[cfg(feature = "unidic")]
 decompress_data!(
     UNIDIC_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-unidic/dict.da")),
+    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-unidic/dict.da")),
     "dict.da"
 );
 #[cfg(not(feature = "unidic"))]
@@ -53,7 +59,10 @@ decompress_data!(UNIDIC_DATA, &[], "dict.da");
 #[cfg(feature = "unidic")]
 decompress_data!(
     UNIDIC_VALS,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-unidic/dict.vals")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-unidic/dict.vals"
+    )),
     "dict.vals"
 );
 #[cfg(not(feature = "unidic"))]
@@ -62,7 +71,7 @@ decompress_data!(UNIDIC_VALS, &[], "dict.vals");
 #[cfg(feature = "unidic")]
 decompress_data!(
     UNKNOWN_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-unidic/unk.bin")),
+    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-unidic/unk.bin")),
     "unk.bin"
 );
 #[cfg(not(feature = "unidic"))]
@@ -71,7 +80,10 @@ decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
 #[cfg(feature = "unidic")]
 decompress_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-unidic/dict.wordsidx")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-unidic/dict.wordsidx"
+    )),
     "dict.wordsidx"
 );
 #[cfg(not(feature = "unidic"))]
@@ -80,7 +92,10 @@ decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
 #[cfg(feature = "unidic")]
 decompress_data!(
     WORDS_DATA,
-    include_bytes!(concat!(env!("OUT_DIR"), "/lindera-unidic/dict.words")),
+    include_bytes!(concat!(
+        env!("LINDERA_WORKDIR"),
+        "/lindera-unidic/dict.words"
+    )),
     "dict.words"
 );
 #[cfg(not(feature = "unidic"))]


### PR DESCRIPTION
Hello :wave:

Thank you for making `lindera`, it is very useful to Meilisearch :heart:

As a Meilisearch developer, I found that the "build.rs" part of the build takes up a significant portion of the build time, especially the time spent downloading, unpacking and parsing the dictionary resources before final inclusion in the binary.

These operations are frequently repeated across different clones of the repository, or when changing the profile (dev vs release), target toolchain, or version of Rust.

As a result, I came up with this PR, which essentially allows the assets of a Lindera version to be stored in a user-defined place so that they can be reused across compilations.

When the `LINDERA_CACHE` environment variable is defined:
1. then the location it points to will be used to download, unpack and parse the dictionary resources.
2. if a dictionary resource was already parsed for a version of Lindera, then download, unpacking and parsing it again is skipped

When the `LINDERA_CACHE` environment variable is **not** defined, the observable behavior is the same as before this PR.

To spare us from replicating a potential future change to the added logic in every `build.rs`, I also took the liberty to factor it in a new`lindera-assets` crate, that serves as a build dependency to lindera dictionary crates.

I extracted the common parameters (output dir, input dir, filename, source url) in the `lindera_assets::FetchParams` structure.

Smaller additions:
- Update the README to tell users about `LINDERA_CACHE`
- ⚠️ Add the new crate to the Makefile and **the GitHub workloads**.

Here are the timings I observe on my Mac Book M1:


| Without cache | With cache | Delta |
|-----|----|---|
|3min13|49s| -144s (-2min 24s) |

As you can see, when `LINDERA_CACHE` is defined and populated, the savings are significant.
Full builds are done with `cargo clean && cargo build --release --all-features`

Thanks for reading so far, let me know if you need anything changed in the PR ☺️ 