### PR TITLE
Fix download retry logic to handle connection reset errors properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,19 +32,19 @@ bench: ## Run all benchmarks
 	@echo "🚀 Running all Lindera benchmarks..."
 	@echo ""
 	@echo "📊 Running IPADIC benchmark..."
-	(cd lindera && cargo bench --bench bench_ipadic --features ipadic,embedded-ipadic) || true
+	(cd lindera && cargo bench --bench=bench_ipadic --features=embedded-ipadic) || true
 	@echo ""
 	@echo "📊 Running IPADIC-NEologd benchmark..."
-	(cd lindera && cargo bench --bench bench_ipadic_neologd --features ipadic-neologd,embedded-ipadic-neologd) || true
+	(cd lindera && cargo bench --bench=bench_ipadic_neologd --features=embedded-ipadic-neologd) || true
 	@echo ""
 	@echo "📊 Running UniDic benchmark..."
-	(cd lindera && cargo bench --bench bench_unidic --features unidic,embedded-unidic) || true
+	(cd lindera && cargo bench --bench=bench_unidic --features=embedded-unidic) || true
 	@echo ""
 	@echo "📊 Running KO-DIC benchmark..."
-	(cd lindera && cargo bench --bench bench_ko_dic --features ko-dic,embedded-ko-dic) || true
+	(cd lindera && cargo bench --bench=bench_ko_dic --features=embedded-ko-dic) || true
 	@echo ""
 	@echo "📊 Running CC-CEDICT benchmark..."
-	(cd lindera && cargo bench --bench bench_cc_cedict --features cc-cedict,embedded-cc-cedict) || true
+	(cd lindera && cargo bench --bench=bench_cc_cedict --features=embedded-cc-cedict) || true
 	@echo ""
 	@echo ""
 	@echo "✅ All benchmarks completed!"

--- a/lindera-cc-cedict/src/lib.rs
+++ b/lindera-cc-cedict/src/lib.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "cc-cedict")]
+#[cfg(feature = "embedded-cc-cedict")]
 pub mod metadata;
-#[cfg(feature = "cc-cedict")]
+#[cfg(feature = "embedded-cc-cedict")]
 pub mod schema;
 
 #[cfg(feature = "embedded-cc-cedict")]

--- a/lindera-cli/Cargo.toml
+++ b/lindera-cli/Cargo.toml
@@ -12,20 +12,6 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ipadic = ["lindera/ipadic"] # Enable Japanese dictionary (IPADIC)
-ipadic-neologd = [
-    "lindera/ipadic-neologd",
-] # Enable Japanese dictionary (IPADIC NEologd)
-unidic = ["lindera/unidic"] # Enable Japanese dictionary (UniDic)
-ko-dic = ["lindera/ko-dic"] # Enable Korean dictionary (ko-dic)
-cc-cedict = ["lindera/cc-cedict"] # Enamble Chinese dictionary (CC-CEDICT)
-
-cjk = ["lindera/cjk"] # Enable CJK dictionaries (IPADIC, ko-dic, CC-CEDICT)
-cjk2 = ["lindera/cjk2"] # Enable CJK dictionaries (UniDic, ko-dic, CC-CEDICT)
-cjk3 = [
-    "lindera/cjk3",
-] # Enable CJK dictionaries (IPADIC NEologd, ko-dic, CC-CEDICT)
-
 embedded-ipadic = [
     "lindera/embedded-ipadic",
 ] # Embed IPADIC dictionary in the binary

--- a/lindera-ipadic-neologd/src/lib.rs
+++ b/lindera-ipadic-neologd/src/lib.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "ipadic-neologd")]
+#[cfg(feature = "embedded-ipadic-neologd")]
 pub mod metadata;
-#[cfg(feature = "ipadic-neologd")]
+#[cfg(feature = "embedded-ipadic-neologd")]
 pub mod schema;
 
 #[cfg(feature = "embedded-ipadic-neologd")]

--- a/lindera-ipadic/src/lib.rs
+++ b/lindera-ipadic/src/lib.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "ipadic")]
+#[cfg(feature = "embedded-ipadic")]
 pub mod metadata;
-#[cfg(feature = "ipadic")]
+#[cfg(feature = "embedded-ipadic")]
 pub mod schema;
 
 #[cfg(feature = "embedded-ipadic")]

