### PR TITLE
Fix MD5 Checksum Verification for Dictionary Downloads

### DIFF
--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -8,11 +8,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             file_name: "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz",
             input_dir: "CC-CEDICT-MeCab-0.1.0-20200409",
             output_dir: "lindera-cc-cedict",
-            download_urls: &[
-                ("https://lindera.s3.ap-northeast-1.amazonaws.com/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz", "https://lindera.s3.ap-northeast-1.amazonaws.com/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz.md5"),
-                ("https://lindera.dev/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz", "https://lindera.dev/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz.md5"),
-            ],
             dummy_input: "测试,0,0,-1131,*,*,*,*,ce4 shi4,測試,测试,to test (machinery etc)/to test (students)/test/quiz/exam/beta (software)/\n",
+            download_urls: &[
+                "https://lindera.s3.ap-northeast-1.amazonaws.com/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz",
+                "https://lindera.dev/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz",
+            ],
+            md5_hash: "aba9748b70f37feede97b70c5d37f8a0",
         },
         lindera_dictionary::dictionary_builder::cc_cedict::CcCedictBuilder::new(),
     )

--- a/lindera-dictionary/README.md
+++ b/lindera-dictionary/README.md
@@ -1,8 +1,8 @@
-# Lindera Core
+# Lindera Dictionary
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Crates.io](https://img.shields.io/crates/v/lindera-core.svg)](https://crates.io/crates/lindera-core)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Crates.io](https://img.shields.io/crates/v/lindera-dictionary.svg)](https://crates.io/crates/lindera-dictionary)
 
-A morphological analysis core library for [Lindera](https://github.com/lindera-morphology/lindera). This project fork from [kuromoji-rs](https://github.com/fulmicoton/kuromoji-rs).
+A morphological analysis dictionary library for [Lindera](https://github.com/lindera-morphology/lindera).
 
 This package contains dictionary structures and the viterbi algorithm.
 
@@ -60,7 +60,6 @@ Refer to the [manual](https://ja.osdn.net/projects/ipadic/docs/ipadic-2.7.0-manu
 | 11 | 読み | Reading | |
 | 12 | 発音 | Pronunciation | |
 | 13 | - | - | After 13, it can be freely expanded. |
-
 
 ### IPADIC NEologd
 
@@ -296,4 +295,4 @@ Refer to the [manual](ftp://ftp.jaist.ac.jp/pub/sourceforge.jp/unidic/57618/unid
 
 The API reference is available. Please see following URL:
 
-- [lindera-core](https://docs.rs/lindera-core)
+- [lindera-dictionary](https://docs.rs/lindera-dictionary)

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -8,11 +8,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             file_name: "mecab-ipadic-neologd-0.0.7-20200820.tar.gz",
             input_dir: "mecab-ipadic-neologd-0.0.7-20200820",
             output_dir: "lindera-ipadic-neologd",
-            download_urls: &[
-                ("https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ipadic-neologd-0.0.7-20200820.tar.gz", "https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ipadic-neologd-0.0.7-20200820.tar.gz.md5"),
-                ("https://lindera.dev/mecab-ipadic-neologd-0.0.7-20200820.tar.gz", "https://lindera.dev/mecab-ipadic-neologd-0.0.7-20200820.tar.gz.md5"),
-            ],
             dummy_input: "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
+            download_urls: &[
+                "https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ipadic-neologd-0.0.7-20200820.tar.gz",
+                "https://lindera.dev/mecab-ipadic-neologd-0.0.7-20200820.tar.gz",
+            ],
+            md5_hash: "3561f0e76980a842dc828b460a8cae96",
         },
         lindera_dictionary::dictionary_builder::ipadic_neologd::IpadicNeologdBuilder::new(),
     )

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -8,11 +8,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             file_name: "mecab-ipadic-2.7.0-20070801.tar.gz",
             input_dir: "mecab-ipadic-2.7.0-20070801",
             output_dir: "lindera-ipadic",
-            download_urls: &[
-                ("https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ipadic-2.7.0-20070801.tar.gz", "https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ipadic-2.7.0-20070801.tar.gz.md5"),
-                ("https://Lindera.dev/mecab-ipadic-2.7.0-20070801.tar.gz", "https://Lindera.dev/mecab-ipadic-2.7.0-20070801.tar.gz.md5"),
-            ],
             dummy_input: "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
+            download_urls: &[
+                "https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ipadic-2.7.0-20070801.tar.gz",
+                "https://Lindera.dev/mecab-ipadic-2.7.0-20070801.tar.gz",
+            ],
+            md5_hash: "3311c7c71a869ca141e1b8bde0c8666c",
         },
         lindera_dictionary::dictionary_builder::ipadic::IpadicBuilder::new(),
     )

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -8,11 +8,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             file_name: "mecab-ko-dic-2.1.1-20180720.tar.gz",
             input_dir: "mecab-ko-dic-2.1.1-20180720",
             output_dir: "lindera-ko-dic",
-            download_urls: &[
-                ("https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ko-dic-2.1.1-20180720.tar.gz", "https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ko-dic-2.1.1-20180720.tar.gz.md5"),
-                ("https://Lindera.dev/mecab-ko-dic-2.1.1-20180720.tar.gz", "https://Lindera.dev/mecab-ko-dic-2.1.1-20180720.tar.gz.md5")
-            ],
             dummy_input: "테스트,1785,3543,4721,NNG,행위,F,테스트,*,*,*,*\n",
+            download_urls: &[
+                "https://lindera.s3.ap-northeast-1.amazonaws.com/mecab-ko-dic-2.1.1-20180720.tar.gz",
+                "https://Lindera.dev/mecab-ko-dic-2.1.1-20180720.tar.gz",
+            ],
+            md5_hash: "b996764e91c96bc89dc32ea208514a96",
         },
         lindera_dictionary::dictionary_builder::ko_dic::KoDicBuilder::new(),
     )

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -8,11 +8,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             file_name: "unidic-mecab-2.1.2.tar.gz",
             input_dir: "unidic-mecab-2.1.2",
             output_dir: "lindera-unidic",
-            download_urls: &[
-                ("https://lindera.s3.ap-northeast-1.amazonaws.com/unidic-mecab-2.1.2.tar.gz", "https://lindera.s3.ap-northeast-1.amazonaws.com/unidic-mecab-2.1.2.tar.gz.md5"),
-                ("https://Lindera.dev/unidic-mecab-2.1.2.tar.gz", "https://Lindera.dev/unidic-mecab-2.1.2.tar.gz.md5"),
-            ],
             dummy_input: "テスト,5131,5131,767,名詞,普通名詞,サ変可能,*,*,*,テスト,テスト-test,テスト,テスト,テスト,テスト,外,*,*,*,*\n",
+            download_urls: &[
+                "https://lindera.s3.ap-northeast-1.amazonaws.com/unidic-mecab-2.1.2.tar.gz",
+                "https://Lindera.dev/unidic-mecab-2.1.2.tar.gz",
+            ],
+            md5_hash: "f4502a563e1da44747f61dcd2b269e35",
         },
         lindera_dictionary::dictionary_builder::unidic::UnidicBuilder::new(),
     )


### PR DESCRIPTION
This patch hardens the integrity check for external dictionary archives downloaded at build-time.
Previous builds compared the archive against an .md5 file fetched from the same server—an attacker who could tamper with the archive could just as easily replace the checksum, letting the attack slip through.

The PR embeds the trusted MD5 digest inside the crate and retries with alternative mirrors whenever a download fails or the calculated digest does not match the embedded value.