### PR TITLE
consolidate dictionary feature cfg attributes with macros

### DIFF
--- a/lindera-cc-cedict/src/cc_cedict.rs
+++ b/lindera-cc-cedict/src/cc_cedict.rs
@@ -26,89 +26,38 @@ macro_rules! decompress_data {
     };
 }
 
-#[cfg(feature = "cc-cedict")]
-decompress_data!(
+macro_rules! cc_cedict_data {
+    ($name: ident, $path: literal, $filename: literal) => {
+        #[cfg(feature = "cc-cedict")]
+        decompress_data!(
+            $name,
+            include_bytes!(concat!(env!("LINDERA_WORKDIR"), $path)),
+            $filename
+        );
+        #[cfg(not(feature = "cc-cedict"))]
+        decompress_data!($name, &[], $filename);
+    };
+}
+
+cc_cedict_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-cc-cedict/char_def.bin"
-    )),
+    "/lindera-cc-cedict/char_def.bin",
     "char_def.bin"
 );
-#[cfg(not(feature = "cc-cedict"))]
-decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
-
-#[cfg(feature = "cc-cedict")]
-decompress_data!(
+cc_cedict_data!(
     CONNECTION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-cc-cedict/matrix.mtx"
-    )),
+    "/lindera-cc-cedict/matrix.mtx",
     "matrix.mtx"
 );
-#[cfg(not(feature = "cc-cedict"))]
-decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
-
-#[cfg(feature = "cc-cedict")]
-decompress_data!(
-    DA_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-cc-cedict/dict.da"
-    )),
-    "dict.da"
-);
-#[cfg(not(feature = "cc-cedict"))]
-decompress_data!(DA_DATA, &[], "dict.da");
-
-#[cfg(feature = "cc-cedict")]
-decompress_data!(
-    VALS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-cc-cedict/dict.vals"
-    )),
-    "dict.vals"
-);
-#[cfg(not(feature = "cc-cedict"))]
-decompress_data!(VALS_DATA, &[], "dict.vals");
-
-#[cfg(feature = "cc-cedict")]
-decompress_data!(
-    UNKNOWN_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-cc-cedict/unk.bin"
-    )),
-    "unk.bin"
-);
-#[cfg(not(feature = "cc-cedict"))]
-decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
-
-#[cfg(feature = "cc-cedict")]
-decompress_data!(
+cc_cedict_data!(DA_DATA, "/lindera-cc-cedict/dict.da", "dict.da");
+cc_cedict_data!(VALS_DATA, "/lindera-cc-cedict/dict.vals", "dict.vals");
+cc_cedict_data!(UNKNOWN_DATA, "/lindera-cc-cedict/unk.bin", "unk.bin");
+cc_cedict_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-cc-cedict/dict.wordsidx"
-    )),
+    "/lindera-cc-cedict/dict.wordsidx",
     "dict.wordsidx"
 );
-#[cfg(not(feature = "cc-cedict"))]
-decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
-
-#[cfg(feature = "cc-cedict")]
-decompress_data!(
-    WORDS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-cc-cedict/dict.words"
-    )),
-    "dict.words"
-);
-#[cfg(not(feature = "cc-cedict"))]
-decompress_data!(WORDS_DATA, &[], "dict.words");
+cc_cedict_data!(WORDS_DATA, "/lindera-cc-cedict/dict.words", "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     #[cfg(feature = "compress")]

--- a/lindera-ipadic-neologd/src/ipadic_neologd.rs
+++ b/lindera-ipadic-neologd/src/ipadic_neologd.rs
@@ -27,89 +27,42 @@ macro_rules! decompress_data {
     };
 }
 
