### PR TITLE
feature "memmap" without leaking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ unicode-blocks = "0.1.9"
 unicode-normalization = "0.1.24"
 unicode-segmentation = "1.11.0"
 yada = "0.5.1"
+memmap2 = "0.9.5"
 
 
 [profile.release]

--- a/lindera-cc-cedict/src/cc_cedict.rs
+++ b/lindera-cc-cedict/src/cc_cedict.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "cc-cedict")]
 use std::env;
+use std::ops::Deref;
 
 #[cfg(feature = "compress")]
 use lindera_dictionary::decompress::decompress;
@@ -108,16 +109,34 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(
-            DA_DATA,
-            VALS_DATA,
-            WORDS_IDX_DATA,
-            WORDS_DATA,
-            true,
-        ),
-        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
-        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
-        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
-    })
+    #[cfg(feature = "compress")]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA.deref(),
+                VALS_DATA.deref(),
+                WORDS_IDX_DATA.deref(),
+                WORDS_DATA.deref(),
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA.deref()),
+            character_definition: CharacterDefinition::load(&CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(&UNKNOWN_DATA)?,
+        })
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA,
+                VALS_DATA,
+                WORDS_IDX_DATA,
+                WORDS_DATA,
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
+            character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
+        })
+    }
 }

--- a/lindera-cc-cedict/src/cc_cedict.rs
+++ b/lindera-cc-cedict/src/cc_cedict.rs
@@ -108,18 +108,15 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    let da_data = &DA_DATA;
-    let vals_data = &VALS_DATA;
-    let words_idx_data = &WORDS_IDX_DATA;
-    let words_data = &WORDS_DATA;
-    let connection_data = &CONNECTION_DATA;
-    let char_definition = &CHAR_DEFINITION_DATA;
-    let unknown_data = &UNKNOWN_DATA;
-
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(da_data, vals_data, words_idx_data, words_data),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(connection_data),
-        character_definition: CharacterDefinition::load(char_definition)?,
-        unknown_dictionary: UnknownDictionary::load(unknown_data)?,
+        prefix_dictionary: PrefixDictionary::load_static(
+            DA_DATA,
+            VALS_DATA,
+            WORDS_IDX_DATA,
+            WORDS_DATA,
+        ),
+        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })
 }

