### PR TITLE
Update version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Put the following in Cargo.toml:
 
 ```toml
 [dependencies]
-lindera = { version = "0.34.0", features = ["ipadic"] }
+lindera = { version = "0.40.0", features = ["ipadic"] }
 ```
 
 For example:


### PR DESCRIPTION
0.37 fails with 
```
error: failed to run custom build command for `lindera-ipadic v0.37.0`

Caused by:
  process didn't exit successfully: `/home/pascal/Development/chinese_tok/target/debug/build/lindera-ipadic-300ec70f3352fdf4/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-changed=Cargo.toml
  cargo::rustc-env=LINDERA_WORKDIR=/home/pascal/Development/chinese_tok/target/debug/build/lindera-ipadic-33250f64a0bf8efe/out

  --- stderr
  Error: Transport(Transport { kind: Dns, message: Some("resolve dns name 'dlwqk3ibdg1xh.cloudfront.net:443'"), url: Some(Url { scheme: "https", cannot_be_a_base: false, username: "", passw
ord: None, host: Some(Domain("dlwqk3ibdg1xh.cloudfront.net")), port: None, path: "/mecab-ipadic-2.7.0-20070801.tar.gz", query: None, fragment: None }), source: Some(Custom { kind: Uncategor
ized, error: "failed to lookup address information: No address associated with hostname" }) })
warning: build failed, waiting for other jobs to finish...
```