### PR TITLE
Add type aliases for dictionary schema and compression types

### DIFF
--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -42,6 +42,10 @@ pub type WordId = lindera_dictionary::viterbi::WordId;
 pub type DictionaryBuilder = lindera_dictionary::dictionary_builder::DictionaryBuilder;
 pub type DictionaryConfig = Value;
 pub type UserDictionaryConfig = Value;
+pub type Schema = lindera_dictionary::dictionary::schema::Schema;
+pub type FieldDefinition = lindera_dictionary::dictionary::schema::FieldDefinition;
+pub type FieldType = lindera_dictionary::dictionary::schema::FieldType;
+pub type CompressionAlgorithm = lindera_dictionary::decompress::Algorithm;
 
 #[derive(Debug, Clone, EnumIter, Deserialize, Serialize, PartialEq, Eq)]
 pub enum DictionaryScheme {


### PR DESCRIPTION
Export Schema, FieldDefinition, FieldType, and CompressionAlgorithm from lindera_dictionary crate to make them available in the public API.