--- a/lindera-cc-cedict/src/cc_cedict.rs
+++ b/lindera-cc-cedict/src/cc_cedict.rs
@@ -109,13 +109,14 @@ decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load_static(
+        prefix_dictionary: PrefixDictionary::load(
             DA_DATA,
             VALS_DATA,
             WORDS_IDX_DATA,
             WORDS_DATA,
+            true,
         ),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
         character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
         unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -12,7 +12,9 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
+default = []
 compress = []
+memmap = ["dep:memmap2"]
 
 [dependencies]
 anyhow.workspace = true
@@ -32,6 +34,7 @@ serde.workspace = true
 tar = { workspace = true }
 thiserror.workspace = true
 yada.workspace = true
+memmap2 = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand.workspace = true

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-default = ["memmap"]
+default = []
 compress = []
 memmap = ["dep:memmap2"]
 

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-default = []
+default = ["memmap"]
 compress = []
 memmap = ["dep:memmap2"]
 

--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -18,6 +18,7 @@ use crate::LinderaResult;
 
 pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
 
+#[derive(Clone)]
 pub struct Dictionary {
     pub prefix_dictionary: PrefixDictionary,
     pub connection_cost_matrix: ConnectionCostMatrix,
@@ -59,7 +60,7 @@ impl Dictionary {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct UserDictionary {
     pub dict: PrefixDictionary,
 }

--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -18,7 +18,6 @@ use crate::LinderaResult;
 
 pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
 
-#[derive(Clone, Serialize, Deserialize)]
 pub struct Dictionary {
     pub prefix_dictionary: PrefixDictionary,
     pub connection_cost_matrix: ConnectionCostMatrix,
@@ -60,7 +59,7 @@ impl Dictionary {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct UserDictionary {
     pub dict: PrefixDictionary,
 }

--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -20,7 +20,7 @@ pub static UNK: Lazy<Vec<&str>> = Lazy::new(|| vec!["UNK"]);
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Dictionary {
-    pub prefix_dictionary: PrefixDictionary<Vec<u8>>,
+    pub prefix_dictionary: PrefixDictionary,
     pub connection_cost_matrix: ConnectionCostMatrix,
     pub character_definition: CharacterDefinition,
     pub unknown_dictionary: UnknownDictionary,
@@ -62,7 +62,7 @@ impl Dictionary {
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct UserDictionary {
-    pub dict: PrefixDictionary<Vec<u8>>,
+    pub dict: PrefixDictionary,
 }
 
 impl UserDictionary {

--- a/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
@@ -1,9 +1,7 @@
 use crate::util::Data;
 
 use byteorder::{ByteOrder, LittleEndian};
-use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
 pub struct ConnectionCostMatrix {
     costs_data: Data,
     backward_size: u32,

--- a/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
@@ -2,6 +2,7 @@ use crate::util::Data;
 
 use byteorder::{ByteOrder, LittleEndian};
 
+#[derive(Clone)]
 pub struct ConnectionCostMatrix {
     costs_data: Data,
     backward_size: u32,

--- a/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/dictionary/connection_cost_matrix.rs
@@ -1,33 +1,26 @@
-use std::borrow::Cow;
+use crate::util::Data;
 
 use byteorder::{ByteOrder, LittleEndian};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ConnectionCostMatrix {
-    pub costs_data: Cow<'static, [u8]>,
-    pub backward_size: u32,
+    costs_data: Data,
+    backward_size: u32,
 }
 
 impl ConnectionCostMatrix {
-    pub fn load_static(conn_data: &'static [u8]) -> ConnectionCostMatrix {
+    pub fn load(conn_data: impl Into<Data>) -> ConnectionCostMatrix {
+        let conn_data = conn_data.into();
         let backward_size = LittleEndian::read_i16(&conn_data[2..4]);
         ConnectionCostMatrix {
-            costs_data: Cow::Borrowed(&conn_data[4..]),
-            backward_size: backward_size as u32,
-        }
-    }
-
-    pub fn load(conn_data: &[u8]) -> ConnectionCostMatrix {
-        let backward_size = LittleEndian::read_i16(&conn_data[2..4]);
-        ConnectionCostMatrix {
-            costs_data: Cow::Owned(conn_data[4..].to_vec()),
+            costs_data: conn_data,
             backward_size: backward_size as u32,
         }
     }
 
     pub fn cost(&self, forward_id: u32, backward_id: u32) -> i32 {
         let cost_id = (backward_id + forward_id * self.backward_size) as usize;
-        LittleEndian::read_i16(&self.costs_data[cost_id * 2..]) as i32
+        LittleEndian::read_i16(&self.costs_data[4 + cost_id * 2..]) as i32
     }
 }

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -1,20 +1,15 @@
-use std::borrow::Cow;
 use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 use yada::DoubleArray;
 
-use crate::viterbi::WordEntry;
+use crate::{util::Data, viterbi::WordEntry};
 
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "DoubleArray")]
 struct DoubleArrayDef<T>(pub T)
 where
     T: Deref<Target = [u8]>;
-
-// note: Cow is only used as an enum over Vec<u8> and &'static [u8]
-//	copy-on-write capability is not used
-type Data = Cow<'static, [u8]>;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PrefixDictionary {
@@ -28,37 +23,20 @@ pub struct PrefixDictionary {
 
 impl PrefixDictionary {
     pub fn load(
-        da_data: Vec<u8>,
-        vals_data: Vec<u8>,
-        words_idx_data: Vec<u8>,
-        words_data: Vec<u8>,
+        da_data: impl Into<Data>,
+        vals_data: impl Into<Data>,
+        words_idx_data: impl Into<Data>,
+        words_data: impl Into<Data>,
         is_system: bool,
     ) -> PrefixDictionary {
-        let da = DoubleArray::new(Cow::Owned(da_data));
+        let da = DoubleArray::new(da_data.into());
 
         PrefixDictionary {
             da,
-            vals_data: Cow::Owned(vals_data),
-            words_idx_data: Cow::Owned(words_idx_data),
-            words_data: Cow::Owned(words_data),
+            vals_data: vals_data.into(),
+            words_idx_data: words_idx_data.into(),
+            words_data: words_data.into(),
             is_system,
-        }
-    }
-
-    pub fn load_static(
-        da_data: &'static [u8],
-        vals_data: &'static [u8],
-        words_idx_data: &'static [u8],
-        words_data: &'static [u8],
-    ) -> PrefixDictionary {
-        let da = DoubleArray::new(Cow::Borrowed(da_data));
-
-        PrefixDictionary {
-            da,
-            vals_data: Cow::Borrowed(vals_data),
-            words_idx_data: Cow::Borrowed(words_idx_data),
-            words_data: Cow::Borrowed(words_data),
-            is_system: true,
         }
     }
 

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -11,7 +11,7 @@ struct DoubleArrayDef<T>(pub T)
 where
     T: Deref<Target = [u8]>;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct PrefixDictionary {
     #[serde(with = "DoubleArrayDef")]
     pub da: DoubleArray<Data>,

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -11,7 +11,7 @@ struct DoubleArrayDef<T>(pub T)
 where
     T: Deref<Target = [u8]>;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct PrefixDictionary {
     #[serde(with = "DoubleArrayDef")]
     pub da: DoubleArray<Data>,

--- a/lindera-dictionary/src/dictionary_builder/user_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_builder/user_dictionary.rs
@@ -10,7 +10,6 @@ use csv::StringRecord;
 use derive_builder::Builder;
 use log::debug;
 use yada::builder::DoubleArrayBuilder;
-use yada::DoubleArray;
 
 use crate::dictionary::prefix_dictionary::PrefixDictionary;
 use crate::dictionary::UserDictionary;
@@ -152,13 +151,7 @@ impl UserDictionaryBuilder {
             }
         }
 
-        let dict = PrefixDictionary {
-            da: DoubleArray::new(da_bytes),
-            vals_data,
-            words_idx_data,
-            words_data,
-            is_system: false,
-        };
+        let dict = PrefixDictionary::load(da_bytes, vals_data, words_idx_data, words_data, false);
 
         Ok(UserDictionary { dict })
     }

--- a/lindera-dictionary/src/dictionary_loader/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/dictionary_loader/connection_cost_matrix.rs
@@ -5,6 +5,8 @@ use crate::decompress::decompress;
 use crate::dictionary::connection_cost_matrix::ConnectionCostMatrix;
 #[cfg(feature = "compress")]
 use crate::error::LinderaErrorKind;
+#[cfg(feature = "memmap")]
+use crate::util::memmap_file;
 use crate::util::read_file;
 use crate::LinderaResult;
 
@@ -22,6 +24,13 @@ impl ConnectionCostMatrixLoader {
             data = decompress(compressed_data)
                 .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
         }
+
+        Ok(ConnectionCostMatrix::load(data))
+    }
+
+    #[cfg(feature = "memmap")]
+    pub fn load_memmap(input_dir: &Path) -> LinderaResult<ConnectionCostMatrix> {
+        let data = memmap_file(input_dir.join("matrix.mtx").as_path())?;
 
         Ok(ConnectionCostMatrix::load(data))
     }

--- a/lindera-dictionary/src/dictionary_loader/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/dictionary_loader/connection_cost_matrix.rs
@@ -23,6 +23,6 @@ impl ConnectionCostMatrixLoader {
                 .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
         }
 
-        Ok(ConnectionCostMatrix::load(data.as_slice()))
+        Ok(ConnectionCostMatrix::load(data))
     }
 }

--- a/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
@@ -58,6 +58,7 @@ impl PrefixDictionaryLoader {
         ))
     }
 
+    #[cfg(feature = "memmap")]
     pub fn load_memmap(input_dir: &Path) -> LinderaResult<PrefixDictionary> {
         let da_data = memmap_file(input_dir.join("dict.da").as_path())?;
         let vals_data = memmap_file(input_dir.join("dict.vals").as_path())?;

--- a/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
@@ -48,10 +48,11 @@ impl PrefixDictionaryLoader {
         }
 
         Ok(PrefixDictionary::load(
-            da_data.as_slice(),
-            vals_data.as_slice(),
-            words_idx_data.as_slice(),
-            words_data.as_slice(),
+            da_data,
+            vals_data,
+            words_idx_data,
+            words_data,
+            true,
         ))
     }
 }

--- a/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
@@ -5,6 +5,8 @@ use crate::decompress::decompress;
 use crate::dictionary::prefix_dictionary::PrefixDictionary;
 #[cfg(feature = "compress")]
 use crate::error::LinderaErrorKind;
+#[cfg(feature = "memmap")]
+use crate::util::memmap_file;
 use crate::util::read_file;
 use crate::LinderaResult;
 
@@ -46,6 +48,21 @@ impl PrefixDictionaryLoader {
             words_data = decompress(compressed_data)
                 .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
         }
+
+        Ok(PrefixDictionary::load(
+            da_data,
+            vals_data,
+            words_idx_data,
+            words_data,
+            true,
+        ))
+    }
+
+    pub fn load_memmap(input_dir: &Path) -> LinderaResult<PrefixDictionary> {
+        let da_data = memmap_file(input_dir.join("dict.da").as_path())?;
+        let vals_data = memmap_file(input_dir.join("dict.vals").as_path())?;
+        let words_idx_data = memmap_file(input_dir.join("dict.wordsidx").as_path())?;
+        let words_data = memmap_file(input_dir.join("dict.words").as_path())?;
 
         Ok(PrefixDictionary::load(
             da_data,

--- a/lindera-dictionary/src/util.rs
+++ b/lindera-dictionary/src/util.rs
@@ -1,13 +1,16 @@
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::{Read, Write};
+use std::ops::Deref;
 use std::path::Path;
 
+use flate2::Status;
 #[cfg(feature = "memmap")]
 use memmap2::Mmap;
 
 use anyhow::anyhow;
 use encoding_rs::Encoding;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "compress")]
 use crate::compress::compress;
@@ -53,12 +56,12 @@ pub fn read_file(filename: &Path) -> LinderaResult<Vec<u8>> {
 }
 
 #[cfg(feature = "memmap")]
-pub fn memmap_file(filename: &Path) -> LinderaResult<&'static [u8]> {
+pub fn memmap_file(filename: &Path) -> LinderaResult<Mmap> {
     let file = File::open(filename)
         .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
     let mmap = unsafe { Mmap::map(&file) }
         .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))?;
-    Ok(Box::leak(Box::new(mmap)))
+    Ok(mmap)
 }
 
 pub fn read_file_with_encoding(filepath: &Path, encoding_name: &str) -> LinderaResult<String> {
@@ -71,6 +74,45 @@ pub fn read_file_with_encoding(filepath: &Path, encoding_name: &str) -> LinderaR
     Ok(encoding.decode(&buffer).0.into_owned())
 }
 
-// note: Cow is only used as an enum over Vec<u8> and &'static [u8]
-//	copy-on-write capability is not used
-pub type Data = Cow<'static, [u8]>;
+#[derive(Serialize, Deserialize)]
+pub enum Data {
+    // serde is only used for user dict, which only uses the Vec variant, so this should be ok
+    // we should probably customize this and call unreachable! to be safe
+    #[serde(skip)]
+    Static(&'static [u8]),
+    Vec(Vec<u8>),
+    #[cfg(feature = "memmap")]
+    #[serde(skip)]
+    Map(Mmap),
+}
+
+impl Deref for Data {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Data::Static(s) => s.deref(),
+            Data::Vec(v) => v.deref(),
+            #[cfg(feature = "memmap")]
+            Data::Map(m) => m.deref(),
+        }
+    }
+}
+
+impl Into<Data> for &'static [u8] {
+    fn into(self) -> Data {
+        Data::Static(self)
+    }
+}
+
+impl Into<Data> for Vec<u8> {
+    fn into(self) -> Data {
+        Data::Vec(self)
+    }
+}
+
+#[cfg(feature = "memmap")]
+impl Into<Data> for Mmap {
+    fn into(self) -> Data {
+        Data::Map(self)
+    }
+}

--- a/lindera-dictionary/src/util.rs
+++ b/lindera-dictionary/src/util.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -57,3 +58,7 @@ pub fn read_file_with_encoding(filepath: &Path, encoding_name: &str) -> LinderaR
     let buffer = read_file(filepath)?;
     Ok(encoding.decode(&buffer).0.into_owned())
 }
