### PR TITLE
fix: Replace Url::to_file_path() with manual path extraction for WASM compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ log = "0.4.27"
 md5 = "0.8.0"
 memmap2 = "0.9.8"
 once_cell = "1.21.3"
+percent-encoding = "2.3.1"
 rand = { version = "0.9.2", default-features = false, features = [
     "small_rng",
 ] } # Specify `default-features` and `features` to support WebAssembly

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ fn main() -> LinderaResult<()> {
         .join("ipadic_simple_userdic.csv");
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../resources")
-        .join("ipadic_metadata.json");
+        .join("../lindera-ipadic")
+        .join("metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -63,6 +63,7 @@ byteorder.workspace = true
 csv.workspace = true
 kanaria.workspace = true
 once_cell.workspace = true
+percent-encoding.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/lindera/README.md
+++ b/lindera/README.md
@@ -104,8 +104,8 @@ fn main() -> LinderaResult<()> {
         .join("ipadic_simple_userdic.csv");
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../resources")
-        .join("ipadic_metadata.json");
+        .join("../lindera-ipadic")
+        .join("metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/benches/bench_cc_cedict.rs
+++ b/lindera/benches/bench_cc_cedict.rs
@@ -34,8 +34,8 @@ fn bench_constructor_with_simple_userdic_cc_cedict(c: &mut Criterion) {
             use lindera::error::LinderaErrorKind;
 
             let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("../resources")
-                .join("cc-cedict_metadata.json");
+                .join("../lindera-cc-cedict")
+                .join("metadata.json");
             let metadata: Metadata = serde_json::from_reader(
                 File::open(metadata_file)
                     .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))
@@ -76,8 +76,8 @@ fn bench_tokenize_with_simple_userdic_cc_cedict(c: &mut Criterion) {
     use lindera::error::LinderaErrorKind;
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../resources")
-        .join("cc-cedict_metadata.json");
+        .join("../lindera-cc-cedict")
+        .join("metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/benches/bench_ipadic.rs
+++ b/lindera/benches/bench_ipadic.rs
@@ -38,8 +38,8 @@ fn bench_constructor_with_simple_userdic_ipadic(c: &mut Criterion) {
             use lindera::error::LinderaErrorKind;
 
             let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("../resources")
-                .join("ipadic_metadata.json");
+                .join("../lindera-ipadic")
+                .join("metadata.json");
             let metadata: Metadata = serde_json::from_reader(
                 File::open(metadata_file)
                     .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))
@@ -80,8 +80,8 @@ fn bench_tokenize_with_simple_userdic_ipadic(c: &mut Criterion) {
     use lindera::error::LinderaErrorKind;
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../resources")
-        .join("ipadic_metadata.json");
+        .join("../lindera-ipadic")
+        .join("metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/benches/bench_ipadic_neologd.rs
+++ b/lindera/benches/bench_ipadic_neologd.rs
@@ -38,8 +38,8 @@ fn bench_constructor_with_simple_userdic_ipadic_neologd(c: &mut Criterion) {
             use lindera::error::LinderaErrorKind;
 
             let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("../resources")
-                .join("ipadic-neologd_metadata.json");
+                .join("../lindera-ipadic-neologd")
+                .join("metadata.json");
             let metadata: Metadata = serde_json::from_reader(
                 File::open(metadata_file)
                     .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))
@@ -80,8 +80,8 @@ fn bench_tokenize_with_simple_userdic_ipadic_neologd(c: &mut Criterion) {
     use lindera::error::LinderaErrorKind;
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../resources")
-        .join("ipadic-neologd_metadata.json");
+        .join("../lindera-ipadic-neologd")
+        .join("metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/benches/bench_ko_dic.rs
+++ b/lindera/benches/bench_ko_dic.rs
@@ -34,8 +34,8 @@ fn bench_constructor_with_simple_userdic_ko_dic(c: &mut Criterion) {
             use lindera::error::LinderaErrorKind;
 
             let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("../resources")
-                .join("ko-dic_metadata.json");
+                .join("../lindera-ko-dic")
+                .join("metadata.json");
             let metadata: Metadata = serde_json::from_reader(
                 File::open(metadata_file)
                     .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))
@@ -76,8 +76,8 @@ fn bench_tokenize_with_simple_userdic_ko_dic(c: &mut Criterion) {
     use lindera::error::LinderaErrorKind;
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../resources")
-        .join("ko-dic_metadata.json");
+        .join("../lindera-ko-dic")
+        .join("metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/benches/bench_unidic.rs
+++ b/lindera/benches/bench_unidic.rs
@@ -38,8 +38,8 @@ fn bench_constructor_with_simple_userdic_unidic(c: &mut Criterion) {
             use lindera::error::LinderaErrorKind;
 
             let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("../resources")
-                .join("unidic_metadata.json");
+                .join("../lindera-unidic")
+                .join("metadata.json");
             let metadata: Metadata = serde_json::from_reader(
                 File::open(metadata_file)
                     .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))
@@ -80,8 +80,8 @@ fn bench_tokenize_with_simple_userdic_unidic(c: &mut Criterion) {
     use lindera::error::LinderaErrorKind;
 
     let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../resources")
-        .join("unidic_metadata.json");
+        .join("../lindera-unidic")
+        .join("metadata.json");
     let metadata: Metadata = serde_json::from_reader(
         File::open(metadata_file)
             .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/examples/tokenize_with_user_dict.rs
+++ b/lindera/examples/tokenize_with_user_dict.rs
@@ -17,8 +17,8 @@ fn main() -> LinderaResult<()> {
             .join("ipadic_simple_userdic.csv");
 
         let metadata_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../resources")
-            .join("ipadic_metadata.json");
+            .join("../lindera-ipadic")
+            .join("metadata.json");
         let metadata: Metadata = serde_json::from_reader(
             File::open(metadata_file)
                 .map_err(|err| LinderaErrorKind::Io.with_error(anyhow::anyhow!(err)))

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum::IntoEnumIterator;
@@ -247,13 +248,28 @@ pub fn load_dictionary(uri: &str) -> LinderaResult<Dictionary> {
                         load_embedded_dictionary(kind)
                     }
                     DictionaryScheme::File => {
-                        let path = parsed_uri.to_file_path().map_err(|_| {
-                            LinderaErrorKind::Dictionary
-                                .with_error(anyhow::anyhow!("Invalid file path"))
-                        })?;
+                        // Extract path from file:// URL manually
+                        let path_str = parsed_uri.path();
+                        
+                        // Handle Windows paths that might start with /C:/ etc.
+                        let path_str = if cfg!(windows) && path_str.len() > 1 && path_str.starts_with('/') {
+                            &path_str[1..]
+                        } else {
+                            path_str
+                        };
+                        
+                        // Decode percent-encoded characters
+                        let decoded_path = percent_decode_str(path_str)
+                            .decode_utf8()
+                            .map_err(|e| {
+                                LinderaErrorKind::Dictionary
+                                    .with_error(anyhow::anyhow!("Invalid UTF-8 in path: {}", e))
+                            })?;
+                        
+                        let path = Path::new(decoded_path.as_ref());
 
                         // Load the file-based dictionary
-                        load_fs_dictionary(&path)
+                        load_fs_dictionary(path)
                     }
                 }
             }
@@ -292,10 +308,27 @@ pub fn load_user_dictionary(uri: &str, metadata: &Metadata) -> LinderaResult<Use
                 })?;
 
                 match scheme {
-                    DictionaryScheme::File => parsed_uri.to_file_path().map_err(|_| {
-                        LinderaErrorKind::Dictionary
-                            .with_error(anyhow::anyhow!("Invalid file path"))
-                    })?,
+                    DictionaryScheme::File => {
+                        // Extract path from file:// URL manually
+                        let path_str = parsed_uri.path();
+                        
+                        // Handle Windows paths that might start with /C:/ etc.
+                        let path_str = if cfg!(windows) && path_str.len() > 1 && path_str.starts_with('/') {
+                            &path_str[1..]
+                        } else {
+                            path_str
+                        };
+                        
+                        // Decode percent-encoded characters
+                        let decoded_path = percent_decode_str(path_str)
+                            .decode_utf8()
+                            .map_err(|e| {
+                                LinderaErrorKind::Dictionary
+                                    .with_error(anyhow::anyhow!("Invalid UTF-8 in path: {}", e))
+                            })?;
+                        
+                        PathBuf::from(decoded_path.as_ref())
+                    },
                     #[cfg(any(
                         feature = "embedded-ipadic",
                         feature = "embedded-ipadic-neologd",

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -250,22 +250,22 @@ pub fn load_dictionary(uri: &str) -> LinderaResult<Dictionary> {
                     DictionaryScheme::File => {
                         // Extract path from file:// URL manually
                         let path_str = parsed_uri.path();
-                        
+
                         // Handle Windows paths that might start with /C:/ etc.
-                        let path_str = if cfg!(windows) && path_str.len() > 1 && path_str.starts_with('/') {
-                            &path_str[1..]
-                        } else {
-                            path_str
-                        };
-                        
+                        let path_str =
+                            if cfg!(windows) && path_str.len() > 1 && path_str.starts_with('/') {
+                                &path_str[1..]
+                            } else {
+                                path_str
+                            };
+
                         // Decode percent-encoded characters
-                        let decoded_path = percent_decode_str(path_str)
-                            .decode_utf8()
-                            .map_err(|e| {
+                        let decoded_path =
+                            percent_decode_str(path_str).decode_utf8().map_err(|e| {
                                 LinderaErrorKind::Dictionary
                                     .with_error(anyhow::anyhow!("Invalid UTF-8 in path: {}", e))
                             })?;
-                        
+
                         let path = Path::new(decoded_path.as_ref());
 
                         // Load the file-based dictionary
@@ -311,24 +311,24 @@ pub fn load_user_dictionary(uri: &str, metadata: &Metadata) -> LinderaResult<Use
                     DictionaryScheme::File => {
                         // Extract path from file:// URL manually
                         let path_str = parsed_uri.path();
-                        
+
                         // Handle Windows paths that might start with /C:/ etc.
-                        let path_str = if cfg!(windows) && path_str.len() > 1 && path_str.starts_with('/') {
-                            &path_str[1..]
-                        } else {
-                            path_str
-                        };
-                        
+                        let path_str =
+                            if cfg!(windows) && path_str.len() > 1 && path_str.starts_with('/') {
+                                &path_str[1..]
+                            } else {
+                                path_str
+                            };
+
                         // Decode percent-encoded characters
-                        let decoded_path = percent_decode_str(path_str)
-                            .decode_utf8()
-                            .map_err(|e| {
+                        let decoded_path =
+                            percent_decode_str(path_str).decode_utf8().map_err(|e| {
                                 LinderaErrorKind::Dictionary
                                     .with_error(anyhow::anyhow!("Invalid UTF-8 in path: {}", e))
                             })?;
-                        
+
                         PathBuf::from(decoded_path.as_ref())
-                    },
+                    }
                     #[cfg(any(
                         feature = "embedded-ipadic",
                         feature = "embedded-ipadic-neologd",


### PR DESCRIPTION
fix: Replace Url::to_file_path() with manual path extraction for WASM compatibility

The to_file_path() method is not available in WASM environments, causing compilation failures. This change manually extracts and decodes file paths from file:// URLs using percent-encoding, ensuring compatibility with WASM targets while maintaining the same functionality.

- Add percent-encoding dependency for URL path decoding
- Replace to_file_path() calls with manual path extraction
- Handle Windows-specific path formats (e.g., /C:/)
- Properly decode percent-encoded characters in paths