### PR TITLE
Remove hardcoded unk_fields_num parameter from dictionary metadata

### DIFF
--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -23,12 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "cc-cedict".to_string(), // Dictionary name
         "UTF-8".to_string(),     // Encoding for CC-CEDICT
         Algorithm::Deflate,      // Compression algorithm
-        3,                       // Number of fields in simple user dictionary
         -10000,                  // Default word cost
         0,                       // Default left context ID
         0,                       // Default right context ID
         "*".to_string(),         // Default field value
-        12,                      // Detailed user dictionary fields number
         10,                      // Unknown fields number
         true,                    // flexible_csv is true for CC-CEDICT
         true,                    // skip_invalid_cost_or_id is true for CC-CEDICT

--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         0,                       // Default left context ID
         0,                       // Default right context ID
         "*".to_string(),         // Default field value
-        10,                      // Unknown fields number
         true,                    // flexible_csv is true for CC-CEDICT
         true,                    // skip_invalid_cost_or_id is true for CC-CEDICT
         false,                   // normalize_details

--- a/lindera-cc-cedict/src/metadata.rs
+++ b/lindera-cc-cedict/src/metadata.rs
@@ -24,7 +24,6 @@ impl CcCedictMetadata {
             0,
             0,
             "*".to_string(),
-            10,
             true,  // flexible_csv is true for CC-CEDICT
             true,  // skip_invalid_cost_or_id is true for CC-CEDICT
             false, // normalize_details

--- a/lindera-cc-cedict/src/metadata.rs
+++ b/lindera-cc-cedict/src/metadata.rs
@@ -20,12 +20,10 @@ impl CcCedictMetadata {
             DICTIONARY_NAME.to_string(),
             DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
-            3,
             -10000,
             0,
             0,
             "*".to_string(),
-            12,
             10,
             true,  // flexible_csv is true for CC-CEDICT
             true,  // skip_invalid_cost_or_id is true for CC-CEDICT

--- a/lindera-dictionary/src/dictionary/metadata.rs
+++ b/lindera-dictionary/src/dictionary/metadata.rs
@@ -11,21 +11,19 @@ const DEFAULT_FIELD_VALUE: &str = "*";
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Metadata {
-    pub name: String,                      // Name of the dictionary
-    pub encoding: String,                  // Character encoding
-    pub compress_algorithm: Algorithm,     // Compression algorithm
-    pub user_dictionary_fields_num: usize, // Number of fields in simple user dictionary
-    pub default_word_cost: i16,            // Word cost for simple user dictionary
-    pub default_left_context_id: u16,      // Context ID for simple user dictionary
-    pub default_right_context_id: u16,     // Context ID for simple user dictionary
-    pub default_field_value: String,       // Default value for fields in simple user dictionary
-    pub dictionary_fields_num: usize,      // Number of fields in detailed user dictionary
-    pub unk_fields_num: usize,             // Number of fields in unknown dictionary
-    pub flexible_csv: bool,                // Handle CSV columns flexibly
-    pub skip_invalid_cost_or_id: bool,     // Skip invalid cost or ID
-    pub normalize_details: bool,           // Normalize characters
-    pub dictionary_schema: Schema,         // Schema for the dictionary
-    pub user_dictionary_schema: Schema,    // Schema for user dictionary
+    pub name: String,                   // Name of the dictionary
+    pub encoding: String,               // Character encoding
+    pub compress_algorithm: Algorithm,  // Compression algorithm
+    pub default_word_cost: i16,         // Word cost for simple user dictionary
+    pub default_left_context_id: u16,   // Context ID for simple user dictionary
+    pub default_right_context_id: u16,  // Context ID for simple user dictionary
+    pub default_field_value: String,    // Default value for fields in simple user dictionary
+    pub unk_fields_num: usize,          // Number of fields in unknown dictionary
+    pub flexible_csv: bool,             // Handle CSV columns flexibly
+    pub skip_invalid_cost_or_id: bool,  // Skip invalid cost or ID
+    pub normalize_details: bool,        // Normalize characters
+    pub dictionary_schema: Schema,      // Schema for the dictionary
+    pub user_dictionary_schema: Schema, // Schema for user dictionary
 }
 
 impl Default for Metadata {
@@ -35,12 +33,10 @@ impl Default for Metadata {
             "default".to_string(),
             "UTF-8".to_string(),
             DEFAULT_COMPRESS_ALGORITHM,
-            3,
             DEFAULT_WORD_COST,
             DEFAULT_LEFT_CONTEXT_ID,
             DEFAULT_RIGHT_CONTEXT_ID,
             DEFAULT_FIELD_VALUE.to_string(),
-            13,
             11,
             false,
             false,
@@ -61,12 +57,10 @@ impl Metadata {
         name: String,
         encoding: String,
         compress_algorithm: Algorithm,
-        simple_userdic_fields_num: usize,
         simple_word_cost: i16,
         default_left_context_id: u16,
         default_right_context_id: u16,
         default_field_value: String,
-        detailed_userdic_fields_num: usize,
         unk_fields_num: usize,
         flexible_csv: bool,
         skip_invalid_cost_or_id: bool,
@@ -77,12 +71,10 @@ impl Metadata {
         Self {
             encoding,
             compress_algorithm,
-            user_dictionary_fields_num: simple_userdic_fields_num,
             default_word_cost: simple_word_cost,
             default_left_context_id,
             default_right_context_id,
             default_field_value,
-            dictionary_fields_num: detailed_userdic_fields_num,
             unk_fields_num,
             dictionary_schema: schema,
             name,
@@ -173,12 +165,10 @@ mod tests {
             "TestDict".to_string(),
             "UTF-8".to_string(),
             Algorithm::Deflate,
-            3,
             -10000,
             0,
             0,
             "*".to_string(),
-            21,
             10,
             false,
             false,

--- a/lindera-dictionary/src/dictionary/metadata.rs
+++ b/lindera-dictionary/src/dictionary/metadata.rs
@@ -18,7 +18,6 @@ pub struct Metadata {
     pub default_left_context_id: u16,   // Context ID for simple user dictionary
     pub default_right_context_id: u16,  // Context ID for simple user dictionary
     pub default_field_value: String,    // Default value for fields in simple user dictionary
-    pub unk_fields_num: usize,          // Number of fields in unknown dictionary
     pub flexible_csv: bool,             // Handle CSV columns flexibly
     pub skip_invalid_cost_or_id: bool,  // Skip invalid cost or ID
     pub normalize_details: bool,        // Normalize characters
@@ -37,7 +36,6 @@ impl Default for Metadata {
             DEFAULT_LEFT_CONTEXT_ID,
             DEFAULT_RIGHT_CONTEXT_ID,
             DEFAULT_FIELD_VALUE.to_string(),
-            11,
             false,
             false,
             false,
@@ -61,7 +59,6 @@ impl Metadata {
         default_left_context_id: u16,
         default_right_context_id: u16,
         default_field_value: String,
-        unk_fields_num: usize,
         flexible_csv: bool,
         skip_invalid_cost_or_id: bool,
         normalize_details: bool,
@@ -75,7 +72,6 @@ impl Metadata {
             default_left_context_id,
             default_right_context_id,
             default_field_value,
-            unk_fields_num,
             dictionary_schema: schema,
             name,
             flexible_csv,
@@ -169,7 +165,6 @@ mod tests {
             0,
             0,
             "*".to_string(),
-            10,
             false,
             false,
             false,

--- a/lindera-dictionary/src/dictionary/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/unknown_dictionary.rs
@@ -114,15 +114,11 @@ fn make_costs_array(entries: &[UnknownDictionaryEntry]) -> Vec<WordEntry> {
         .collect()
 }
 
-pub fn parse_unk(
-    categories: &[String],
-    file_content: &str,
-    expected_fields_len: usize,
-) -> LinderaResult<UnknownDictionary> {
+pub fn parse_unk(categories: &[String], file_content: &str) -> LinderaResult<UnknownDictionary> {
     let mut unknown_dict_entries = Vec::new();
     for line in file_content.lines() {
         let fields: Vec<&str> = line.split(',').collect::<Vec<&str>>();
-        let entry = parse_dictionary_entry(&fields[..], expected_fields_len)?;
+        let entry = parse_dictionary_entry(&fields[..], fields.len())?;
         unknown_dict_entries.push(entry);
     }
 
@@ -133,6 +129,3 @@ pub fn parse_unk(
         costs,
     })
 }
-
-#[cfg(test)]
-mod tests {}

--- a/lindera-dictionary/src/dictionary_builder.rs
+++ b/lindera-dictionary/src/dictionary_builder.rs
@@ -122,8 +122,8 @@ impl DictionaryBuilder {
         let default_field_value = self.metadata.default_field_value.clone();
 
         UserDictionaryBuilderOptions::default()
-            .user_dictionary_fields_num(self.metadata.user_dictionary_fields_num)
-            .dictionary_fields_num(self.metadata.dictionary_fields_num)
+            .user_dictionary_fields_num(self.metadata.user_dictionary_schema.field_count())
+            .dictionary_fields_num(self.metadata.dictionary_schema.field_count())
             .default_word_cost(self.metadata.default_word_cost)
             .default_left_context_id(self.metadata.default_left_context_id)
             .default_right_context_id(self.metadata.default_right_context_id)

--- a/lindera-dictionary/src/dictionary_builder.rs
+++ b/lindera-dictionary/src/dictionary_builder.rs
@@ -71,7 +71,6 @@ impl DictionaryBuilder {
         UnknownDictionaryBuilderOptions::default()
             .encoding(self.metadata.encoding.clone())
             .compress_algorithm(self.metadata.compress_algorithm)
-            .unk_fields_num(self.metadata.unk_fields_num)
             .builder()
             .unwrap()
             .build(input_dir, chardef, output_dir)

--- a/lindera-dictionary/src/dictionary_builder/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary_builder/unknown_dictionary.rs
@@ -21,8 +21,6 @@ pub struct UnknownDictionaryBuilder {
     encoding: Cow<'static, str>,
     #[builder(default = "Algorithm::Deflate")]
     compress_algorithm: Algorithm,
-    #[builder(default = "11")]
-    unk_fields_num: usize,
 }
 
 impl UnknownDictionaryBuilder {
@@ -35,7 +33,7 @@ impl UnknownDictionaryBuilder {
         let unk_data_path = input_dir.join("unk.def");
         debug!("reading {unk_data_path:?}");
         let unk_data = read_file_with_encoding(&unk_data_path, &self.encoding)?;
-        let unknown_dictionary = parse_unk(chardef.categories(), &unk_data, self.unk_fields_num)?;
+        let unknown_dictionary = parse_unk(chardef.categories(), &unk_data)?;
 
         let mut unk_buffer = Vec::new();
         bincode::serde::encode_into_std_write(

--- a/lindera-dictionary/src/dictionary_loader/metadata.rs
+++ b/lindera-dictionary/src/dictionary_loader/metadata.rs
@@ -107,7 +107,6 @@ mod tests {
         assert_eq!(loaded_metadata.encoding, "UTF-8");
         assert_eq!(loaded_metadata.default_word_cost, -10000);
         assert_eq!(loaded_metadata.default_left_context_id, 1288);
-        assert_eq!(loaded_metadata.unk_fields_num, 11);
         // Cleanup
         std::fs::remove_dir_all(&temp_path).ok();
     }

--- a/lindera-dictionary/src/dictionary_loader/metadata.rs
+++ b/lindera-dictionary/src/dictionary_loader/metadata.rs
@@ -107,8 +107,6 @@ mod tests {
         assert_eq!(loaded_metadata.encoding, "UTF-8");
         assert_eq!(loaded_metadata.default_word_cost, -10000);
         assert_eq!(loaded_metadata.default_left_context_id, 1288);
-        assert_eq!(loaded_metadata.user_dictionary_fields_num, 3);
-        assert_eq!(loaded_metadata.dictionary_fields_num, 13);
         assert_eq!(loaded_metadata.unk_fields_num, 11);
         // Cleanup
         std::fs::remove_dir_all(&temp_path).ok();

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -23,12 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "ipadic-neologd".to_string(), // Dictionary name
         "UTF-8".to_string(),          // Encoding for IPADIC NEologd
         Algorithm::Deflate,           // Compression algorithm
-        3,                            // Number of fields in simple user dictionary
         -10000,                       // Default word cost
         0,                            // Default left context ID
         0,                            // Default right context ID
         "*".to_string(),              // Default field value
-        13,                           // Detailed user dictionary fields number
         11,                           // Unknown fields number
         false,                        // flexible_csv
         false,                        // skip_invalid_cost_or_id

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         0,                            // Default left context ID
         0,                            // Default right context ID
         "*".to_string(),              // Default field value
-        11,                           // Unknown fields number
         false,                        // flexible_csv
         false,                        // skip_invalid_cost_or_id
         true,                         // normalize_details is true for IPAdic-NEologd

--- a/lindera-ipadic-neologd/src/metadata.rs
+++ b/lindera-ipadic-neologd/src/metadata.rs
@@ -24,7 +24,6 @@ impl IPADICNEologdMetadata {
             0,
             0,
             "*".to_string(),
-            11,
             true,  // flexible_csv
             false, // skip_invalid_cost_or_id
             true,  // normalize_details is true for IPAdic-NEologd

--- a/lindera-ipadic-neologd/src/metadata.rs
+++ b/lindera-ipadic-neologd/src/metadata.rs
@@ -20,12 +20,10 @@ impl IPADICNEologdMetadata {
             DICTIONARY_NAME.to_string(),
             DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
-            3,
             -10000,
             0,
             0,
             "*".to_string(),
-            13,
             11,
             true,  // flexible_csv
             false, // skip_invalid_cost_or_id

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         0,                    // Default left context ID
         0,                    // Default right context ID
         "*".to_string(),      // Default field value
-        11,                   // Unknown fields number
         false,                // flexible_csv
         false,                // skip_invalid_cost_or_id
         true,                 // normalize_details

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -23,12 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "ipadic".to_string(), // Dictionary name
         "EUC-JP".to_string(), // Encoding for IPADIC
         Algorithm::Deflate,   // Compression algorithm
-        3,                    // Number of fields in simple user dictionary
         -10000,               // Default word cost
         0,                    // Default left context ID
         0,                    // Default right context ID
         "*".to_string(),      // Default field value
-        13,                   // Detailed user dictionary fields number
         11,                   // Unknown fields number
         false,                // flexible_csv
         false,                // skip_invalid_cost_or_id

--- a/lindera-ipadic/src/metadata.rs
+++ b/lindera-ipadic/src/metadata.rs
@@ -20,12 +20,10 @@ impl IPADICMetadata {
             DICTIONARY_NAME.to_string(),
             DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
-            3,
             -10000,
             0,
             0,
             "*".to_string(),
-            13,
             11,
             true,  // flexible_csv
             false, // skip_invalid_cost_or_id

--- a/lindera-ipadic/src/metadata.rs
+++ b/lindera-ipadic/src/metadata.rs
@@ -24,7 +24,6 @@ impl IPADICMetadata {
             0,
             0,
             "*".to_string(),
-            11,
             true,  // flexible_csv
             false, // skip_invalid_cost_or_id
             true,  // normalize_details is true for IPAdic

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         0,                    // Default left context ID
         0,                    // Default right context ID
         "*".to_string(),      // Default field value
-        12,                   // Unknown fields number
         false,                // flexible_csv
         false,                // skip_invalid_cost_or_id
         false,                // normalize_details

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -23,12 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "ko-dic".to_string(), // Dictionary name
         "UTF-8".to_string(),  // Encoding for Ko-Dic
         Algorithm::Deflate,   // Compression algorithm
-        3,                    // Number of fields in simple user dictionary
         -10000,               // Default word cost
         0,                    // Default left context ID
         0,                    // Default right context ID
         "*".to_string(),      // Default field value
-        12,                   // Detailed user dictionary fields number
         12,                   // Unknown fields number
         false,                // flexible_csv
         false,                // skip_invalid_cost_or_id

--- a/lindera-ko-dic/src/metadata.rs
+++ b/lindera-ko-dic/src/metadata.rs
@@ -24,7 +24,6 @@ impl KoDicMetadata {
             0,
             0,
             "*".to_string(),
-            12,
             false, // flexible_csv
             false, // skip_invalid_cost_or_id
             false, // normalize_details

--- a/lindera-ko-dic/src/metadata.rs
+++ b/lindera-ko-dic/src/metadata.rs
@@ -20,12 +20,10 @@ impl KoDicMetadata {
             DICTIONARY_NAME.to_string(),
             DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
-            3,
             -10000,
             0,
             0,
             "*".to_string(),
-            12,
             12,
             false, // flexible_csv
             false, // skip_invalid_cost_or_id

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         0,                    // Default left context ID
         0,                    // Default right context ID
         "*".to_string(),      // Default field value
-        10,                   // Unknown fields number
         true,                 // flexible_csv
         false,                // skip_invalid_cost_or_id
         false,                // normalize_details

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -23,12 +23,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         "unidic".to_string(), // Dictionary name
         "UTF-8".to_string(),  // Encoding for UniDic
         Algorithm::Deflate,   // Compression algorithm
-        3,                    // Number of fields in simple user dictionary
         -10000,               // Default word cost=
         0,                    // Default left context ID
         0,                    // Default right context ID
         "*".to_string(),      // Default field value
-        21,                   // Detailed user dictionary fields number
         10,                   // Unknown fields number
         true,                 // flexible_csv
         false,                // skip_invalid_cost_or_id

--- a/lindera-unidic/src/metadata.rs
+++ b/lindera-unidic/src/metadata.rs
@@ -20,12 +20,10 @@ impl UniDicMetadata {
             DICTIONARY_NAME.to_string(),
             DICTIONARY_ENCODING.to_string(),
             Algorithm::Deflate,
-            3,
             -10000,
             0,
             0,
             "*".to_string(),
-            21,
             10,
             false, // flexible_csv
             false, // skip_invalid_cost_or_id

--- a/lindera-unidic/src/metadata.rs
+++ b/lindera-unidic/src/metadata.rs
@@ -24,7 +24,6 @@ impl UniDicMetadata {
             0,
             0,
             "*".to_string(),
-            10,
             false, // flexible_csv
             false, // skip_invalid_cost_or_id
             false, // normalize_details


### PR DESCRIPTION
refactor: Remove hardcoded unk_fields_num parameter from dictionary metadata

- Change to dynamically determine the number of fields in unknown dictionary
- Remove unk_fields_num parameter from Metadata
- Simplify parse_unk function to use actual field count
- Apply to all dictionary implementations (IPADIC, UniDic, Ko-Dic, CC-CEDICT, IPADIC-NEologd)

This change makes unknown dictionary processing more flexible and  improves handling of different dictionary format variations.