+
+// note: Cow is only used as an enum over Vec<u8> and &'static [u8]
+//	copy-on-write capability is not used
+pub type Data = Cow<'static, [u8]>;

--- a/lindera-ipadic-neologd/src/ipadic_neologd.rs
+++ b/lindera-ipadic-neologd/src/ipadic_neologd.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "ipadic-neologd")]
 use std::env;
+use std::ops::Deref;
 
 use lindera_dictionary::dictionary::character_definition::CharacterDefinition;
 use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix;
@@ -109,16 +110,34 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(
-            DA_DATA,
-            VALS_DATA,
-            WORDS_IDX_DATA,
-            WORDS_DATA,
-            true,
-        ),
-        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
-        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
-        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
-    })
+    #[cfg(feature = "compress")]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA.deref(),
+                VALS_DATA.deref(),
+                WORDS_IDX_DATA.deref(),
+                WORDS_DATA.deref(),
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA.deref()),
+            character_definition: CharacterDefinition::load(&CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(&UNKNOWN_DATA)?,
+        })
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA,
+                VALS_DATA,
+                WORDS_IDX_DATA,
+                WORDS_DATA,
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
+            character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
+        })
+    }
 }

--- a/lindera-ipadic-neologd/src/ipadic_neologd.rs
+++ b/lindera-ipadic-neologd/src/ipadic_neologd.rs
@@ -110,13 +110,14 @@ decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load_static(
+        prefix_dictionary: PrefixDictionary::load(
             DA_DATA,
             VALS_DATA,
             WORDS_IDX_DATA,
             WORDS_DATA,
+            true,
         ),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
         character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
         unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })

--- a/lindera-ipadic-neologd/src/ipadic_neologd.rs
+++ b/lindera-ipadic-neologd/src/ipadic_neologd.rs
@@ -109,18 +109,15 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    let da_data = &DA_DATA;
-    let vals_data = &VALS_DATA;
-    let words_idx_data = &WORDS_IDX_DATA;
-    let words_data = &WORDS_DATA;
-    let connection_data = &CONNECTION_DATA;
-    let char_definition = &CHAR_DEFINITION_DATA;
-    let unknown_data = &UNKNOWN_DATA;
-
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(da_data, vals_data, words_idx_data, words_data),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(connection_data),
-        character_definition: CharacterDefinition::load(char_definition)?,
-        unknown_dictionary: UnknownDictionary::load(unknown_data)?,
+        prefix_dictionary: PrefixDictionary::load_static(
+            DA_DATA,
+            VALS_DATA,
+            WORDS_IDX_DATA,
+            WORDS_DATA,
+        ),
+        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })
 }

--- a/lindera-ipadic/src/ipadic.rs
+++ b/lindera-ipadic/src/ipadic.rs
@@ -103,13 +103,14 @@ decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load_static(
+        prefix_dictionary: PrefixDictionary::load(
             DA_DATA,
             VALS_DATA,
             WORDS_IDX_DATA,
             WORDS_DATA,
+            true,
         ),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
         character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
         unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })

--- a/lindera-ipadic/src/ipadic.rs
+++ b/lindera-ipadic/src/ipadic.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "ipadic")]
 use std::env;
+use std::ops::Deref;
 
 #[cfg(feature = "compress")]
 use lindera_dictionary::decompress::decompress;
@@ -102,16 +103,34 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(
-            DA_DATA,
-            VALS_DATA,
-            WORDS_IDX_DATA,
-            WORDS_DATA,
-            true,
-        ),
-        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
-        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
-        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
-    })
+    #[cfg(feature = "compress")]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA.deref(),
+                VALS_DATA.deref(),
+                WORDS_IDX_DATA.deref(),
+                WORDS_DATA.deref(),
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA.deref()),
+            character_definition: CharacterDefinition::load(&CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(&UNKNOWN_DATA)?,
+        })
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA,
+                VALS_DATA,
+                WORDS_IDX_DATA,
+                WORDS_DATA,
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
+            character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
+        })
+    }
 }

--- a/lindera-ipadic/src/ipadic.rs
+++ b/lindera-ipadic/src/ipadic.rs
@@ -102,18 +102,15 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    let da_data = &DA_DATA;
-    let vals_data = &VALS_DATA;
-    let words_idx_data = &WORDS_IDX_DATA;
-    let words_data = &WORDS_DATA;
-    let connection_data = &CONNECTION_DATA;
-    let char_definition = &CHAR_DEFINITION_DATA;
-    let unknown_data = &UNKNOWN_DATA;
-
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(da_data, vals_data, words_idx_data, words_data),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(connection_data),
-        character_definition: CharacterDefinition::load(char_definition)?,
-        unknown_dictionary: UnknownDictionary::load(unknown_data)?,
+        prefix_dictionary: PrefixDictionary::load_static(
+            DA_DATA,
+            VALS_DATA,
+            WORDS_IDX_DATA,
+            WORDS_DATA,
+        ),
+        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })
 }

