### PR TITLE
Fix compress feature dependencies

### DIFF
--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -27,11 +27,11 @@ cjk2 = ["unidic", "ko-dic", "cc-cedict"] # Include CJK dictionaries
 cjk3 = ["ipadic-neologd", "ko-dic", "cc-cedict"] # Include CJK dictionaries
 compress = [
     "lindera-dictionary/compress",
-    "lindera-ipadic/compress",
-    "lindera-ipadic-neologd/compress",
-    "lindera-unidic/compress",
-    "lindera-ko-dic/compress",
-    "lindera-cc-cedict/compress",
+    "lindera-ipadic?/compress",
+    "lindera-ipadic-neologd?/compress",
+    "lindera-unidic?/compress",
+    "lindera-ko-dic?/compress",
+    "lindera-cc-cedict?/compress",
 ] # Compress dictionaries
 memmap = ["lindera-dictionary/memmap"]
 


### PR DESCRIPTION
Enabling `compress` currently enables all dictionaries. This PR makes the `compress` feature only enable `compress` on dictionary deps which are already enabled. So if you enabled `unidic,compress` you would only enable one dictionary (~50M compressed) instead of all dictionaries (~300M compressed).