### PR TITLE
Simplify dictionary loading and improve code readability

### DIFF
--- a/lindera/benches/bench.rs
+++ b/lindera/benches/bench.rs
@@ -5,14 +5,14 @@ fn bench_constructor(c: &mut Criterion) {
     #[cfg(feature = "ipadic")]
     {
         use lindera::dictionary::DictionaryKind;
-        use lindera::dictionary::load_dictionary_from_kind;
+        use lindera::dictionary::load_embedded_dictionary;
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
         c.bench_function("bench-constructor-ipadic", |b| {
             b.iter(|| {
-                let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
                 let segmenter = Segmenter::new(
                     Mode::Normal,
                     dictionary,
@@ -28,14 +28,14 @@ fn bench_constructor(c: &mut Criterion) {
     #[cfg(feature = "unidic")]
     {
         use lindera::dictionary::DictionaryKind;
-        use lindera::dictionary::load_dictionary_from_kind;
+        use lindera::dictionary::load_embedded_dictionary;
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
         c.bench_function("bench-constructor-unidic", |b| {
             b.iter(|| {
-                let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::UniDic).unwrap();
                 let segmenter = Segmenter::new(
                     Mode::Normal,
                     dictionary,
@@ -51,14 +51,14 @@ fn bench_constructor(c: &mut Criterion) {
     #[cfg(feature = "ko-dic")]
     {
         use lindera::dictionary::DictionaryKind;
-        use lindera::dictionary::load_dictionary_from_kind;
+        use lindera::dictionary::load_embedded_dictionary;
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
         c.bench_function("bench-constructor-ko-dic", |b| {
             b.iter(|| {
-                let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
                 let segmenter = Segmenter::new(
                     Mode::Normal,
                     dictionary,
@@ -74,14 +74,14 @@ fn bench_constructor(c: &mut Criterion) {
     #[cfg(feature = "cc-cedict")]
     {
         use lindera::dictionary::DictionaryKind;
-        use lindera::dictionary::load_dictionary_from_kind;
+        use lindera::dictionary::load_embedded_dictionary;
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
         c.bench_function("bench-constructor-cc-cedict", |b| {
             b.iter(|| {
-                let dictionary = load_dictionary_from_kind(DictionaryKind::CcCedict).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::CcCedict).unwrap();
                 let segmenter = Segmenter::new(
                     Mode::Normal,
                     dictionary,
@@ -102,7 +102,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -114,7 +114,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
                     .join("../resources")
                     .join("ipadic_simple_userdic.csv");
 
-                let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
                 let user_dictionary =
                     load_user_dictionary_from_csv(DictionaryKind::IPADIC, userdic_file.as_path())
                         .unwrap();
@@ -135,7 +135,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -147,7 +147,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
                     .join("../resources")
                     .join("unidic_simple_userdic.csv");
 
-                let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::UniDic).unwrap();
                 let user_dictionary =
                     load_user_dictionary_from_csv(DictionaryKind::UniDic, userdic_file.as_path())
                         .unwrap();
@@ -168,7 +168,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -180,7 +180,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
                     .join("../resources")
                     .join("ko-dic_simple_userdic.csv");
 
-                let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
                 let user_dictionary =
                     load_user_dictionary_from_csv(DictionaryKind::KoDic, userdic_file.as_path())
                         .unwrap();
@@ -201,7 +201,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -213,7 +213,7 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
                     .join("../resources")
                     .join("cc-cedict_simple_userdic.csv");
 
-                let dictionary = load_dictionary_from_kind(DictionaryKind::CcCedict).unwrap();
+                let dictionary = load_embedded_dictionary(DictionaryKind::CcCedict).unwrap();
                 let user_dictionary =
                     load_user_dictionary_from_csv(DictionaryKind::CcCedict, userdic_file.as_path())
                         .unwrap();
@@ -234,12 +234,12 @@ fn bench_constructor_with_simple_userdic(c: &mut Criterion) {
 fn bench_tokenize(c: &mut Criterion) {
     #[cfg(feature = "ipadic")]
     {
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,
@@ -256,12 +256,12 @@ fn bench_tokenize(c: &mut Criterion) {
 
     #[cfg(feature = "unidic")]
     {
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::UniDic).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,
@@ -278,12 +278,12 @@ fn bench_tokenize(c: &mut Criterion) {
 
     #[cfg(feature = "ko-dic")]
     {
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,
@@ -300,12 +300,12 @@ fn bench_tokenize(c: &mut Criterion) {
 
     #[cfg(feature = "cc-cedict")]
     {
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::CcCedict).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::CcCedict).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,
@@ -328,7 +328,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -338,7 +338,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
             .join("../resources")
             .join("ipadic_simple_userdic.csv");
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
         let user_dictionary =
             load_user_dictionary_from_csv(DictionaryKind::IPADIC, userdic_file.as_path()).unwrap();
         let segmenter = Segmenter::new(
@@ -362,7 +362,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -372,7 +372,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
             .join("../resources")
             .join("unidic_simple_userdic.csv");
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::UniDic).unwrap();
         let user_dictionary =
             load_user_dictionary_from_csv(DictionaryKind::UniDic, userdic_file.as_path()).unwrap();
         let segmenter = Segmenter::new(
@@ -396,7 +396,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -406,7 +406,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
             .join("../resources")
             .join("ko-dic_simple_userdic.csv");
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
         let user_dictionary =
             load_user_dictionary_from_csv(DictionaryKind::KoDic, userdic_file.as_path()).unwrap();
         let segmenter = Segmenter::new(
@@ -428,7 +428,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -438,7 +438,7 @@ fn bench_tokenize_with_simple_userdic(c: &mut Criterion) {
             .join("../resources")
             .join("cc-cedict_simple_userdic.csv");
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::CcCedict).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::CcCedict).unwrap();
         let user_dictionary =
             load_user_dictionary_from_csv(DictionaryKind::CcCedict, userdic_file.as_path())
                 .unwrap();
@@ -466,7 +466,7 @@ fn bench_tokenize_long_text(c: &mut Criterion) {
         use std::io::Read;
         use std::path::PathBuf;
 
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
@@ -482,7 +482,7 @@ fn bench_tokenize_long_text(c: &mut Criterion) {
         let mut long_text = String::new();
         let _size = long_text_file.read_to_string(&mut long_text).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,
@@ -508,7 +508,7 @@ fn bench_tokenize_long_text(c: &mut Criterion) {
         use std::io::Read;
         use std::path::PathBuf;
 
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
@@ -524,7 +524,7 @@ fn bench_tokenize_long_text(c: &mut Criterion) {
         let mut long_text = String::new();
         let _size = long_text_file.read_to_string(&mut long_text).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,
@@ -553,7 +553,7 @@ fn bench_tokenize_details_long_text(c: &mut Criterion) {
         use std::io::Read;
         use std::path::PathBuf;
 
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
@@ -569,7 +569,7 @@ fn bench_tokenize_details_long_text(c: &mut Criterion) {
         let mut long_text = String::new();
         let _size = long_text_file.read_to_string(&mut long_text).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,
@@ -600,7 +600,7 @@ fn bench_tokenize_details_long_text(c: &mut Criterion) {
         use std::io::Read;
         use std::path::PathBuf;
 
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::tokenizer::Tokenizer;
@@ -616,7 +616,7 @@ fn bench_tokenize_details_long_text(c: &mut Criterion) {
         let mut long_text = String::new();
         let _size = long_text_file.read_to_string(&mut long_text).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::UniDic).unwrap();
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,

--- a/lindera/examples/tokenize.rs
+++ b/lindera/examples/tokenize.rs
@@ -4,12 +4,12 @@ macro_rules! run_with_feature {
     ($feature:literal, $dict_kind:expr, $text:expr) => {
         #[cfg(feature = $feature)]
         {
-            use lindera::dictionary::load_dictionary_from_kind;
+            use lindera::dictionary::load_embedded_dictionary;
             use lindera::mode::Mode;
             use lindera::segmenter::Segmenter;
             use lindera::tokenizer::Tokenizer;
 
-            let dictionary = load_dictionary_from_kind($dict_kind)?;
+            let dictionary = load_embedded_dictionary($dict_kind)?;
             let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
             let tokenizer = Tokenizer::new(segmenter);
 

--- a/lindera/examples/tokenize_with_filters.rs
+++ b/lindera/examples/tokenize_with_filters.rs
@@ -8,7 +8,7 @@ fn main() -> LinderaResult<()> {
         use lindera::character_filter::unicode_normalize::{
             UnicodeNormalizeCharacterFilter, UnicodeNormalizeKind,
         };
-        use lindera::dictionary::{DictionaryKind, load_dictionary_from_kind};
+        use lindera::dictionary::{DictionaryKind, load_embedded_dictionary};
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
         use lindera::token_filter::BoxTokenFilter;
@@ -17,7 +17,7 @@ fn main() -> LinderaResult<()> {
         use lindera::token_filter::japanese_stop_tags::JapaneseStopTagsTokenFilter;
         use lindera::tokenizer::Tokenizer;
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC)?;
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC)?;
         let segmenter = Segmenter::new(
             Mode::Normal,
             dictionary,

--- a/lindera/examples/tokenize_with_user_dict.rs
+++ b/lindera/examples/tokenize_with_user_dict.rs
@@ -6,7 +6,7 @@ fn main() -> LinderaResult<()> {
         use std::path::PathBuf;
 
         use lindera::dictionary::{
-            DictionaryKind, load_dictionary_from_kind, load_user_dictionary_from_csv,
+            DictionaryKind, load_embedded_dictionary, load_user_dictionary_from_csv,
         };
         use lindera::mode::Mode;
         use lindera::segmenter::Segmenter;
@@ -16,7 +16,7 @@ fn main() -> LinderaResult<()> {
             .join("../resources")
             .join("ipadic_simple_userdic.csv");
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC)?;
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC)?;
         let user_dictionary =
             load_user_dictionary_from_csv(DictionaryKind::IPADIC, user_dict_path.as_path())?;
         let segmenter = Segmenter::new(

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -192,7 +192,7 @@ pub fn load_dictionary_from_config(
         let kind_str = kind_value.as_str().ok_or_else(|| {
             LinderaErrorKind::Parse.with_error(anyhow::anyhow!("kind field must be a string"))
         })?;
-        
+
         let kind = DictionaryKind::from_str(kind_str)?;
         return load_embedded_dictionary(kind);
     }
@@ -202,7 +202,7 @@ pub fn load_dictionary_from_config(
         let path_str = path_value.as_str().ok_or_else(|| {
             LinderaErrorKind::Parse.with_error(anyhow::anyhow!("path field must be a string"))
         })?;
-        
+
         let path = PathBuf::from(path_str);
         return load_dictionary(&path);
     }
@@ -257,9 +257,13 @@ pub fn load_user_dictionary_from_config(
 ) -> LinderaResult<UserDictionary> {
     let path = get_path_from_config(dictionary_config)?;
 
-    let extension = path.extension().and_then(|ext| ext.to_str()).ok_or_else(|| {
-        LinderaErrorKind::Args.with_error(anyhow::anyhow!("Invalid user dictionary source file"))
-    })?;
+    let extension = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .ok_or_else(|| {
+            LinderaErrorKind::Args
+                .with_error(anyhow::anyhow!("Invalid user dictionary source file"))
+        })?;
 
     match extension {
         "csv" => {

--- a/lindera/src/token_filter/japanese_base_form.rs
+++ b/lindera/src/token_filter/japanese_base_form.rs
@@ -185,7 +185,7 @@ mod tests {
     fn test_japanese_base_form_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_base_form::{
@@ -200,7 +200,7 @@ mod tests {
         let config: JapaneseBaseFormTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseBaseFormTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {
@@ -315,7 +315,7 @@ mod tests {
     fn test_japanese_base_form_token_filter_apply_unidic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_base_form::{
@@ -330,7 +330,7 @@ mod tests {
         let config: JapaneseBaseFormTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseBaseFormTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::UniDic).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -336,7 +336,7 @@ mod tests {
     fn test_japanese_compound_word_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_compound_word::{
@@ -357,7 +357,7 @@ mod tests {
             serde_json::from_str(config_str).unwrap();
         let filter = JapaneseCompoundWordTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/japanese_kana.rs
+++ b/lindera/src/token_filter/japanese_kana.rs
@@ -201,7 +201,7 @@ mod tests {
     fn test_japanese_kana_token_filter_apply_katakana_to_hiragana_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_kana::{
@@ -216,7 +216,7 @@ mod tests {
         let config: JapaneseKanaTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKanaTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {
@@ -296,7 +296,7 @@ mod tests {
     fn test_japanese_kana_token_filter_apply_hiragana_to_katakana_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_kana::{
@@ -311,7 +311,7 @@ mod tests {
         let config: JapaneseKanaTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKanaTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {
@@ -426,7 +426,7 @@ mod tests {
     fn test_japanese_kana_token_filter_apply_katakana_to_katakana_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_kana::{
@@ -441,7 +441,7 @@ mod tests {
         let config: JapaneseKanaTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKanaTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {
@@ -521,7 +521,7 @@ mod tests {
     fn test_japanese_kana_token_filter_apply_hiragana_to_hiragana_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_kana::{
@@ -536,7 +536,7 @@ mod tests {
         let config: JapaneseKanaTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKanaTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {
@@ -651,7 +651,7 @@ mod tests {
     fn test_japanese_kana_token_filter_apply_mixed_to_katakana_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_kana::{
@@ -666,7 +666,7 @@ mod tests {
         let config: JapaneseKanaTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKanaTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {
@@ -781,7 +781,7 @@ mod tests {
     fn test_japanese_kana_token_filter_applymixed_to_hiragana_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_kana::{
@@ -796,7 +796,7 @@ mod tests {
         let config: JapaneseKanaTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKanaTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/japanese_katakana_stem.rs
+++ b/lindera/src/token_filter/japanese_katakana_stem.rs
@@ -190,7 +190,7 @@ mod tests {
     fn test_japanese_katakana_stem_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_katakana_stem::{
@@ -206,7 +206,7 @@ mod tests {
             serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKatakanaStemTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/japanese_keep_tags.rs
+++ b/lindera/src/token_filter/japanese_keep_tags.rs
@@ -231,7 +231,7 @@ mod tests {
     fn test_japanese_keep_tags_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_keep_tags::{
@@ -286,7 +286,7 @@ mod tests {
         let config: JapaneseKeepTagsTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseKeepTagsTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/japanese_number.rs
+++ b/lindera/src/token_filter/japanese_number.rs
@@ -892,7 +892,7 @@ mod tests {
     fn test_japanese_number_token_filter_apply_numbers_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::{token::Token, token_filter::TokenFilter};
 
         let config_str = r#"
@@ -905,7 +905,7 @@ mod tests {
         let config: JapaneseNumberTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseNumberTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         {
             let mut tokens: Vec<Token> = vec![Token {
@@ -1070,7 +1070,7 @@ mod tests {
     fn test_japanese_number_token_filter_apply_empty_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::{token::Token, token_filter::TokenFilter};
 
         let config_str = r#"
@@ -1079,7 +1079,7 @@ mod tests {
             "#;
         let config: JapaneseNumberTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseNumberTokenFilter::from_config(&config).unwrap();
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         {
             let mut tokens: Vec<Token> = vec![Token {

--- a/lindera/src/token_filter/japanese_reading_form.rs
+++ b/lindera/src/token_filter/japanese_reading_form.rs
@@ -190,7 +190,7 @@ mod tests {
     fn test_japanese_reading_form_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_reading_form::{
@@ -206,7 +206,7 @@ mod tests {
             serde_json::from_str(config_str).unwrap();
         let filter = JapaneseReadingFormTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {
@@ -286,7 +286,7 @@ mod tests {
     fn test_japanese_reading_form_token_filter_apply_unidic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::japanese_reading_form::{
@@ -302,7 +302,7 @@ mod tests {
             serde_json::from_str(config_str).unwrap();
         let filter = JapaneseReadingFormTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::UniDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::UniDic).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -204,7 +204,7 @@ mod tests {
     fn test_japanese_stop_tags_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -242,7 +242,7 @@ mod tests {
         let config: JapaneseStopTagsTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = JapaneseStopTagsTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/keep_words.rs
+++ b/lindera/src/token_filter/keep_words.rs
@@ -122,7 +122,7 @@ mod tests {
     fn test_keep_words_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -137,7 +137,7 @@ mod tests {
         let config: KeepWordsTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = KeepWordsTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/korean_keep_tags.rs
+++ b/lindera/src/token_filter/korean_keep_tags.rs
@@ -137,7 +137,7 @@ mod tests {
     fn test_korean_keep_tags_token_filter_apply() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -151,7 +151,7 @@ mod tests {
         let config: KoreanKeepTagsTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = KoreanKeepTagsTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/korean_reading_form.rs
+++ b/lindera/src/token_filter/korean_reading_form.rs
@@ -60,14 +60,14 @@ mod tests {
     fn test_korean_reading_form_token_filter_apply() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::korean_reading_form::KoreanReadingFormTokenFilter;
 
         let filter = KoreanReadingFormTokenFilter::new();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/korean_stop_tags.rs
+++ b/lindera/src/token_filter/korean_stop_tags.rs
@@ -168,7 +168,7 @@ mod tests {
     fn test_korean_stop_tags_token_filter_apply() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -211,7 +211,7 @@ mod tests {
         let config: KoreanStopTagsTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = KoreanStopTagsTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::KoDic).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/length.rs
+++ b/lindera/src/token_filter/length.rs
@@ -128,7 +128,7 @@ mod tests {
     fn test_length_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -141,7 +141,7 @@ mod tests {
         let config: LengthTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = LengthTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/lowercase.rs
+++ b/lindera/src/token_filter/lowercase.rs
@@ -53,14 +53,14 @@ mod tests {
     fn test_lowercase_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::lowercase::LowercaseTokenFilter;
 
         let filter = LowercaseTokenFilter::new();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![Token {
             text: Cow::Borrowed("Rust"),

--- a/lindera/src/token_filter/mapping.rs
+++ b/lindera/src/token_filter/mapping.rs
@@ -149,7 +149,7 @@ mod tests {
     fn test_mapping_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -164,7 +164,7 @@ mod tests {
 
         let filter = MappingTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/remove_diacritical_mark.rs
+++ b/lindera/src/token_filter/remove_diacritical_mark.rs
@@ -136,7 +136,7 @@ mod tests {
     fn test_remove_diacritical_token_filter_apply() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -149,7 +149,7 @@ mod tests {
             serde_json::from_str(config_str).unwrap();
         let filter = RemoveDiacriticalMarkTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         {
             let mut tokens: Vec<Token> = vec![Token {
@@ -209,7 +209,7 @@ mod tests {
     fn test_remove_diacritical_token_filter_apply_japanese() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -222,7 +222,7 @@ mod tests {
             serde_json::from_str(config_str).unwrap();
         let filter = RemoveDiacriticalMarkTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         {
             let mut tokens: Vec<Token> = vec![Token {

--- a/lindera/src/token_filter/stop_words.rs
+++ b/lindera/src/token_filter/stop_words.rs
@@ -95,7 +95,7 @@ mod tests {
     fn test_stop_words_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
 
@@ -110,7 +110,7 @@ mod tests {
         let config: StopWordsTokenFilterConfig = serde_json::from_str(config_str).unwrap();
         let filter = StopWordsTokenFilter::from_config(&config).unwrap();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![
             Token {

--- a/lindera/src/token_filter/uppercase.rs
+++ b/lindera/src/token_filter/uppercase.rs
@@ -52,14 +52,14 @@ mod tests {
     fn test_uppercase_token_filter_apply() {
         use std::borrow::Cow;
 
-        use crate::dictionary::{DictionaryKind, WordId, load_dictionary_from_kind};
+        use crate::dictionary::{DictionaryKind, WordId, load_embedded_dictionary};
         use crate::token::Token;
         use crate::token_filter::TokenFilter;
         use crate::token_filter::uppercase::UppercaseTokenFilter;
 
         let filter = UppercaseTokenFilter::new();
 
-        let dictionary = load_dictionary_from_kind(DictionaryKind::IPADIC).unwrap();
+        let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![Token {
             text: Cow::Borrowed("Rust"),


### PR DESCRIPTION
Simplify dictionary loading and improve code readability

  - Remove use_mmap parameter from load_dictionary_from_path
  - Unify external dictionary loading via StandardDictionaryLoader
  - Fix resolve_embedded_loader to return only embedded loaders
  - Rename load_dictionary_from_kind to load_embedded_dictionary
  - Improve readability of config-based dictionary loading functions