-#[cfg(feature = "ipadic-neologd")]
-decompress_data!(
+macro_rules! ipadic_neologd_data {
+    ($name: ident, $path: literal, $filename: literal) => {
+        #[cfg(feature = "ipadic-neologd")]
+        decompress_data!(
+            $name,
+            include_bytes!(concat!(env!("LINDERA_WORKDIR"), $path)),
+            $filename
+        );
+        #[cfg(not(feature = "ipadic-neologd"))]
+        decompress_data!($name, &[], $filename);
+    };
+}
+
+ipadic_neologd_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic-neologd/char_def.bin"
-    )),
+    "/lindera-ipadic-neologd/char_def.bin",
     "char_def.bin"
 );
-#[cfg(not(feature = "ipadic-neologd"))]
-decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
-
-#[cfg(feature = "ipadic-neologd")]
-decompress_data!(
+ipadic_neologd_data!(
     CONNECTION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic-neologd/matrix.mtx"
-    )),
+    "/lindera-ipadic-neologd/matrix.mtx",
     "matrix.mtx"
 );
-#[cfg(not(feature = "ipadic-neologd"))]
-decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
-
-#[cfg(feature = "ipadic-neologd")]
-decompress_data!(
-    DA_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic-neologd/dict.da"
-    )),
-    "dict.da"
-);
-#[cfg(not(feature = "ipadic-neologd"))]
-decompress_data!(DA_DATA, &[], "dict.da");
-
-#[cfg(feature = "ipadic-neologd")]
-decompress_data!(
-    VALS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic-neologd/dict.vals"
-    )),
-    "dict.vals"
-);
-#[cfg(not(feature = "ipadic-neologd"))]
-decompress_data!(VALS_DATA, &[], "dict.vals");
-
-#[cfg(feature = "ipadic-neologd")]
-decompress_data!(
-    UNKNOWN_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic-neologd/unk.bin"
-    )),
-    "unk.bin"
-);
-#[cfg(not(feature = "ipadic-neologd"))]
-decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
-
-#[cfg(feature = "ipadic-neologd")]
-decompress_data!(
+ipadic_neologd_data!(DA_DATA, "/lindera-ipadic-neologd/dict.da", "dict.da");
+ipadic_neologd_data!(VALS_DATA, "/lindera-ipadic-neologd/dict.vals", "dict.vals");
+ipadic_neologd_data!(UNKNOWN_DATA, "/lindera-ipadic-neologd/unk.bin", "unk.bin");
+ipadic_neologd_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic-neologd/dict.wordsidx"
-    )),
+    "/lindera-ipadic-neologd/dict.wordsidx",
     "dict.wordsidx"
 );
-#[cfg(not(feature = "ipadic-neologd"))]
-decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
-
-#[cfg(feature = "ipadic-neologd")]
-decompress_data!(
+ipadic_neologd_data!(
     WORDS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic-neologd/dict.words"
-    )),
+    "/lindera-ipadic-neologd/dict.words",
     "dict.words"
 );
-#[cfg(not(feature = "ipadic-neologd"))]
-decompress_data!(WORDS_DATA, &[], "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     #[cfg(feature = "compress")]

--- a/lindera-ipadic/src/ipadic.rs
+++ b/lindera-ipadic/src/ipadic.rs
@@ -26,83 +26,34 @@ macro_rules! decompress_data {
     };
 }
 
-#[cfg(feature = "ipadic")]
-decompress_data!(
+macro_rules! ipadic_data {
+    ($name: ident, $path: literal, $filename: literal) => {
+        #[cfg(feature = "ipadic")]
+        decompress_data!(
+            $name,
+            include_bytes!(concat!(env!("LINDERA_WORKDIR"), $path)),
+            $filename
+        );
+        #[cfg(not(feature = "ipadic"))]
+        decompress_data!($name, &[], $filename);
+    };
+}
+
+ipadic_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic/char_def.bin"
-    )),
+    "/lindera-ipadic/char_def.bin",
     "char_def.bin"
 );
