### PR TITLE
refactor: Improve error handling with descriptive contexts and reorganize error types

### DIFF
--- a/lindera-dictionary/src/dictionary_loader/character_definition.rs
+++ b/lindera-dictionary/src/dictionary_loader/character_definition.rs
@@ -20,10 +20,15 @@ impl CharacterDefinitionLoader {
             let (compressed_data, _) =
                 bincode::serde::decode_from_slice(data.as_slice(), bincode::config::legacy())
                     .map_err(|err| {
-                        LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err))
+                        LinderaErrorKind::Deserialize
+                            .with_error(anyhow::anyhow!(err))
+                            .add_context("Failed to deserialize char_def.bin data")
                     })?;
-            data = decompress(compressed_data)
-                .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
+            data = decompress(compressed_data).map_err(|err| {
+                LinderaErrorKind::Compression
+                    .with_error(err)
+                    .add_context("Failed to decompress character definition data")
+            })?;
         }
 
         CharacterDefinition::load(data.as_slice())

--- a/lindera-dictionary/src/dictionary_loader/connection_cost_matrix.rs
+++ b/lindera-dictionary/src/dictionary_loader/connection_cost_matrix.rs
@@ -22,10 +22,15 @@ impl ConnectionCostMatrixLoader {
             let (compressed_data, _) =
                 bincode::serde::decode_from_slice(data.as_slice(), bincode::config::legacy())
                     .map_err(|err| {
-                        LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err))
+                        LinderaErrorKind::Deserialize
+                            .with_error(anyhow::anyhow!(err))
+                            .add_context("Failed to deserialize matrix.mtx data")
                     })?;
-            data = decompress(compressed_data)
-                .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
+            data = decompress(compressed_data).map_err(|err| {
+                LinderaErrorKind::Compression
+                    .with_error(err)
+                    .add_context("Failed to decompress connection cost matrix data")
+            })?;
         }
 
         Ok(ConnectionCostMatrix::load(data))

--- a/lindera-dictionary/src/dictionary_loader/metadata.rs
+++ b/lindera-dictionary/src/dictionary_loader/metadata.rs
@@ -44,8 +44,11 @@ impl MetadataLoader {
     pub fn load(input_dir: &Path) -> LinderaResult<Metadata> {
         let data = read_file(input_dir.join("metadata.json").as_path())?;
 
-        let metadata: Metadata = serde_json::from_slice(&data)
-            .map_err(|err| LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err)))?;
+        let metadata: Metadata = serde_json::from_slice(&data).map_err(|err| {
+            LinderaErrorKind::Deserialize
+                .with_error(anyhow::anyhow!(err))
+                .add_context("Failed to deserialize metadata.json file")
+        })?;
 
         Ok(metadata)
     }
@@ -66,8 +69,11 @@ impl MetadataLoader {
     pub fn load_mmap(input_dir: &Path) -> LinderaResult<Metadata> {
         let data = mmap_file(input_dir.join("metadata.json").as_path())?;
 
-        let metadata: Metadata = serde_json::from_slice(&data)
-            .map_err(|err| LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err)))?;
+        let metadata: Metadata = serde_json::from_slice(&data).map_err(|err| {
+            LinderaErrorKind::Deserialize
+                .with_error(anyhow::anyhow!(err))
+                .add_context("Failed to deserialize metadata.json file (mmap)")
+        })?;
 
         Ok(metadata)
     }

--- a/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_loader/prefix_dictionary.rs
@@ -25,20 +25,30 @@ impl PrefixDictionaryLoader {
             let (compressed_data, _) =
                 bincode::serde::decode_from_slice(da_data.as_slice(), bincode::config::legacy())
                     .map_err(|err| {
-                        LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err))
+                        LinderaErrorKind::Deserialize
+                            .with_error(anyhow::anyhow!(err))
+                            .add_context("Failed to deserialize dict.da data")
                     })?;
-            da_data = decompress(compressed_data)
-                .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
+            da_data = decompress(compressed_data).map_err(|err| {
+                LinderaErrorKind::Compression
+                    .with_error(err)
+                    .add_context("Failed to decompress dict.da DoubleArray data")
+            })?;
         }
         #[cfg(feature = "compress")]
         {
             let (compressed_data, _) =
                 bincode::serde::decode_from_slice(vals_data.as_slice(), bincode::config::legacy())
                     .map_err(|err| {
-                        LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err))
+                        LinderaErrorKind::Deserialize
+                            .with_error(anyhow::anyhow!(err))
+                            .add_context("Failed to deserialize dict.vals data")
                     })?;
