### PR TITLE
Add option to load config from mem

### DIFF
--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -1,19 +1,17 @@
-use std::borrow::Cow;
-use std::env;
-use std::fs::File;
-use std::io::Read;
-use std::path::Path;
+use std::{borrow::Cow, env, fs::File, io::Read, path::Path};
 
 use serde_json::{json, Value};
 
-use crate::character_filter::{correct_offset, BoxCharacterFilter, CharacterFilterLoader};
-use crate::dictionary::DictionaryKind;
-use crate::error::LinderaErrorKind;
-use crate::mode::Mode;
-use crate::segmenter::Segmenter;
-use crate::token::Token;
-use crate::token_filter::{BoxTokenFilter, TokenFilterLoader};
-use crate::LinderaResult;
+use crate::{
+    character_filter::{correct_offset, BoxCharacterFilter, CharacterFilterLoader},
+    dictionary::DictionaryKind,
+    error::LinderaErrorKind,
+    mode::Mode,
+    segmenter::Segmenter,
+    token::Token,
+    token_filter::{BoxTokenFilter, TokenFilterLoader},
+    LinderaResult,
+};
 
 pub type TokenizerConfig = Value;
 
@@ -87,16 +85,12 @@ impl TokenizerBuilder {
     pub fn from_file(file_path: &Path) -> LinderaResult<Self> {
         let config = yaml_to_config(file_path)?;
 
-        println!("config: {:?}", config);
-
         Ok(TokenizerBuilder {
             config: ensure_keys(config),
         })
     }
 
-     pub fn from_config(config: TokenizerConfig) -> LinderaResult<Self> {
-        println!("config: {:?}", config);
-
+    pub fn from_config(config: TokenizerConfig) -> LinderaResult<Self> {
         Ok(TokenizerBuilder {
             config: ensure_keys(config),
         })
@@ -432,8 +426,7 @@ mod tests {
     #[test]
     #[cfg(feature = "ipadic")]
     fn test_tokenize_ipadic() {
-        use std::borrow::Cow;
-        use std::path::PathBuf;
+        use std::{borrow::Cow, path::PathBuf};
 
         use crate::tokenizer::TokenizerBuilder;
 

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -94,6 +94,14 @@ impl TokenizerBuilder {
         })
     }
 
+     pub fn from_config(config: TokenizerConfig) -> LinderaResult<Self> {
+        println!("config: {:?}", config);
+
+        Ok(TokenizerBuilder {
+            config: ensure_keys(config),
+        })
+    }
+
     pub fn set_segmenter_mode(&mut self, mode: &Mode) -> &mut Self {
         self.config["segmenter"]["mode"] = json!(mode.as_str());
         self

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -93,7 +93,6 @@ impl TokenizerBuilder {
     }
 
     pub fn from_config(config: TokenizerConfig) -> LinderaResult<Self> {
-        
         Ok(TokenizerBuilder {
             config: ensure_keys(config),
         })

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -93,6 +93,7 @@ impl TokenizerBuilder {
     }
 
     pub fn from_config(config: TokenizerConfig) -> LinderaResult<Self> {
+        
         Ok(TokenizerBuilder {
             config: ensure_keys(config),
         })

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -1,17 +1,19 @@
-use std::{borrow::Cow, env, fs::File, io::Read, path::Path};
+use std::borrow::Cow;
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 
 use serde_json::{json, Value};
 
-use crate::{
-    character_filter::{correct_offset, BoxCharacterFilter, CharacterFilterLoader},
-    dictionary::DictionaryKind,
-    error::LinderaErrorKind,
-    mode::Mode,
-    segmenter::Segmenter,
-    token::Token,
-    token_filter::{BoxTokenFilter, TokenFilterLoader},
-    LinderaResult,
-};
+use crate::character_filter::{correct_offset, BoxCharacterFilter, CharacterFilterLoader};
+use crate::dictionary::DictionaryKind;
+use crate::error::LinderaErrorKind;
+use crate::mode::Mode;
+use crate::segmenter::Segmenter;
+use crate::token::Token;
+use crate::token_filter::{BoxTokenFilter, TokenFilterLoader};
+use crate::LinderaResult;
 
 pub type TokenizerConfig = Value;
 
@@ -426,7 +428,8 @@ mod tests {
     #[test]
     #[cfg(feature = "ipadic")]
     fn test_tokenize_ipadic() {
-        use std::{borrow::Cow, path::PathBuf};
+        use std::borrow::Cow;
+        use std::path::PathBuf;
 
         use crate::tokenizer::TokenizerBuilder;
 


### PR DESCRIPTION
This is likely very much an edge-case scenario, but it is 100% needed for my use case. I load .dlls into games through my application & thus the relative paths in the config will be incorrect in its new environment. Therefore I need to edit the config during runtime before passing it to the `TokenizerBuilder`

Perhaps the proper function name would be `from_mem`