### PR TITLE
remove `lindera_dictionary` "build.rs"-only code/deps from full crate

### DIFF
--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -15,6 +15,7 @@ license = "MIT"
 default = []
 compress = []
 memmap = ["dep:memmap2"]
+build_rs = ["dep:reqwest"]
 
 [dependencies]
 anyhow.workspace = true
@@ -29,12 +30,15 @@ flate2 = { workspace = true }
 glob.workspace = true
 log.workspace = true
 once_cell.workspace = true
-reqwest.workspace = true
 serde.workspace = true
 tar = { workspace = true }
 thiserror.workspace = true
 yada.workspace = true
 memmap2 = { workspace = true, optional = true }
+
+[dependencies.reqwest]
+workspace = true
+optional = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/lindera-dictionary/src/lib.rs
+++ b/lindera-dictionary/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "build_rs")]
 pub mod assets;
 pub mod compress;
 pub mod decompress;

--- a/lindera-ipadic-neologd/Cargo.toml
+++ b/lindera-ipadic-neologd/Cargo.toml
@@ -23,5 +23,8 @@ once_cell.workspace = true
 lindera-dictionary.workspace = true
 
 [build-dependencies]
-lindera-dictionary.workspace = true
 tokio.workspace = true
+
+[builddependencies.lindera-dictionary]
+workspace = true
+features = ["build_rs"]

--- a/lindera-ipadic-neologd/Cargo.toml
+++ b/lindera-ipadic-neologd/Cargo.toml
@@ -25,6 +25,6 @@ lindera-dictionary.workspace = true
 [build-dependencies]
 tokio.workspace = true
 
-[builddependencies.lindera-dictionary]
+[build-dependencies.lindera-dictionary]
 workspace = true
 features = ["build_rs"]

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -23,5 +23,8 @@ once_cell.workspace = true
 lindera-dictionary.workspace = true
 
 [build-dependencies]
-lindera-dictionary.workspace = true
 tokio.workspace = true
+
+[builddependencies.lindera-dictionary]
+workspace = true
+features = ["build_rs"]

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -25,6 +25,6 @@ lindera-dictionary.workspace = true
 [build-dependencies]
 tokio.workspace = true
 
-[builddependencies.lindera-dictionary]
+[build-dependencies.lindera-dictionary]
 workspace = true
 features = ["build_rs"]

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -23,5 +23,8 @@ once_cell.workspace = true
 lindera-dictionary.workspace = true
 
 [build-dependencies]
-lindera-dictionary.workspace = true
 tokio.workspace = true
+
+[build-dependencies.lindera-dictionary]
+workspace = true
+features = ["build_rs"]

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -23,5 +23,8 @@ once_cell.workspace = true
 lindera-dictionary.workspace = true
 
 [build-dependencies]
-lindera-dictionary.workspace = true
 tokio.workspace = true
+
+[builddependencies.lindera-dictionary]
+workspace = true
+features = ["build_rs"]

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -25,6 +25,6 @@ lindera-dictionary.workspace = true
 [build-dependencies]
 tokio.workspace = true
 
-[builddependencies.lindera-dictionary]
+[build-dependencies.lindera-dictionary]
 workspace = true
 features = ["build_rs"]


### PR DESCRIPTION
Hi!  

We (https://github.com/paradedb/paradedb/) have a dependency on the top-level `lindera` crate and noticed that our project's dependency tree was pulling in other crates we don't use, such as `reqwest` and `tokio` (and many others).

After some `cargo tree` analysis we realized it was coming from `lindera-dictionary` -- specifically its "assets" module.  

It turns out that "assets" is only used by Lindera Dictionary's `build.rs`, so...

This PR introduces a new feature flag for `lindera-dictionary` so the other Lindera crates can toggle this new `build_rs` feature flag only for their "build dependency" on `lindera-dictionary`.  

Ultimately, this removes (at least) `reqwest` and all its dependencies, which was our goal.

There's probably a few different ways this could be accomplished, and I'm happy to rework this PR in any way that y'all deem correct for the Lindera project.  I really just wanted to put this in front of y'all.  It's a big bonus for us not to have these unused crates as part of our compiled library and runtime.