### PR TITLE
Remove native tls dependency making lindera more portable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rand = { version = "0.9.1", default-features = false, features = [
     "small_rng",
 ] } # Specify `default-features` and `features` to support WebAssembly
 regex = "1.11.1"
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["rustls-tls"], default-features = false } # use rustls-tls instead of native-tls which avoids the need to link openssl
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"


### PR DESCRIPTION
The last versions of Lindera add a dependency to native tls forcing the external install of openssl on linux distributions.

This PR removes this dependency by relying on  `rustls-tls` instead