--- a/lindera-ko-dic/src/ko_dic.rs
+++ b/lindera-ko-dic/src/ko_dic.rs
@@ -103,13 +103,14 @@ decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load_static(
+        prefix_dictionary: PrefixDictionary::load(
             DA_DATA,
             VALS_DATA,
             WORDS_IDX_DATA,
             WORDS_DATA,
+            true,
         ),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
         character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
         unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })

--- a/lindera-ko-dic/src/ko_dic.rs
+++ b/lindera-ko-dic/src/ko_dic.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "ko-dic")]
 use std::env;
+use std::ops::Deref;
 
 #[cfg(feature = "compress")]
 use lindera_dictionary::decompress::decompress;
@@ -102,16 +103,34 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(
-            DA_DATA,
-            VALS_DATA,
-            WORDS_IDX_DATA,
-            WORDS_DATA,
-            true,
-        ),
-        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
-        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
-        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
-    })
+    #[cfg(feature = "compress")]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA.deref(),
+                VALS_DATA.deref(),
+                WORDS_IDX_DATA.deref(),
+                WORDS_DATA.deref(),
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA.deref()),
+            character_definition: CharacterDefinition::load(&CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(&UNKNOWN_DATA)?,
+        })
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA,
+                VALS_DATA,
+                WORDS_IDX_DATA,
+                WORDS_DATA,
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
+            character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
+        })
+    }
 }

--- a/lindera-ko-dic/src/ko_dic.rs
+++ b/lindera-ko-dic/src/ko_dic.rs
@@ -102,18 +102,15 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    let da_data = &DA_DATA;
-    let vals_data = &VALS_DATA;
-    let words_idx_data = &WORDS_IDX_DATA;
-    let words_data = &WORDS_DATA;
-    let connection_data = &CONNECTION_DATA;
-    let char_definition = &CHAR_DEFINITION_DATA;
-    let unknown_data = &UNKNOWN_DATA;
-
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(da_data, vals_data, words_idx_data, words_data),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(connection_data),
-        character_definition: CharacterDefinition::load(char_definition)?,
-        unknown_dictionary: UnknownDictionary::load(unknown_data)?,
+        prefix_dictionary: PrefixDictionary::load_static(
+            DA_DATA,
+            VALS_DATA,
+            WORDS_IDX_DATA,
+            WORDS_DATA,
+        ),
+        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })
 }

--- a/lindera-unidic/src/unidic.rs
+++ b/lindera-unidic/src/unidic.rs
@@ -103,13 +103,14 @@ decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load_static(
+        prefix_dictionary: PrefixDictionary::load(
             DA_DATA,
             VALS_DATA,
             WORDS_IDX_DATA,
             WORDS_DATA,
+            true,
         ),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
         character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
         unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })

--- a/lindera-unidic/src/unidic.rs
+++ b/lindera-unidic/src/unidic.rs
@@ -102,18 +102,15 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    let da_data = &DA_DATA;
-    let vals_data = &VALS_DATA;
-    let words_idx_data = &WORDS_IDX_DATA;
-    let words_data = &WORDS_DATA;
-    let connection_data = &CONNECTION_DATA;
-    let char_definition = &CHAR_DEFINITION_DATA;
-    let unknown_data = &UNKNOWN_DATA;
-
     Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(da_data, vals_data, words_idx_data, words_data),
-        connection_cost_matrix: ConnectionCostMatrix::load_static(connection_data),
-        character_definition: CharacterDefinition::load(char_definition)?,
-        unknown_dictionary: UnknownDictionary::load(unknown_data)?,
+        prefix_dictionary: PrefixDictionary::load_static(
+            DA_DATA,
+            VALS_DATA,
+            WORDS_IDX_DATA,
+            WORDS_DATA,
+        ),
+        connection_cost_matrix: ConnectionCostMatrix::load_static(CONNECTION_DATA),
+        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
     })
 }

--- a/lindera-unidic/src/unidic.rs
+++ b/lindera-unidic/src/unidic.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "unidic")]
 use std::env;
+use std::ops::Deref;
 
 #[cfg(feature = "compress")]
 use lindera_dictionary::decompress::decompress;