-#[cfg(not(feature = "ipadic"))]
-decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
-
-#[cfg(feature = "ipadic")]
-decompress_data!(
-    CONNECTION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic/matrix.mtx"
-    )),
-    "matrix.mtx"
-);
-#[cfg(not(feature = "ipadic"))]
-decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
-
-#[cfg(feature = "ipadic")]
-decompress_data!(
-    DA_DATA,
-    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ipadic/dict.da")),
-    "dict.da"
-);
-#[cfg(not(feature = "ipadic"))]
-decompress_data!(DA_DATA, &[], "dict.da");
-
-#[cfg(feature = "ipadic")]
-decompress_data!(
-    VALS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic/dict.vals"
-    )),
-    "dict.vals"
-);
-#[cfg(not(feature = "ipadic"))]
-decompress_data!(VALS_DATA, &[], "dict.vals");
-
-#[cfg(feature = "ipadic")]
-decompress_data!(
-    UNKNOWN_DATA,
-    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ipadic/unk.bin")),
-    "unk.bin"
-);
-#[cfg(not(feature = "ipadic"))]
-decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
-
-#[cfg(feature = "ipadic")]
-decompress_data!(
+ipadic_data!(CONNECTION_DATA, "/lindera-ipadic/matrix.mtx", "matrix.mtx");
+ipadic_data!(DA_DATA, "/lindera-ipadic/dict.da", "dict.da");
+ipadic_data!(VALS_DATA, "/lindera-ipadic/dict.vals", "dict.vals");
+ipadic_data!(UNKNOWN_DATA, "/lindera-ipadic/unk.bin", "unk.bin");
+ipadic_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic/dict.wordsidx"
-    )),
+    "/lindera-ipadic/dict.wordsidx",
     "dict.wordsidx"
 );
-#[cfg(not(feature = "ipadic"))]
-decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
-
-#[cfg(feature = "ipadic")]
-decompress_data!(
-    WORDS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ipadic/dict.words"
-    )),
-    "dict.words"
-);
-#[cfg(not(feature = "ipadic"))]
-decompress_data!(WORDS_DATA, &[], "dict.words");
+ipadic_data!(WORDS_DATA, "/lindera-ipadic/dict.words", "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     #[cfg(feature = "compress")]

--- a/lindera-ko-dic/src/ko_dic.rs
+++ b/lindera-ko-dic/src/ko_dic.rs
@@ -26,83 +26,34 @@ macro_rules! decompress_data {
     };
 }
 
-#[cfg(feature = "ko-dic")]
-decompress_data!(
+macro_rules! ko_dic_data {
+    ($name: ident, $path: literal, $filename: literal) => {
+        #[cfg(feature = "ko-dic")]
+        decompress_data!(
+            $name,
+            include_bytes!(concat!(env!("LINDERA_WORKDIR"), $path)),
+            $filename
+        );
+        #[cfg(not(feature = "ko-dic"))]
+        decompress_data!($name, &[], $filename);
+    };
+}
+
+ko_dic_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ko-dic/char_def.bin"
-    )),
+    "/lindera-ko-dic/char_def.bin",
     "char_def.bin"
 );
-#[cfg(not(feature = "ko-dic"))]
-decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
-
-#[cfg(feature = "ko-dic")]
-decompress_data!(
-    CONNECTION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ko-dic/matrix.mtx"
-    )),
-    "matrix.mtx"
-);
-#[cfg(not(feature = "ko-dic"))]
-decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
-
-#[cfg(feature = "ko-dic")]
-decompress_data!(
-    DA_DATA,
-    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ko-dic/dict.da")),
-    "dict.da"
-);
-#[cfg(not(feature = "ko-dic"))]
-decompress_data!(DA_DATA, &[], "dict.da");
-
-#[cfg(feature = "ko-dic")]
-decompress_data!(
-    VALS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ko-dic/dict.vals"
-    )),
-    "dict.vals"
-);
-#[cfg(not(feature = "ko-dic"))]
-decompress_data!(VALS_DATA, &[], "dict.vals");
-
-#[cfg(feature = "ko-dic")]
-decompress_data!(
-    UNKNOWN_DATA,
-    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-ko-dic/unk.bin")),
-    "unk.bin"
-);
-#[cfg(not(feature = "ko-dic"))]
-decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
-
-#[cfg(feature = "ko-dic")]
-decompress_data!(
+ko_dic_data!(CONNECTION_DATA, "/lindera-ko-dic/matrix.mtx", "matrix.mtx");
+ko_dic_data!(DA_DATA, "/lindera-ko-dic/dict.da", "dict.da");
+ko_dic_data!(VALS_DATA, "/lindera-ko-dic/dict.vals", "dict.vals");
+ko_dic_data!(UNKNOWN_DATA, "/lindera-ko-dic/unk.bin", "unk.bin");
+ko_dic_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ko-dic/dict.wordsidx"
-    )),
+    "/lindera-ko-dic/dict.wordsidx",
     "dict.wordsidx"
 );