--- a/lindera-ko-dic/src/lib.rs
+++ b/lindera-ko-dic/src/lib.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "ko-dic")]
+#[cfg(feature = "embedded-ko-dic")]
 pub mod metadata;
-#[cfg(feature = "ko-dic")]
+#[cfg(feature = "embedded-ko-dic")]
 pub mod schema;
 
 #[cfg(feature = "embedded-ko-dic")]

--- a/lindera-unidic/src/lib.rs
+++ b/lindera-unidic/src/lib.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "unidic")]
+#[cfg(feature = "embedded-unidic")]
 pub mod metadata;
-#[cfg(feature = "unidic")]
+#[cfg(feature = "embedded-unidic")]
 pub mod schema;
 
 #[cfg(feature = "embedded-unidic")]

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -12,50 +12,19 @@ categories = ["text-processing"]
 license = "MIT"
 
 [features]
-ipadic = ["lindera-ipadic/ipadic"] # Enable Japanese dictionary (IPADIC)
-ipadic-neologd = [
-    "lindera-ipadic-neologd/ipadic-neologd",
-] # Enable Japanese dictionary (IPADIC NEologd)
-unidic = ["lindera-unidic/unidic"] # Enable Japanese dictionary (UniDic)
-ko-dic = ["lindera-ko-dic/ko-dic"] # Enable Korean dictionary (ko-dic)
-cc-cedict = [
-    "lindera-cc-cedict/cc-cedict",
-] # Enable Chinese dictionary (CC-CEDICT)
-
-cjk = [
-    "ipadic",
-    "ko-dic",
-    "cc-cedict",
-] # Enable CJK dictionaries (IPADIC, ko-dic, CC-CEDICT)
-cjk2 = [
-    "unidic",
-    "ko-dic",
-    "cc-cedict",
-] # Enable CJK dictionaries (UniDic, ko-dic, CC-CEDICT)
-cjk3 = [
-    "ipadic-neologd",
-    "ko-dic",
-    "cc-cedict",
-] # Enable CJK dictionaries (IPADIC NEologd, ko-dic, CC-CEDICT)
-
 embedded-ipadic = [
-    "ipadic",
     "lindera-ipadic/embedded-ipadic",
 ] # Embed IPADIC dictionary in the binary
 embedded-ipadic-neologd = [
-    "ipadic-neologd",
     "lindera-ipadic-neologd/embedded-ipadic-neologd",
 ] # Embed IPADIC-NEologd dictionary in the binary
 embedded-unidic = [
-    "unidic",
     "lindera-unidic/embedded-unidic",
 ] # Embed UniDic dictionary in the binary
 embedded-ko-dic = [
-    "ko-dic",
     "lindera-ko-dic/embedded-ko-dic",
 ] # Embed ko-dic dictionary in the binary
 embedded-cc-cedict = [
-    "cc-cedict",
     "lindera-cc-cedict/embedded-cc-cedict",
 ] # Embed CC-CEDICT dictionary in the binary
 
@@ -122,24 +91,24 @@ once_cell.workspace = true
 [[bench]]
 name = "bench_ipadic"
 harness = false
-required-features = ["ipadic"]
+required-features = ["embedded-ipadic"]
 
 [[bench]]
 name = "bench_unidic"
 harness = false
-required-features = ["unidic"]
+required-features = ["embedded-unidic"]
 
 [[bench]]
 name = "bench_ko_dic"
 harness = false
-required-features = ["ko-dic"]
+required-features = ["embedded-ko-dic"]
 
 [[bench]]
 name = "bench_cc_cedict"
 harness = false
-required-features = ["cc-cedict"]
+required-features = ["embedded-cc-cedict"]
 
 [[bench]]
 name = "bench_ipadic_neologd"
 harness = false
-required-features = ["ipadic-neologd"]
+required-features = ["embedded-ipadic-neologd"]

--- a/lindera/benches/bench_ipadic.rs
+++ b/lindera/benches/bench_ipadic.rs
@@ -126,7 +126,7 @@ fn bench_tokenize_long_text_ipadic(c: &mut Criterion) {
     });
 }
 
