### PR TITLE
Fix CLI binary name in --version output

### DIFF
--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -17,7 +17,7 @@ use lindera_cli::get_version;
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "linera",
+    name = "lindera",
     author,
     about = "A morphological analysis command line interface",
     version = get_version(),

--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -17,7 +17,7 @@ use lindera_cli::get_version;
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "lindera",
+    name = env!("CARGO_BIN_NAME"),
     author,
     about = "A morphological analysis command line interface",
     version = get_version(),


### PR DESCRIPTION
Before:

```console
$ target/release/lindera --version
linera 0.43.0
```

After:

```console
$ target/release/lindera --version
lindera 0.43.0
```

Replace hardcoded name with CARGO_BIN_NAME environment variable to use value from Cargo.toml:

https://github.com/lindera/lindera/blob/88f94232a5a41ee8e1aa8a50427d533bf78d4ce3/lindera-cli/Cargo.toml#L36