-#[cfg(not(feature = "ko-dic"))]
-decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
-
-#[cfg(feature = "ko-dic")]
-decompress_data!(
-    WORDS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-ko-dic/dict.words"
-    )),
-    "dict.words"
-);
-#[cfg(not(feature = "ko-dic"))]
-decompress_data!(WORDS_DATA, &[], "dict.words");
+ko_dic_data!(WORDS_DATA, "/lindera-ko-dic/dict.words", "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     #[cfg(feature = "compress")]

--- a/lindera-unidic/src/unidic.rs
+++ b/lindera-unidic/src/unidic.rs
@@ -26,83 +26,34 @@ macro_rules! decompress_data {
     };
 }
 
-#[cfg(feature = "unidic")]
-decompress_data!(
+macro_rules! unidic_data {
+    ($name: ident, $path: literal, $filename: literal) => {
+        #[cfg(feature = "unidic")]
+        decompress_data!(
+            $name,
+            include_bytes!(concat!(env!("LINDERA_WORKDIR"), $path)),
+            $filename
+        );
+        #[cfg(not(feature = "unidic"))]
+        decompress_data!($name, &[], $filename);
+    };
+}
+
+unidic_data!(
     CHAR_DEFINITION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-unidic/char_def.bin"
-    )),
+    "/lindera-unidic/char_def.bin",
     "char_def.bin"
 );
-#[cfg(not(feature = "unidic"))]
-decompress_data!(CHAR_DEFINITION_DATA, &[], "char_def.bin");
-
-#[cfg(feature = "unidic")]
-decompress_data!(
-    CONNECTION_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-unidic/matrix.mtx"
-    )),
-    "matrix.mtx"
-);
-#[cfg(not(feature = "unidic"))]
-decompress_data!(CONNECTION_DATA, &[], "matrix.mtx");
-
-#[cfg(feature = "unidic")]
-decompress_data!(
-    DA_DATA,
-    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-unidic/dict.da")),
-    "dict.da"
-);
-#[cfg(not(feature = "unidic"))]
-decompress_data!(DA_DATA, &[], "dict.da");
-
-#[cfg(feature = "unidic")]
-decompress_data!(
-    VALS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-unidic/dict.vals"
-    )),
-    "dict.vals"
-);
-#[cfg(not(feature = "unidic"))]
-decompress_data!(VALS_DATA, &[], "dict.vals");
-
-#[cfg(feature = "unidic")]
-decompress_data!(
-    UNKNOWN_DATA,
-    include_bytes!(concat!(env!("LINDERA_WORKDIR"), "/lindera-unidic/unk.bin")),
-    "unk.bin"
-);
-#[cfg(not(feature = "unidic"))]
-decompress_data!(UNKNOWN_DATA, &[], "unk.bin");
-
-#[cfg(feature = "unidic")]
-decompress_data!(
+unidic_data!(CONNECTION_DATA, "/lindera-unidic/matrix.mtx", "matrix.mtx");
+unidic_data!(DA_DATA, "/lindera-unidic/dict.da", "dict.da");
+unidic_data!(VALS_DATA, "/lindera-unidic/dict.vals", "dict.vals");
+unidic_data!(UNKNOWN_DATA, "/lindera-unidic/unk.bin", "unk.bin");
+unidic_data!(
     WORDS_IDX_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-unidic/dict.wordsidx"
-    )),
+    "/lindera-unidic/dict.wordsidx",
     "dict.wordsidx"
 );