-            vals_data = decompress(compressed_data)
-                .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
+            vals_data = decompress(compressed_data).map_err(|err| {
+                LinderaErrorKind::Compression
+                    .with_error(err)
+                    .add_context("Failed to decompress dict.vals word values data")
+            })?;
         }
         #[cfg(feature = "compress")]
         {
@@ -46,19 +56,31 @@ impl PrefixDictionaryLoader {
                 words_idx_data.as_slice(),
                 bincode::config::legacy(),
             )
-            .map_err(|err| LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err)))?;
-            words_idx_data = decompress(compressed_data)
-                .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
+            .map_err(|err| {
+                LinderaErrorKind::Deserialize
+                    .with_error(anyhow::anyhow!(err))
+                    .add_context("Failed to deserialize dict.wordsidx data")
+            })?;
+            words_idx_data = decompress(compressed_data).map_err(|err| {
+                LinderaErrorKind::Compression
+                    .with_error(err)
+                    .add_context("Failed to decompress dict.wordsidx word index data")
+            })?;
         }
         #[cfg(feature = "compress")]
         {
             let (compressed_data, _) =
                 bincode::serde::decode_from_slice(words_data.as_slice(), bincode::config::legacy())
                     .map_err(|err| {
-                        LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err))
+                        LinderaErrorKind::Deserialize
+                            .with_error(anyhow::anyhow!(err))
+                            .add_context("Failed to deserialize dict.words data")
                     })?;
-            words_data = decompress(compressed_data)
-                .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
+            words_data = decompress(compressed_data).map_err(|err| {
+                LinderaErrorKind::Compression
+                    .with_error(err)
+                    .add_context("Failed to decompress dict.words word details data")
+            })?;
         }
 
         Ok(PrefixDictionary::load(

--- a/lindera-dictionary/src/dictionary_loader/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_loader/unknown_dictionary.rs
@@ -20,10 +20,15 @@ impl UnknownDictionaryLoader {
             let (compressed_data, _) =
                 bincode::serde::decode_from_slice(data.as_slice(), bincode::config::legacy())
                     .map_err(|err| {
-                        LinderaErrorKind::Deserialize.with_error(anyhow::anyhow!(err))
+                        LinderaErrorKind::Deserialize
+                            .with_error(anyhow::anyhow!(err))
+                            .add_context("Failed to deserialize unk.bin data")
                     })?;
-            data = decompress(compressed_data)
-                .map_err(|err| LinderaErrorKind::Decompress.with_error(err))?;
+            data = decompress(compressed_data).map_err(|err| {
+                LinderaErrorKind::Compression
+                    .with_error(err)
+                    .add_context("Failed to decompress unknown dictionary data")
+            })?;
         }
 
         UnknownDictionary::load(data.as_slice())

--- a/lindera-dictionary/src/error.rs
+++ b/lindera-dictionary/src/error.rs
@@ -12,15 +12,12 @@ pub enum LinderaErrorKind {
     Io,
     Parse,
     Serialize,
-    Compress,
-    Decompress,
+    Compression,
     NotFound,
-    Load,
     Build,
     Dictionary,
-    Source,
     Mode,
-    Token,
+    FeatureDisabled,
 }
 
 impl LinderaErrorKind {

--- a/lindera/src/character_filter/mapping.rs
+++ b/lindera/src/character_filter/mapping.rs
@@ -28,7 +28,7 @@ impl MappingCharacterFilter {
         }
 
         let data = DoubleArrayBuilder::build(&keyset).ok_or_else(|| {
-            LinderaErrorKind::Io.with_error(anyhow::anyhow!("DoubleArray build error."))
+            LinderaErrorKind::Build.with_error(anyhow::anyhow!("DoubleArray build error."))
         })?;
 
         let trie = DoubleArray::new(data);

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -97,35 +97,35 @@ pub fn resolve_builder(dictionary_type: DictionaryKind) -> LinderaResult<Diction
             lindera_ipadic::metadata::IPADICMetadata::metadata(),
         )),
         #[cfg(not(feature = "ipadic"))]
-        DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::IPADIC => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(feature = "ipadic-neologd")]
         DictionaryKind::IPADICNEologd => Ok(DictionaryBuilder::new(
             lindera_ipadic_neologd::metadata::IPADICNEologdMetadata::metadata(),
         )),
         #[cfg(not(feature = "ipadic-neologd"))]
-        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(feature = "unidic")]
         DictionaryKind::UniDic => Ok(DictionaryBuilder::new(
             lindera_unidic::metadata::UniDicMetadata::metadata(),
         )),
         #[cfg(not(feature = "unidic"))]
-        DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::UniDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
         #[cfg(feature = "ko-dic")]
         DictionaryKind::KoDic => Ok(DictionaryBuilder::new(
             lindera_ko_dic::metadata::KoDicMetadata::metadata(),
         )),
         #[cfg(not(feature = "ko-dic"))]