-#[cfg(feature = "ipadic")]
+#[cfg(feature = "embedded-ipadic")]
 fn bench_tokenize_details_long_text_ipadic(c: &mut Criterion) {
     let mut long_text_file = BufReader::new(
         File::open(
@@ -153,7 +153,7 @@ fn bench_tokenize_details_long_text_ipadic(c: &mut Criterion) {
     });
 }
 
-#[cfg(feature = "ipadic")]
+#[cfg(feature = "embedded-ipadic")]
 criterion_group!(
     benches,
     bench_constructor_ipadic,
@@ -164,10 +164,10 @@ criterion_group!(
     bench_tokenize_details_long_text_ipadic,
 );
 
-#[cfg(feature = "ipadic")]
+#[cfg(feature = "embedded-ipadic")]
 criterion_main!(benches);
 
-#[cfg(not(feature = "ipadic"))]
+#[cfg(not(feature = "embedded-ipadic"))]
 fn main() {
-    println!("IPADIC feature is not enabled");
+    println!("Embedded IPADIC feature is not enabled");
 }

--- a/lindera/benches/bench_ipadic_neologd.rs
+++ b/lindera/benches/bench_ipadic_neologd.rs
@@ -39,7 +39,7 @@ fn bench_constructor_with_simple_userdic_ipadic_neologd(c: &mut Criterion) {
 
             let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("../resources")
-                .join("ipadic-neologd-metadata.json");
+                .join("ipadic-neologd_metadata.json");
             let metadata: Metadata = serde_json::from_reader(
                 File::open(metadata_file)
                     .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))
@@ -81,7 +81,7 @@ fn bench_tokenize_with_simple_userdic_ipadic_neologd(c: &mut Criterion) {
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../resources")
-        .join("ipadic-neologd-metadata.json");
+        .join("ipadic-neologd_metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/examples/tokenize.rs
+++ b/lindera/examples/tokenize.rs
@@ -14,7 +14,7 @@ fn main() -> LinderaResult<()> {
 
         let text = "関西国際空港限定トートバッグ";
         let mut tokens = tokenizer.tokenize(text)?;
-        println!("text:\t{}", text);
+        println!("text:\t{text}");
         for token in tokens.iter_mut() {
             let details = token.details().join(",");
             println!("token:\t{}\t{}", token.text.as_ref(), details);

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -260,11 +260,11 @@ impl Segmenter {
 mod tests {
     #[allow(unused_imports)]
     #[cfg(any(
-        feature = "ipadic",
-        feature = "ipadic-neologd",
-        feature = "unidic",
-        feature = "ko-dic",
-        feature = "cc-cedict"
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+        feature = "embedded-ko-dic",
+        feature = "embedded-cc-cedict"
     ))]
     use std::{
         fs::File,
@@ -272,32 +272,22 @@ mod tests {
         path::PathBuf,
     };
 
-    #[allow(unused_imports)]
-    #[cfg(any(
-        feature = "ipadic",
-        feature = "ipadic-neologd",
-        feature = "unidic",
-        feature = "ko-dic",
-        feature = "cc-cedict"
-    ))]
-    use crate::mode::{Mode, Penalty};
+    // use crate::mode::{Mode, Penalty};
 
     #[cfg(any(
-        feature = "ipadic",
-        feature = "unidic",
-        feature = "ko-dic",
-        feature = "cc-cedict"
+        feature = "embedded-ipadic",
+        feature = "embedded-unidic",
+        feature = "embedded-ko-dic",
+        feature = "embedded-cc-cedict"
     ))]
     use crate::segmenter::{Segmenter, SegmenterConfig};
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segmenter_config_ipadic_normal() {
         let config_str = r#"
         {
-            "dictionary": {
-                "kind": "ipadic"
-            },
+            "dictionary": "embedded://ipadic",
             "mode": "normal"
         }
         "#;
@@ -307,13 +297,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segmenter_config_ipadic_decompose() {
         let config_str = r#"
         {
-            "dictionary": {
-                "kind": "ipadic"
-            },
+            "dictionary": "embedded://ipadic",
             "mode": {
                 "decompose": {
                     "kanji_penalty_length_threshold": 2,
@@ -330,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segment_ipadic() {
         use std::borrow::Cow;
 
@@ -588,7 +576,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+    #[cfg(feature = "embedded-unidic")]
     fn test_segment_unidic() {
         use std::borrow::Cow;
 
@@ -998,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+    #[cfg(feature = "embedded-ko-dic")]
     fn test_segment_ko_dic() {
         use std::borrow::Cow;
 
@@ -1168,7 +1156,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
+    #[cfg(feature = "embedded-cc-cedict")]
     fn test_segment_cc_cedict() {
         use std::borrow::Cow;
 
@@ -1302,7 +1290,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segment_with_simple_userdic_ipadic() {
         use std::borrow::Cow;
 
@@ -1450,7 +1438,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+    #[cfg(feature = "embedded-unidic")]
     fn test_segment_with_simple_userdic_unidic() {
         use std::borrow::Cow;
 
@@ -1714,7 +1702,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+    #[cfg(feature = "embedded-ko-dic")]
     fn test_segment_with_simple_userdic_ko_dic() {
         use std::borrow::Cow;
 
@@ -1793,7 +1781,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
+    #[cfg(feature = "embedded-cc-cedict")]
     fn test_segment_with_simple_userdic_cc_cedict() {
         use std::borrow::Cow;
 
@@ -1900,7 +1888,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segment_with_simple_userdic_bin_ipadic() {
         use std::borrow::Cow;
 
@@ -2048,7 +2036,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+    #[cfg(feature = "embedded-unidic")]
     fn test_segment_with_simple_userdic_bin_unidic() {
         use std::borrow::Cow;
 
@@ -2312,7 +2300,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+    #[cfg(feature = "embedded-ko-dic")]
     fn test_segment_with_simple_userdic_bin_ko_dic() {
         use std::borrow::Cow;
 
@@ -2391,7 +2379,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "cc-cedict", feature = "embedded-cc-cedict"))]
+    #[cfg(feature = "embedded-cc-cedict")]
     fn test_segment_with_simple_userdic_bin_cc_cedict() {
         use std::borrow::Cow;
 
@@ -2498,7 +2486,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segment_with_detailed_userdic_ipadic() {
         use std::borrow::Cow;
 
@@ -2646,7 +2634,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     #[should_panic(expected = "failed to parse word cost")]
     fn test_user_dict_invalid_word_cost() {
         let userdic_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -2663,7 +2651,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     #[should_panic(expected = "user dictionary should be a CSV with 3 or 13+ fields")]
     fn test_user_dict_number_of_fields_is_11() {
         let userdic_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -2680,7 +2668,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segment_with_nomal_mode() {
         use std::borrow::Cow;
 
@@ -2750,7 +2738,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segment_with_decompose_mode() {
         use std::borrow::Cow;
 
@@ -2849,7 +2837,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_segment_with_decompose_mode_default_penalty() {
         use std::borrow::Cow;
 
@@ -2942,7 +2930,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_long_text() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_base_form.rs
+++ b/lindera/src/token_filter/japanese_base_form.rs
@@ -60,7 +60,7 @@ impl TokenFilter for JapaneseBaseFormTokenFilter {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     #[test]
     fn test_japanese_base_form_token_filter_apply_ipadic() {
         use std::borrow::Cow;
@@ -182,7 +182,7 @@ mod tests {
         assert_eq!(tokens[3].text, "ます");
     }
 
-    #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+    #[cfg(feature = "embedded-unidic")]
     #[test]
     fn test_japanese_base_form_token_filter_apply_unidic() {
         use std::borrow::Cow;

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -198,7 +198,7 @@ impl TokenFilter for JapaneseCompoundWordTokenFilter {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     #[test]
     fn test_japanese_compound_word_token_filter_config_ipadic() {
         use crate::token_filter::japanese_compound_word::JapaneseCompoundWordTokenFilterConfig;
@@ -217,7 +217,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     #[test]
     fn test_japanese_compound_word_token_filter_ipadic() {
         use crate::token_filter::japanese_compound_word::{
@@ -241,7 +241,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_compound_word_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_kana.rs
+++ b/lindera/src/token_filter/japanese_kana.rs
@@ -133,7 +133,11 @@ impl TokenFilter for JapaneseKanaTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_kana_token_filter_config_hiragana() {
         use crate::token_filter::japanese_kana::JapaneseKanaTokenFilterConfig;
 
@@ -147,7 +151,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_kana_token_filter_config_katakana() {
         use crate::token_filter::japanese_kana::JapaneseKanaTokenFilterConfig;
 
@@ -161,7 +169,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_kana_token_filter_hiragana() {
         use crate::token_filter::japanese_kana::{
             JapaneseKanaTokenFilter, JapaneseKanaTokenFilterConfig,
@@ -179,7 +191,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_kana_token_filter_from_slice_katakana() {
         use crate::token_filter::japanese_kana::{
             JapaneseKanaTokenFilter, JapaneseKanaTokenFilterConfig,
@@ -197,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_kana_token_filter_apply_katakana_to_hiragana_ipadic() {
         use std::borrow::Cow;
 
@@ -292,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_kana_token_filter_apply_hiragana_to_katakana_ipadic() {
         use std::borrow::Cow;
 
@@ -422,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_kana_token_filter_apply_katakana_to_katakana_ipadic() {
         use std::borrow::Cow;
 
@@ -517,7 +533,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_kana_token_filter_apply_hiragana_to_hiragana_ipadic() {
         use std::borrow::Cow;
 
@@ -647,7 +663,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_kana_token_filter_apply_mixed_to_katakana_ipadic() {
         use std::borrow::Cow;
 
@@ -777,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_kana_token_filter_applymixed_to_hiragana_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_katakana_stem.rs
+++ b/lindera/src/token_filter/japanese_katakana_stem.rs
@@ -120,7 +120,11 @@ fn is_katakana(text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_katakana_stem_token_filter_config() {
         use crate::token_filter::japanese_katakana_stem::JapaneseKatakanaStemTokenFilterConfig;
 
@@ -135,7 +139,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_katakana_stem_token_filter_config_zero() {
         use crate::token_filter::japanese_katakana_stem::JapaneseKatakanaStemTokenFilterConfig;
 
@@ -151,7 +159,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_katakana_stem_token_filter() {
         use crate::token_filter::japanese_katakana_stem::{
             JapaneseKatakanaStemTokenFilter, JapaneseKatakanaStemTokenFilterConfig,
@@ -170,7 +182,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_katakana_stem_token_filter_zero() {
         use crate::token_filter::japanese_katakana_stem::{
             JapaneseKatakanaStemTokenFilter, JapaneseKatakanaStemTokenFilterConfig,
@@ -189,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_katakana_stem_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_keep_tags.rs
+++ b/lindera/src/token_filter/japanese_keep_tags.rs
@@ -116,7 +116,7 @@ impl TokenFilter for JapaneseKeepTagsTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_keep_tags_token_filter_config() {
         use crate::token_filter::japanese_keep_tags::JapaneseKeepTagsTokenFilterConfig;
 
@@ -170,7 +170,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_keep_tags_token_filter() {
         use crate::token_filter::japanese_keep_tags::{
             JapaneseKeepTagsTokenFilter, JapaneseKeepTagsTokenFilterConfig,
@@ -228,7 +228,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_keep_tags_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_number.rs
+++ b/lindera/src/token_filter/japanese_number.rs
@@ -276,13 +276,21 @@ fn to_arabic_numerals(from_str: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     use crate::token_filter::japanese_number::{
         JapaneseNumberTokenFilter, JapaneseNumberTokenFilterConfig,
     };
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_to_number_str() {
         use std::str::FromStr;
 
@@ -825,7 +833,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_number_token_filter_config() {
         {
             let config_str = r#"
@@ -862,7 +874,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "ipadic", feature = "ipadic-neologd", feature = "unidic",))]
+    #[cfg(any(
+        feature = "embedded-ipadic",
+        feature = "embedded-ipadic-neologd",
+        feature = "embedded-unidic",
+    ))]
     fn test_japanese_number_token_filter() {
         {
             // test empty tags
@@ -892,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_number_token_filter_apply_numbers_ipadic() {
         use std::borrow::Cow;
 
@@ -1070,7 +1086,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_number_token_filter_apply_empty_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/japanese_reading_form.rs
+++ b/lindera/src/token_filter/japanese_reading_form.rs
@@ -90,7 +90,7 @@ impl TokenFilter for JapaneseReadingFormTokenFilter {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     #[test]
     fn test_japanese_reading_form_token_filter_apply_ipadic() {
         use std::borrow::Cow;
@@ -177,7 +177,7 @@ mod tests {
         assert_eq!(&tokens[2].text, "トートバッグ");
     }
 
-    #[cfg(all(feature = "unidic", feature = "embedded-unidic"))]
+    #[cfg(feature = "embedded-unidic")]
     #[test]
     fn test_japanese_reading_form_token_filter_apply_unidic() {
         use std::borrow::Cow;

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -119,13 +119,13 @@ impl TokenFilter for JapaneseStopTagsTokenFilter {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     use crate::token_filter::japanese_stop_tags::{
         JapaneseStopTagsTokenFilter, JapaneseStopTagsTokenFilterConfig,
     };
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_stop_tags_token_filter_config() {
         let config_str = r#"
             {
@@ -163,7 +163,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_stop_tagss_token_filter() {
         let config_str = r#"
             {
@@ -203,7 +203,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_japanese_stop_tags_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/keep_words.rs
+++ b/lindera/src/token_filter/keep_words.rs
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_keep_words_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/korean_keep_tags.rs
+++ b/lindera/src/token_filter/korean_keep_tags.rs
@@ -100,13 +100,11 @@ impl TokenFilter for KoreanKeepTagsTokenFilter {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "ko-dic")]
     use crate::token_filter::korean_keep_tags::{
         KoreanKeepTagsTokenFilter, KoreanKeepTagsTokenFilterConfig,
     };
 
     #[test]
-    #[cfg(feature = "ko-dic")]
     fn test_korean_keep_tags_token_filter_config() {
         let config_str = r#"
         {
@@ -120,7 +118,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ko-dic")]
     fn test_korean_keep_tags_token_filter() {
         let config_str = r#"
         {
@@ -136,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+    #[cfg(feature = "embedded-ko-dic")]
     fn test_korean_keep_tags_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/korean_reading_form.rs
+++ b/lindera/src/token_filter/korean_reading_form.rs
@@ -56,7 +56,7 @@ impl TokenFilter for KoreanReadingFormTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+    #[cfg(feature = "embedded-ko-dic")]
     fn test_korean_reading_form_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/korean_stop_tags.rs
+++ b/lindera/src/token_filter/korean_stop_tags.rs
@@ -73,13 +73,11 @@ impl TokenFilter for KoreanStopTagsTokenFilter {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "ko-dic")]
     use crate::token_filter::korean_stop_tags::{
         KoreanStopTagsTokenFilter, KoreanStopTagsTokenFilterConfig,
     };
 
     #[test]
-    #[cfg(feature = "ko-dic")]
     fn test_korean_stop_tags_token_filter_config() {
         let config_str = r#"
             {
@@ -122,7 +120,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ko-dic")]
     fn test_korean_stop_tagss_token_filter_from_slice() {
         let config_str = r#"
             {
@@ -167,7 +164,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ko-dic", feature = "embedded-ko-dic"))]
+    #[cfg(feature = "embedded-ko-dic")]
     fn test_korean_stop_tags_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/length.rs
+++ b/lindera/src/token_filter/length.rs
@@ -124,7 +124,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_length_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/lowercase.rs
+++ b/lindera/src/token_filter/lowercase.rs
@@ -48,7 +48,7 @@ impl TokenFilter for LowercaseTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_lowercase_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/mapping.rs
+++ b/lindera/src/token_filter/mapping.rs
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_mapping_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/remove_diacritical_mark.rs
+++ b/lindera/src/token_filter/remove_diacritical_mark.rs
@@ -132,7 +132,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_remove_diacritical_token_filter_apply() {
         use std::borrow::Cow;
 
@@ -205,7 +205,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_remove_diacritical_token_filter_apply_japanese() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/stop_words.rs
+++ b/lindera/src/token_filter/stop_words.rs
@@ -91,7 +91,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_stop_words_token_filter_apply_ipadic() {
         use std::borrow::Cow;
 

--- a/lindera/src/token_filter/uppercase.rs
+++ b/lindera/src/token_filter/uppercase.rs
@@ -48,7 +48,7 @@ impl TokenFilter for UppercaseTokenFilter {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg(all(feature = "ipadic", feature = "embedded-ipadic"))]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_uppercase_token_filter_apply() {
         use std::borrow::Cow;
 

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -405,7 +405,7 @@ impl Clone for Tokenizer {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     #[test]
     fn test_tokenizer_config_from_slice() {
         use std::path::PathBuf;
@@ -422,7 +422,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_tokenizer_config_clone() {
         use std::path::PathBuf;
 
@@ -440,7 +440,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "ipadic")]
+    #[cfg(feature = "embedded-ipadic")]
     fn test_tokenize_ipadic() {
         use std::borrow::Cow;
         use std::path::PathBuf;


### PR DESCRIPTION
fix: Fix download retry logic to handle connection reset errors properly

- Wrap resp.bytes().await with match to catch connection errors
- Prevent early return on network errors during download
- Ensure all retry rounds are attempted when downloads fail
- Add proper error logging for failed content downloads

This fixes the issue where connection reset errors would immediately fail the build instead of retrying with alternative URLs or retry rounds.