-#[cfg(not(feature = "unidic"))]
-decompress_data!(WORDS_IDX_DATA, &[], "dict.wordsidx");
-
-#[cfg(feature = "unidic")]
-decompress_data!(
-    WORDS_DATA,
-    include_bytes!(concat!(
-        env!("LINDERA_WORKDIR"),
-        "/lindera-unidic/dict.words"
-    )),
-    "dict.words"
-);
-#[cfg(not(feature = "unidic"))]
-decompress_data!(WORDS_DATA, &[], "dict.words");
+unidic_data!(WORDS_DATA, "/lindera-unidic/dict.words", "dict.words");
 
 pub fn load() -> LinderaResult<Dictionary> {
     #[cfg(feature = "compress")]

--- a/lindera/examples/tokenize.rs
+++ b/lindera/examples/tokenize.rs
@@ -1,34 +1,45 @@
 use lindera::LinderaResult;
 
-fn main() -> LinderaResult<()> {
-    #[cfg(feature = "ipadic")]
-    {
-        use lindera::dictionary::{load_dictionary_from_kind, DictionaryKind};
-        use lindera::mode::Mode;
-        use lindera::segmenter::Segmenter;
-        use lindera::tokenizer::Tokenizer;
+macro_rules! run_with_feature {
+    ($feature:literal, $dict_kind:expr, $text:expr) => {
+        #[cfg(feature = $feature)]
+        {
+            use lindera::dictionary::load_dictionary_from_kind;
+            use lindera::mode::Mode;
+            use lindera::segmenter::Segmenter;
+            use lindera::tokenizer::Tokenizer;
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC)?;
-        let segmenter = Segmenter::new(
-            Mode::Normal,
-            dictionary,
-            None, // Assuming no user dictionary is provided
-        );
+            let dictionary = load_dictionary_from_kind($dict_kind)?;
+            let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+            let tokenizer = Tokenizer::new(segmenter);
 
-        // Create a tokenizer.
-        let tokenizer = Tokenizer::new(segmenter);
-
-        // Tokenize a text.
-        let text = "関西国際空港限定トートバッグ";
-        let mut tokens = tokenizer.tokenize(text)?;
-
-        // Print the text and tokens.
-        println!("text:\t{}", text);
-        for token in tokens.iter_mut() {
-            let details = token.details().join(",");
-            println!("token:\t{}\t{}", token.text.as_ref(), details);
+            let mut tokens = tokenizer.tokenize($text)?;
+            println!("text:\t{}", $text);
+            for token in tokens.iter_mut() {
+                let details = token.details().join(",");
+                println!("token:\t{}\t{}", token.text.as_ref(), details);
+            }
         }
-    }
 
+        #[cfg(not(feature = $feature))]
+        {
+            eprintln!(
+                "This example requires the '{}' feature to be enabled.",
+                $feature
+            );
+            eprintln!(
+                "Run with: cargo run --features {} --example tokenize",
+                $feature
+            );
+        }
+    };
+}
+
+fn main() -> LinderaResult<()> {
+    run_with_feature!(
+        "ipadic",
+        lindera::dictionary::DictionaryKind::IPADIC,
+        "関西国際空港限定トートバッグ"
+    );
     Ok(())
 }

--- a/lindera/src/lib.rs
+++ b/lindera/src/lib.rs
@@ -27,3 +27,51 @@ fn parse_cli_flag(cli_flag: &str) -> LinderaResult<(&str, Value)> {
 
     Ok((kind, args))
 }
+
+#[cfg(test)]
+mod tests {
+    /// Common test macros to reduce feature-specific repetition
+
+    #[macro_export]
+    macro_rules! feature_test {
+        ($feature:literal, $test_name:ident, $test_body:block) => {
+            #[test]
+            #[cfg(feature = $feature)]
+            fn $test_name() {
+                $test_body
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! dictionary_test {
+        ($feature:literal, $dict_kind:expr, $test_name:ident, $test_body:expr) => {
+            #[test]
+            #[cfg(feature = $feature)]
+            fn $test_name() {
+                use crate::dictionary::{load_dictionary_from_kind, DictionaryKind};
+
+                let dictionary = load_dictionary_from_kind($dict_kind).unwrap();
+                $test_body(dictionary);
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! token_filter_test {
+        ($feature:literal, $dict_kind:expr, $test_name:ident, $filter_setup:expr, $test_body:expr) => {
+            #[test]
+            #[cfg(feature = $feature)]
+            fn $test_name() {
+                use crate::dictionary::{load_dictionary_from_kind, DictionaryKind, WordId};
+                use crate::token::Token;
+                use crate::token_filter::TokenFilter;
+                use std::borrow::Cow;
+
+                let dictionary = load_dictionary_from_kind($dict_kind).unwrap();
+                let filter = $filter_setup;
+                $test_body(filter, dictionary);
+            }
+        };
+    }
+}

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -227,7 +227,6 @@ mod tests {
 
     #[cfg(any(
         feature = "ipadic",
-        feature = "ipadic-neologd",
         feature = "unidic",
         feature = "ko-dic",
         feature = "cc-cedict"

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -20,6 +20,7 @@ pub type JapaneseCompoundWordTokenFilterConfig = Value;
 pub struct JapaneseCompoundWordTokenFilter {
     kind: DictionaryKind,
     tags: HashSet<String>,
+    #[allow(dead_code)]
     new_tag: Option<String>,
 }
 

--- a/lindera/src/token_filter/japanese_reading_form.rs
+++ b/lindera/src/token_filter/japanese_reading_form.rs
@@ -89,28 +89,28 @@ impl TokenFilter for JapaneseReadingFormTokenFilter {
                 }
             }
 
-            match self.kind {
-                #[cfg(feature = "ipadic")]
-                DictionaryKind::IPADIC => {
-                    if let Some(detail) = token.get_detail(7) {
-                        token.text = Cow::Owned(detail.to_string());
+            macro_rules! apply_reading_form {
+                ($($feature:literal => $kind:path => $index:expr),* $(,)?) => {
+                    match self.kind {
+                        $(
+                            #[cfg(feature = $feature)]
+                            $kind => {
+                                if let Some(detail) = token.get_detail($index) {
+                                    token.text = Cow::Owned(detail.to_string());
+                                }
+                            }
+                        )*
+                        _ => {
+                            // NOOP
+                        }
                     }
-                }
-                #[cfg(feature = "ipadic-neologd")]
-                DictionaryKind::IPADICNEologd => {
-                    if let Some(detail) = token.get_detail(7) {
-                        token.text = Cow::Owned(detail.to_string());
-                    }
-                }
-                #[cfg(feature = "unidic")]
-                DictionaryKind::UniDic => {
-                    if let Some(detail) = token.get_detail(6) {
-                        token.text = Cow::Owned(detail.to_string());
-                    }
-                }
-                _ => {
-                    // NOOP
-                }
+                };
+            }
+
+            apply_reading_form! {
+                "ipadic" => DictionaryKind::IPADIC => 7,
+                "ipadic-neologd" => DictionaryKind::IPADICNEologd => 7,
+                "unidic" => DictionaryKind::UniDic => 6,
             }
         }
 


### PR DESCRIPTION
- Replace repetitive #[cfg(feature = "...")] blocks with unified macros
  in dictionary files (ipadic, ipadic-neologd, cc-cedict, unidic, ko-dic)
- Fix unused import warnings by adjusting feature-conditional imports
- Improve code readability and maintainability by reducing duplication
- Move test macros to appropriate location in lib.rs