-        DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::KoDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
         #[cfg(feature = "cc-cedict")]
         DictionaryKind::CcCedict => Ok(DictionaryBuilder::new(
             lindera_cc_cedict::metadata::CcCedictMetadata::metadata(),
         )),
         #[cfg(not(feature = "cc-cedict"))]
-        DictionaryKind::CcCedict => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::CcCedict => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("CC-CEDICT feature is not enabled"))),
     }
 }
@@ -137,43 +137,43 @@ pub fn resolve_embedded_loader(
         #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
         DictionaryKind::IPADIC => Ok(Box::new(EmbeddedIPADICLoader::new())),
         #[cfg(all(feature = "ipadic", not(feature = "embedded-ipadic")))]
-        DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::IPADIC => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("IPADIC embedded feature is not enabled"))),
         #[cfg(not(feature = "ipadic"))]
-        DictionaryKind::IPADIC => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::IPADIC => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("IPADIC feature is not enabled"))),
         #[cfg(all(feature = "ipadic-neologd", feature = "embedded-ipadic-neologd"))]
         DictionaryKind::IPADICNEologd => Ok(Box::new(EmbeddedIPADICNEologdLoader::new())),
         #[cfg(all(feature = "ipadic-neologd", not(feature = "embedded-ipadic-neologd")))]
-        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary.with_error(
+        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::FeatureDisabled.with_error(
             anyhow::anyhow!("IPADIC-NEologd embedded feature is not enabled"),
         )),
         #[cfg(not(feature = "ipadic-neologd"))]
-        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::IPADICNEologd => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("IPADIC-NEologd feature is not enabled"))),
         #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
         DictionaryKind::UniDic => Ok(Box::new(EmbeddedUniDicLoader::new())),
         #[cfg(all(feature = "unidic", not(feature = "embedded-unidic")))]
-        DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::UniDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("UniDic embedded feature is not enabled"))),
         #[cfg(not(feature = "unidic"))]
-        DictionaryKind::UniDic => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::UniDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("UniDic feature is not enabled"))),
         #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
         DictionaryKind::KoDic => Ok(Box::new(EmbeddedKoDicLoader::new())),
         #[cfg(all(feature = "ko-dic", not(feature = "embedded-ko-dic")))]
-        DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::KoDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("KO-DIC embedded feature is not enabled"))),
         #[cfg(not(feature = "ko-dic"))]
-        DictionaryKind::KoDic => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::KoDic => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("KO-DIC feature is not enabled"))),
         #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
         DictionaryKind::CcCedict => Ok(Box::new(EmbeddedCcCedictLoader::new())),
         #[cfg(all(feature = "cc-cedict", not(feature = "embedded-cc-cedict")))]
-        DictionaryKind::CcCedict => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::CcCedict => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("CC-CEDICT embedded feature is not enabled"))),
         #[cfg(not(feature = "cc-cedict"))]
-        DictionaryKind::CcCedict => Err(LinderaErrorKind::Dictionary
+        DictionaryKind::CcCedict => Err(LinderaErrorKind::FeatureDisabled
             .with_error(anyhow::anyhow!("CC-CEDICT feature is not enabled"))),
     }
 }

--- a/lindera/src/token_filter/mapping.rs
+++ b/lindera/src/token_filter/mapping.rs
@@ -32,7 +32,7 @@ impl MappingTokenFilter {
         }
 
         let data = DoubleArrayBuilder::build(&keyset).ok_or_else(|| {
-            LinderaErrorKind::Io.with_error(anyhow::anyhow!("DoubleArray build error."))
+            LinderaErrorKind::Build.with_error(anyhow::anyhow!("DoubleArray build error."))
         })?;
 
         let trie = DoubleArray::new(data);


### PR DESCRIPTION
  refactor: Improve error handling with descriptive contexts and reorganize error types

  - Reorganize LinderaErrorKind enum:
    - Add FeatureDisabled for feature-related errors
    - Consolidate Compress/Decompress into Compression
    - Remove unused error kinds (Load, Source, Token)
    - Fix misused error kinds (Io→Build for DoubleArray, Dictionary→FeatureDisabled for features)

  - Enhance error handling throughout the codebase:
    - Add descriptive context messages to all error sites
    - Include file paths, line numbers, and data types in error messages
    - Remove unnecessary anyhow::anyhow!() wrapping
    - Improve debugging experience with detailed error contexts

  - Standardize struct naming conventions:
    - Rename EmbeddedLoader to dictionary-specific names (EmbeddedIPADICLoader, etc.)
    - Use consistent uppercase for acronyms (IPADIC, UniDic, etc.)
    - Remove redundant load() methods from EmbeddedLoader impls

  These changes significantly improve error diagnostics and make debugging easier
  by providing clear, contextual information about what operation failed and why.