### PR TITLE
refactor: Remove redundant load methods and improve struct naming consistency

### DIFF
--- a/lindera-cc-cedict/src/embedded.rs
+++ b/lindera-cc-cedict/src/embedded.rs
@@ -132,19 +132,15 @@ pub fn load() -> LinderaResult<Dictionary> {
     }
 }
 
-pub struct EmbeddedLoader;
+pub struct EmbeddedCcCedictLoader;
 
-impl EmbeddedLoader {
+impl EmbeddedCcCedictLoader {
     pub fn new() -> Self {
         Self
     }
-
-    pub fn load(&self) -> LinderaResult<Dictionary> {
-        load()
-    }
 }
 
-impl DictionaryLoader for EmbeddedLoader {
+impl DictionaryLoader for EmbeddedCcCedictLoader {
     fn load(&self) -> LinderaResult<Dictionary> {
         load()
     }

--- a/lindera-ipadic-neologd/src/embedded.rs
+++ b/lindera-ipadic-neologd/src/embedded.rs
@@ -99,7 +99,7 @@ ipadicneologd_metadata!(
 pub fn load() -> LinderaResult<Dictionary> {
     // Load metadata from embedded binary data with fallback to default
     let metadata = Metadata::load_or_default(METADATA_DATA, || {
-        crate::metadata::IpadicNeologdMetadata::metadata()
+        crate::metadata::IPADICNEologdMetadata::metadata()
     });
 
     #[cfg(feature = "compress")]
@@ -136,19 +136,15 @@ pub fn load() -> LinderaResult<Dictionary> {
     }
 }
 
-pub struct EmbeddedLoader;
+pub struct EmbeddedIPADICNEologdLoader;
 
-impl EmbeddedLoader {
+impl EmbeddedIPADICNEologdLoader {
     pub fn new() -> Self {
         Self
     }
-
-    pub fn load(&self) -> LinderaResult<Dictionary> {
-        load()
-    }
 }
 
-impl DictionaryLoader for EmbeddedLoader {
+impl DictionaryLoader for EmbeddedIPADICNEologdLoader {
     fn load(&self) -> LinderaResult<Dictionary> {
         load()
     }

--- a/lindera-ipadic-neologd/src/metadata.rs
+++ b/lindera-ipadic-neologd/src/metadata.rs
@@ -1,18 +1,18 @@
 use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
-use crate::schema::IpadicNeologdSchema;
+use crate::schema::IPADICNEologdSchema;
 
 /// IPADIC NEologd metadata factory
-pub struct IpadicNeologdMetadata;
+pub struct IPADICNEologdMetadata;
 
-impl Default for IpadicNeologdMetadata {
+impl Default for IPADICNEologdMetadata {
     fn default() -> Self {
         Self
     }
 }
 
-impl IpadicNeologdMetadata {
+impl IPADICNEologdMetadata {
     /// Create default IPADIC NEologd metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
@@ -27,7 +27,7 @@ impl IpadicNeologdMetadata {
             true,  // flexible_csv
             false, // skip_invalid_cost_or_id
             true,  // normalize_details is true for IPAdic-NEologd
-            IpadicNeologdSchema::schema(),
+            IPADICNEologdSchema::schema(),
             vec![
                 Some(1), // Major POS classification
                 None,    // Middle POS classification

--- a/lindera-ipadic-neologd/src/schema.rs
+++ b/lindera-ipadic-neologd/src/schema.rs
@@ -1,15 +1,15 @@
 use lindera_dictionary::dictionary::schema::Schema;
 
 /// IPADIC NEologd dictionary schema factory
-pub struct IpadicNeologdSchema;
+pub struct IPADICNEologdSchema;
 
-impl Default for IpadicNeologdSchema {
+impl Default for IPADICNEologdSchema {
     fn default() -> Self {
         Self
     }
 }
 
-impl IpadicNeologdSchema {
+impl IPADICNEologdSchema {
     /// Create default IPADIC NEologd schema
     pub fn schema() -> Schema {
         Schema::new(

--- a/lindera-ipadic/src/embedded.rs
+++ b/lindera-ipadic/src/embedded.rs
@@ -91,7 +91,7 @@ ipadic_metadata!(
 pub fn load() -> LinderaResult<Dictionary> {
     // Load metadata from embedded binary data with fallback to default
     let metadata =
-        Metadata::load_or_default(METADATA_DATA, crate::metadata::IpadicMetadata::metadata);
+        Metadata::load_or_default(METADATA_DATA, crate::metadata::IPADICMetadata::metadata);
 
     #[cfg(feature = "compress")]
     {
@@ -127,19 +127,15 @@ pub fn load() -> LinderaResult<Dictionary> {
     }
 }
 
-pub struct EmbeddedLoader;
+pub struct EmbeddedIPADICLoader;
 
-impl EmbeddedLoader {
+impl EmbeddedIPADICLoader {
     pub fn new() -> Self {
         Self
     }
-
-    pub fn load(&self) -> LinderaResult<Dictionary> {
-        load()
-    }
 }
 
-impl DictionaryLoader for EmbeddedLoader {
+impl DictionaryLoader for EmbeddedIPADICLoader {
     fn load(&self) -> LinderaResult<Dictionary> {
         load()
     }

--- a/lindera-ipadic/src/metadata.rs
+++ b/lindera-ipadic/src/metadata.rs
@@ -1,18 +1,18 @@
 use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
-use crate::schema::IpadicSchema;
+use crate::schema::IPADICSchema;
 
 /// IPADIC metadata factory
-pub struct IpadicMetadata;
+pub struct IPADICMetadata;
 
-impl Default for IpadicMetadata {
+impl Default for IPADICMetadata {
     fn default() -> Self {
         Self
     }
 }
 
-impl IpadicMetadata {
+impl IPADICMetadata {
     /// Create default IPADIC metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
@@ -27,7 +27,7 @@ impl IpadicMetadata {
             true,  // flexible_csv
             false, // skip_invalid_cost_or_id
             true,  // normalize_details is true for IPAdic
-            IpadicSchema::schema(),
+            IPADICSchema::schema(),
             vec![
                 Some(1), // Major POS classification
                 None,    // Middle POS classification

--- a/lindera-ipadic/src/schema.rs
+++ b/lindera-ipadic/src/schema.rs
@@ -1,15 +1,15 @@
 use lindera_dictionary::dictionary::schema::Schema;
 
 /// IPADIC dictionary schema factory
-pub struct IpadicSchema;
+pub struct IPADICSchema;
 
-impl Default for IpadicSchema {
+impl Default for IPADICSchema {
     fn default() -> Self {
         Self
     }
 }
 
-impl IpadicSchema {
+impl IPADICSchema {
     /// Create default IPADIC schema
     pub fn schema() -> Schema {
         Schema::new(

--- a/lindera-ko-dic/src/embedded.rs
+++ b/lindera-ko-dic/src/embedded.rs
@@ -127,19 +127,15 @@ pub fn load() -> LinderaResult<Dictionary> {
     }
 }
 
-pub struct EmbeddedLoader;
+pub struct EmbeddedKoDicLoader;
 
-impl EmbeddedLoader {
+impl EmbeddedKoDicLoader {
     pub fn new() -> Self {
         Self
     }
-
-    pub fn load(&self) -> LinderaResult<Dictionary> {
-        load()
-    }
 }
 
-impl DictionaryLoader for EmbeddedLoader {
+impl DictionaryLoader for EmbeddedKoDicLoader {
     fn load(&self) -> LinderaResult<Dictionary> {
         load()
     }

--- a/lindera-unidic/src/embedded.rs
+++ b/lindera-unidic/src/embedded.rs
@@ -91,7 +91,7 @@ unidic_metadata!(
 pub fn load() -> LinderaResult<Dictionary> {
     // Load metadata from embedded binary data with fallback to default
     let metadata =
-        Metadata::load_or_default(METADATA_DATA, crate::metadata::UnidicMetadata::metadata);
+        Metadata::load_or_default(METADATA_DATA, crate::metadata::UniDicMetadata::metadata);
 
     #[cfg(feature = "compress")]
     {
@@ -127,19 +127,15 @@ pub fn load() -> LinderaResult<Dictionary> {
     }
 }
 
-pub struct EmbeddedLoader;
+pub struct EmbeddedUniDicLoader;
 
-impl EmbeddedLoader {
+impl EmbeddedUniDicLoader {
     pub fn new() -> Self {
         Self
     }
-
-    pub fn load(&self) -> LinderaResult<Dictionary> {
-        load()
-    }
 }
 
-impl DictionaryLoader for EmbeddedLoader {
+impl DictionaryLoader for EmbeddedUniDicLoader {
     fn load(&self) -> LinderaResult<Dictionary> {
         load()
     }

--- a/lindera-unidic/src/metadata.rs
+++ b/lindera-unidic/src/metadata.rs
@@ -1,18 +1,18 @@
 use lindera_dictionary::decompress::Algorithm;
 use lindera_dictionary::dictionary::metadata::Metadata;
 
-use crate::schema::UnidicSchema;
+use crate::schema::UniDicSchema;
 
 /// UniDic metadata factory
-pub struct UnidicMetadata;
+pub struct UniDicMetadata;
 
-impl Default for UnidicMetadata {
+impl Default for UniDicMetadata {
     fn default() -> Self {
         Self
     }
 }
 
-impl UnidicMetadata {
+impl UniDicMetadata {
     /// Create default UniDic metadata
     pub fn metadata() -> Metadata {
         Metadata::new(
@@ -27,7 +27,7 @@ impl UnidicMetadata {
             false, // flexible_csv
             false, // skip_invalid_cost_or_id
             false, // normalize_details
-            UnidicSchema::schema(),
+            UniDicSchema::schema(),
             vec![
                 Some(1), // Major POS classification
                 None,    // Middle POS classification

--- a/lindera-unidic/src/schema.rs
+++ b/lindera-unidic/src/schema.rs
@@ -1,15 +1,15 @@
 use lindera_dictionary::dictionary::schema::Schema;
 
 /// UniDic dictionary schema factory
-pub struct UnidicSchema;
+pub struct UniDicSchema;
 
-impl Default for UnidicSchema {
+impl Default for UniDicSchema {
     fn default() -> Self {
         Self
     }
 }
 
-impl UnidicSchema {
+impl UniDicSchema {
     /// Create default UniDic schema
     pub fn schema() -> Schema {
         Schema::new(

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -1,6 +1,16 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+#[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
+use lindera_cc_cedict::embedded::EmbeddedCcCedictLoader;
+#[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+use lindera_ipadic::embedded::EmbeddedIPADICLoader;
+#[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
+use lindera_ipadic_neologd::embedded::EmbeddedIPADICNEologdLoader;
+#[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+use lindera_ko_dic::embedded::EmbeddedKoDicLoader;
+#[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+use lindera_unidic::embedded::EmbeddedUniDicLoader;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::IntoEnumIterator;
@@ -84,21 +94,21 @@ pub fn resolve_builder(dictionary_type: DictionaryKind) -> LinderaResult<Diction
     match dictionary_type {
         #[cfg(feature = "ipadic")]
         DictionaryKind::IPADIC => Ok(DictionaryBuilder::new(
-            lindera_ipadic::metadata::IpadicMetadata::metadata(),
+            lindera_ipadic::metadata::IPADICMetadata::metadata(),
         )),
         #[cfg(not(feature = "ipadic"))]
         DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(feature = "ipadic-neologd")]
         DictionaryKind::IPADICNEologd => Ok(DictionaryBuilder::new(
-            lindera_ipadic_neologd::metadata::IpadicNeologdMetadata::metadata(),
+            lindera_ipadic_neologd::metadata::IPADICNEologdMetadata::metadata(),
         )),
         #[cfg(not(feature = "ipadic-neologd"))]
         DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(feature = "unidic")]
         DictionaryKind::UniDic => Ok(DictionaryBuilder::new(
-            lindera_unidic::metadata::UnidicMetadata::metadata(),
+            lindera_unidic::metadata::UniDicMetadata::metadata(),
         )),
         #[cfg(not(feature = "unidic"))]
         DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
@@ -125,7 +135,7 @@ pub fn resolve_embedded_loader(
 ) -> LinderaResult<Box<dyn DictionaryLoader>> {
     match dictionary_type {
         #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
-        DictionaryKind::IPADIC => Ok(Box::new(lindera_ipadic::embedded::EmbeddedLoader::new())),
+        DictionaryKind::IPADIC => Ok(Box::new(EmbeddedIPADICLoader::new())),
         #[cfg(all(feature = "ipadic", not(feature = "embedded-ipadic")))]
         DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC embedded feature is not enabled"))),
@@ -133,9 +143,7 @@ pub fn resolve_embedded_loader(
         DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
-        DictionaryKind::IPADICNEologd => Ok(Box::new(
-            lindera_ipadic_neologd::embedded::EmbeddedLoader::new(),
-        )),
+        DictionaryKind::IPADICNEologd => Ok(Box::new(EmbeddedIPADICNEologdLoader::new())),
         #[cfg(all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")))]
         DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary.with_error(
             anyhow::anyhow!("IPADIC-NEologd embedded feature is not enabled"),
@@ -144,7 +152,7 @@ pub fn resolve_embedded_loader(
         DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
-        DictionaryKind::UniDic => Ok(Box::new(lindera_unidic::embedded::EmbeddedLoader::new())),
+        DictionaryKind::UniDic => Ok(Box::new(EmbeddedUniDicLoader::new())),
         #[cfg(all(feature = "unidic", not(feature = "embedded-unidic")))]
         DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("UniDic embedded feature is not enabled"))),
@@ -152,7 +160,7 @@ pub fn resolve_embedded_loader(
         DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
         #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
-        DictionaryKind::KoDic => Ok(Box::new(lindera_ko_dic::embedded::EmbeddedLoader::new())),
+        DictionaryKind::KoDic => Ok(Box::new(EmbeddedKoDicLoader::new())),
         #[cfg(all(feature = "ko-dic", not(feature = "embedded-ko-dic")))]
         DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("KO-DIC embedded feature is not enabled"))),
@@ -160,9 +168,7 @@ pub fn resolve_embedded_loader(
         DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
         #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
-        DictionaryKind::CcCedict => {
-            Ok(Box::new(lindera_cc_cedict::embedded::EmbeddedLoader::new()))
-        }
+        DictionaryKind::CcCedict => Ok(Box::new(EmbeddedCcCedictLoader::new())),
         #[cfg(all(feature = "cc-cedict", not(feature = "embedded-cc-cedict")))]
         DictionaryKind::CcCedict => Err(LinderaErrorKind::Dictionary
             .with_error(anyhow::anyhow!("CC-CEDICT embedded feature is not enabled"))),


### PR DESCRIPTION
refactor: Remove redundant load methods and improve struct naming consistency

  - Remove duplicate load() methods from EmbeddedLoader impl blocks across all dictionary crates
    - The DictionaryLoader trait already provides the same functionality
  - Rename loader structs for clarity and consistency:
    - EmbeddedLoader -> EmbeddedIPADICLoader
    - EmbeddedLoader -> EmbeddedIPADICNEologdLoader
    - EmbeddedLoader -> EmbeddedUniDicLoader
    - EmbeddedLoader -> EmbeddedKoDicLoader
    - EmbeddedLoader -> EmbeddedCcCedictLoader
  - Standardize naming convention for metadata and schema structs:
    - Use uppercase for acronyms (IPADIC, UniDic, etc.)
  - Update all imports and references to use the new struct names