@@ -102,16 +103,34 @@ decompress_data!(
 decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
-    Ok(Dictionary {
-        prefix_dictionary: PrefixDictionary::load(
-            DA_DATA,
-            VALS_DATA,
-            WORDS_IDX_DATA,
-            WORDS_DATA,
-            true,
-        ),
-        connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
-        character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
-        unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
-    })
+    #[cfg(feature = "compress")]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA.deref(),
+                VALS_DATA.deref(),
+                WORDS_IDX_DATA.deref(),
+                WORDS_DATA.deref(),
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA.deref()),
+            character_definition: CharacterDefinition::load(&CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(&UNKNOWN_DATA)?,
+        })
+    }
+    #[cfg(not(feature = "compress"))]
+    {
+        Ok(Dictionary {
+            prefix_dictionary: PrefixDictionary::load(
+                DA_DATA,
+                VALS_DATA,
+                WORDS_IDX_DATA,
+                WORDS_DATA,
+                true,
+            ),
+            connection_cost_matrix: ConnectionCostMatrix::load(CONNECTION_DATA),
+            character_definition: CharacterDefinition::load(CHAR_DEFINITION_DATA)?,
+            unknown_dictionary: UnknownDictionary::load(UNKNOWN_DATA)?,
+        })
+    }
 }

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -33,6 +33,7 @@ compress = [
     "lindera-ko-dic/compress",
     "lindera-cc-cedict/compress",
 ] # Compress dictionaries
+memmap = ["lindera-dictionary/memmap"]
 
 [dependencies]
 anyhow.workspace = true

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -1168,13 +1168,13 @@ mod tests {
             assert_eq!(
                 token.details(),
                 vec![
-                    "*", 
-                    "*", 
-                    "*", 
-                    "*", 
-                    "jin4 xing2", 
-                    "進行", 
-                    "进行", 
+                    "*",
+                    "*",
+                    "*",
+                    "*",
+                    "jin4 xing2",
+                    "進行",
+                    "进行",
                     "to advance/to conduct/underway/in progress/to do/to carry out/to carry on/to execute/"
                 ]
             );
@@ -1848,14 +1848,14 @@ mod tests {
             assert_eq!(
                 token.details(),
                 vec![
-                    "*", 
-                    "*", 
-                    "*", 
-                    "*", 
-                    "bao1", 
-                    "包", 
-                    "包", 
-                    "to cover/to wrap/to hold/to include/to take charge of/to contract (to or for)/package/wrapper/container/bag/to hold or embrace/bundle/packet/CL:個|个[ge4]", 
+                    "*",
+                    "*",
+                    "*",
+                    "*",
+                    "bao1",
+                    "包",
+                    "包",
+                    "to cover/to wrap/to hold/to include/to take charge of/to contract (to or for)/package/wrapper/container/bag/to hold or embrace/bundle/packet/CL:個|个[ge4]",
                     "隻|只[zhi1]/"
                 ]
             );
@@ -2462,14 +2462,14 @@ mod tests {
             assert_eq!(
                 token.details(),
                 vec![
-                    "*", 
-                    "*", 
-                    "*", 
-                    "*", 
-                    "bao1", 
-                    "包", 
-                    "包", 
-                    "to cover/to wrap/to hold/to include/to take charge of/to contract (to or for)/package/wrapper/container/bag/to hold or embrace/bundle/packet/CL:個|个[ge4]", 
+                    "*",
+                    "*",
+                    "*",
+                    "*",
+                    "bao1",
+                    "包",
+                    "包",
+                    "to cover/to wrap/to hold/to include/to take charge of/to contract (to or for)/package/wrapper/container/bag/to hold or embrace/bundle/packet/CL:個|个[ge4]",
                     "隻|只[zhi1]/"
                 ]
             );

--- a/lindera/src/token.rs
+++ b/lindera/src/token.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use crate::dictionary::WordId;
 use lindera_dictionary::dictionary::{Dictionary, UserDictionary, UNK};
 
-#[derive(Serialize, Clone)]
+#[derive(Clone)]
 pub struct Token<'a> {
     /// The text content of the token, which is a copy-on-write string slice.
     /// This allows for efficient handling of both owned and borrowed string data.


### PR DESCRIPTION
Similar to #441 but with a custom enum which works with memmap, no need for Box::leak.