### PR TITLE
Replace as_map() with as_value() for proper JSON type handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-lindera-dictionary = { version = "1.1.2", path = "lindera-dictionary" }
-lindera-cc-cedict = { version = "1.1.2", path = "lindera-cc-cedict" }
-lindera-ipadic = { version = "1.1.2", path = "lindera-ipadic" }
-lindera-ipadic-neologd = { version = "1.1.2", path = "lindera-ipadic-neologd" }
-lindera-ko-dic = { version = "1.1.2", path = "lindera-ko-dic" }
-lindera-unidic = { version = "1.1.2", path = "lindera-unidic" }
-lindera = { version = "1.1.2", path = "lindera" }
-lindera-cli = { version = "1.1.2", path = "lindera-cli" }
+lindera-dictionary = { version = "1.2.0", path = "lindera-dictionary" }
+lindera-cc-cedict = { version = "1.2.0", path = "lindera-cc-cedict" }
+lindera-ipadic = { version = "1.2.0", path = "lindera-ipadic" }
+lindera-ipadic-neologd = { version = "1.2.0", path = "lindera-ipadic-neologd" }
+lindera-ko-dic = { version = "1.2.0", path = "lindera-ko-dic" }
+lindera-unidic = { version = "1.2.0", path = "lindera-unidic" }
+lindera = { version = "1.2.0", path = "lindera" }
+lindera-cli = { version = "1.2.0", path = "lindera-cli" }
 
 anyhow = "1.0.99"
 bincode = { version = "2.0.1", features = ["serde"] }

--- a/lindera-cc-cedict/Cargo.toml
+++ b/lindera-cc-cedict/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cc-cedict"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A Japanese morphological dictionary for CC-CEDICT."
 documentation = "https://docs.rs/lindera-cc-cedict"

--- a/lindera-cli/Cargo.toml
+++ b/lindera-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-cli"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A morphological analysis command line interface."
 documentation = "https://docs.rs/lindera-cli"

--- a/lindera-cli/src/main.rs
+++ b/lindera-cli/src/main.rs
@@ -148,7 +148,7 @@ fn list(_args: ListArgs) -> LinderaResult<()> {
 fn mecab_output(mut tokens: Vec<Token>) -> LinderaResult<()> {
     for token in tokens.iter_mut() {
         let details = token.details().join(",");
-        println!("{}\t{}", token.text.as_ref(), details);
+        println!("{}\t{}", token.surface.as_ref(), details);
     }
     println!("EOS");
 
@@ -158,8 +158,8 @@ fn mecab_output(mut tokens: Vec<Token>) -> LinderaResult<()> {
 fn json_output(mut tokens: Vec<Token>) -> LinderaResult<()> {
     let mut json_tokens = Vec::new();
     for token in tokens.iter_mut() {
-        let token_map = token.as_map();
-        json_tokens.push(token_map);
+        let token_value = token.as_value();
+        json_tokens.push(token_value);
     }
 
     println!(
@@ -175,9 +175,9 @@ fn wakati_output(tokens: Vec<Token>) -> LinderaResult<()> {
     let mut it = tokens.iter().peekable();
     while let Some(token) = it.next() {
         if it.peek().is_some() {
-            print!("{} ", token.text.as_ref());
+            print!("{} ", token.surface.as_ref());
         } else {
-            println!("{}", token.text.as_ref());
+            println!("{}", token.surface.as_ref());
         }
     }
 

--- a/lindera-dictionary/Cargo.toml
+++ b/lindera-dictionary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-dictionary"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera-dictionary"

--- a/lindera-ipadic-neologd/Cargo.toml
+++ b/lindera-ipadic-neologd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic-neologd"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A Japanese morphological dictionary for IPADIC NEologd."
 documentation = "https://docs.rs/lindera-ipadic-neologd"

--- a/lindera-ipadic/Cargo.toml
+++ b/lindera-ipadic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ipadic"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A Japanese morphological dictionary for IPADIC."
 documentation = "https://docs.rs/lindera-ipadic"

--- a/lindera-ko-dic/Cargo.toml
+++ b/lindera-ko-dic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-ko-dic"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A Korean morphological dictionary for Ko-Dic."
 documentation = "https://docs.rs/lindera-ko-dic"

--- a/lindera-unidic/Cargo.toml
+++ b/lindera-unidic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-unidic"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A Japanese morphological dictionary for UniDic."
 documentation = "https://docs.rs/lindera-unidic"

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 description = "A morphological analysis library."
 documentation = "https://docs.rs/lindera"

--- a/lindera/examples/tokenize.rs
+++ b/lindera/examples/tokenize.rs
@@ -17,7 +17,7 @@ fn main() -> LinderaResult<()> {
         println!("text:\t{text}");
         for token in tokens.iter_mut() {
             let details = token.details().join(",");
-            println!("token:\t{}\t{}", token.text.as_ref(), details);
+            println!("token:\t{}\t{}", token.surface.as_ref(), details);
         }
     }
 

--- a/lindera/examples/tokenize_with_config.rs
+++ b/lindera/examples/tokenize_with_config.rs
@@ -23,7 +23,7 @@ fn main() -> LinderaResult<()> {
         for token in tokens {
             println!(
                 "token: {:?}, start: {:?}, end: {:?}, details: {:?}",
-                token.text, token.byte_start, token.byte_end, token.details
+                token.surface, token.byte_start, token.byte_end, token.details
             );
         }
     }

--- a/lindera/examples/tokenize_with_filters.rs
+++ b/lindera/examples/tokenize_with_filters.rs
@@ -93,7 +93,7 @@ fn main() -> LinderaResult<()> {
         for token in tokens {
             println!(
                 "token: {:?}, start: {:?}, end: {:?}, details: {:?}",
-                token.text, token.byte_start, token.byte_end, token.details
+                token.surface, token.byte_start, token.byte_end, token.details
             );
         }
     }

--- a/lindera/examples/tokenize_with_user_dict.rs
+++ b/lindera/examples/tokenize_with_user_dict.rs
@@ -46,7 +46,7 @@ fn main() -> LinderaResult<()> {
         println!("text:\t{text}");
         for token in tokens.iter_mut() {
             let details = token.details().join(",");
-            println!("token:\t{}\t{}", token.text.as_ref(), details);
+            println!("token:\t{}\t{}", token.surface.as_ref(), details);
         }
     }
 

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -339,7 +339,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "日本語");
+            assert_eq!(token.surface, "日本語");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 9);
             assert_eq!(token.position, 0);
@@ -361,7 +361,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "の");
+            assert_eq!(token.surface, "の");
             assert_eq!(token.byte_start, 9);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 1);
@@ -373,7 +373,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "形態素");
+            assert_eq!(token.surface, "形態素");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 21);
             assert_eq!(token.position, 2);
@@ -395,7 +395,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "解析");
+            assert_eq!(token.surface, "解析");
             assert_eq!(token.byte_start, 21);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 3);
@@ -417,7 +417,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "を");
+            assert_eq!(token.surface, "を");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 4);
@@ -429,7 +429,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "行う");
+            assert_eq!(token.surface, "行う");
             assert_eq!(token.byte_start, 30);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 5);
@@ -451,7 +451,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "こと");
+            assert_eq!(token.surface, "こと");
             assert_eq!(token.byte_start, 36);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 6);
@@ -473,7 +473,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "が");
+            assert_eq!(token.surface, "が");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 45);
             assert_eq!(token.position, 7);
@@ -485,7 +485,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "でき");
+            assert_eq!(token.surface, "でき");
             assert_eq!(token.byte_start, 45);
             assert_eq!(token.byte_end, 51);
             assert_eq!(token.position, 8);
@@ -507,7 +507,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "ます");
+            assert_eq!(token.surface, "ます");
             assert_eq!(token.byte_start, 51);
             assert_eq!(token.byte_end, 57);
             assert_eq!(token.position, 9);
@@ -529,7 +529,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 57);
             assert_eq!(token.byte_end, 60);
             assert_eq!(token.position, 10);
@@ -541,7 +541,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "テスト");
+            assert_eq!(token.surface, "テスト");
             assert_eq!(token.byte_start, 60);
             assert_eq!(token.byte_end, 69);
             assert_eq!(token.position, 11);
@@ -563,7 +563,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 69);
             assert_eq!(token.byte_end, 72);
             assert_eq!(token.position, 12);
@@ -595,7 +595,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "日本");
+            assert_eq!(token.surface, "日本");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 6);
             assert_eq!(token.position, 0);
@@ -625,7 +625,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "語");
+            assert_eq!(token.surface, "語");
             assert_eq!(token.byte_start, 6);
             assert_eq!(token.byte_end, 9);
             assert_eq!(token.position, 1);
@@ -655,7 +655,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "の");
+            assert_eq!(token.surface, "の");
             assert_eq!(token.byte_start, 9);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 2);
@@ -685,7 +685,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "形態");
+            assert_eq!(token.surface, "形態");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 3);
@@ -715,7 +715,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "素");
+            assert_eq!(token.surface, "素");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 21);
             assert_eq!(token.position, 4);
@@ -745,7 +745,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "解析");
+            assert_eq!(token.surface, "解析");
             assert_eq!(token.byte_start, 21);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 5);
@@ -775,7 +775,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "を");
+            assert_eq!(token.surface, "を");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 6);
@@ -805,7 +805,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "行う");
+            assert_eq!(token.surface, "行う");
             assert_eq!(token.byte_start, 30);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 7);
@@ -835,7 +835,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "こと");
+            assert_eq!(token.surface, "こと");
             assert_eq!(token.byte_start, 36);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 8);
@@ -865,7 +865,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "が");
+            assert_eq!(token.surface, "が");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 45);
             assert_eq!(token.position, 9);
@@ -895,7 +895,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "でき");
+            assert_eq!(token.surface, "でき");
             assert_eq!(token.byte_start, 45);
             assert_eq!(token.byte_end, 51);
             assert_eq!(token.position, 10);
@@ -925,7 +925,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "ます");
+            assert_eq!(token.surface, "ます");
             assert_eq!(token.byte_start, 51);
             assert_eq!(token.byte_end, 57);
             assert_eq!(token.position, 11);
@@ -955,7 +955,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 57);
             assert_eq!(token.byte_end, 60);
             assert_eq!(token.position, 12);
@@ -1005,7 +1005,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "한국어");
+            assert_eq!(token.surface, "한국어");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 9);
             assert_eq!(token.position, 0);
@@ -1026,7 +1026,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "의");
+            assert_eq!(token.surface, "의");
             assert_eq!(token.byte_start, 9);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 1);
@@ -1038,7 +1038,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "형태");
+            assert_eq!(token.surface, "형태");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 2);
@@ -1050,7 +1050,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "해석");
+            assert_eq!(token.surface, "해석");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 3);
@@ -1062,7 +1062,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "을");
+            assert_eq!(token.surface, "을");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 4);
@@ -1074,7 +1074,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "실시");
+            assert_eq!(token.surface, "실시");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 33);
             assert_eq!(token.position, 5);
@@ -1086,7 +1086,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "할");
+            assert_eq!(token.surface, "할");
             assert_eq!(token.byte_start, 33);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 6);
@@ -1107,7 +1107,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "수");
+            assert_eq!(token.surface, "수");
             assert_eq!(token.byte_start, 36);
             assert_eq!(token.byte_end, 39);
             assert_eq!(token.position, 7);
@@ -1119,7 +1119,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "있");
+            assert_eq!(token.surface, "있");
             assert_eq!(token.byte_start, 39);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 8);
@@ -1131,7 +1131,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "습니다");
+            assert_eq!(token.surface, "습니다");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 51);
             assert_eq!(token.position, 9);
@@ -1143,7 +1143,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, ".");
+            assert_eq!(token.surface, ".");
             assert_eq!(token.byte_start, 51);
             assert_eq!(token.byte_end, 52);
             assert_eq!(token.position, 10);
@@ -1175,7 +1175,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "可以");
+            assert_eq!(token.surface, "可以");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 6);
             assert_eq!(token.position, 0);
@@ -1196,7 +1196,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "进行");
+            assert_eq!(token.surface, "进行");
             assert_eq!(token.byte_start, 6);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 1);
@@ -1217,7 +1217,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "中文");
+            assert_eq!(token.surface, "中文");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 2);
@@ -1238,7 +1238,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "形态学");
+            assert_eq!(token.surface, "形态学");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 3);
@@ -1259,7 +1259,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "分析");
+            assert_eq!(token.surface, "分析");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 33);
             assert_eq!(token.position, 4);
@@ -1280,7 +1280,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 33);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 5);
@@ -1313,7 +1313,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "東京スカイツリー");
+            assert_eq!(token.surface, "東京スカイツリー");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 0);
@@ -1335,7 +1335,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "の");
+            assert_eq!(token.surface, "の");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 1);
@@ -1347,7 +1347,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "最寄り駅");
+            assert_eq!(token.surface, "最寄り駅");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 39);
             assert_eq!(token.position, 2);
@@ -1369,7 +1369,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "は");
+            assert_eq!(token.surface, "は");
             assert_eq!(token.byte_start, 39);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 3);
@@ -1381,7 +1381,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "とうきょうスカイツリー駅");
+            assert_eq!(token.surface, "とうきょうスカイツリー駅");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 78);
             assert_eq!(token.position, 4);
@@ -1403,7 +1403,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "です");
+            assert_eq!(token.surface, "です");
             assert_eq!(token.byte_start, 78);
             assert_eq!(token.byte_end, 84);
             assert_eq!(token.position, 5);
@@ -1425,7 +1425,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 84);
             assert_eq!(token.byte_end, 87);
             assert_eq!(token.position, 6);
@@ -1461,7 +1461,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "東京スカイツリー");
+            assert_eq!(token.surface, "東京スカイツリー");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 0);
@@ -1491,7 +1491,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "の");
+            assert_eq!(token.surface, "の");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 1);
@@ -1521,7 +1521,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "最寄り");
+            assert_eq!(token.surface, "最寄り");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 2);
@@ -1551,7 +1551,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "駅");
+            assert_eq!(token.surface, "駅");
             assert_eq!(token.byte_start, 36);
             assert_eq!(token.byte_end, 39);
             assert_eq!(token.position, 3);
@@ -1581,7 +1581,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "は");
+            assert_eq!(token.surface, "は");
             assert_eq!(token.byte_start, 39);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 4);
@@ -1611,7 +1611,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "とうきょうスカイツリー駅");
+            assert_eq!(token.surface, "とうきょうスカイツリー駅");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 78);
             assert_eq!(token.position, 5);
@@ -1641,7 +1641,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "です");
+            assert_eq!(token.surface, "です");
             assert_eq!(token.byte_start, 78);
             assert_eq!(token.byte_end, 84);
             assert_eq!(token.position, 6);
@@ -1671,7 +1671,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 84);
             assert_eq!(token.byte_end, 87);
             assert_eq!(token.position, 7);
@@ -1723,7 +1723,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "하네다공항");
+            assert_eq!(token.surface, "하네다공항");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 15);
             assert_eq!(token.position, 0);
@@ -1735,7 +1735,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "한정");
+            assert_eq!(token.surface, "한정");
             assert_eq!(token.byte_start, 15);
             assert_eq!(token.byte_end, 21);
             assert_eq!(token.position, 1);
@@ -1747,7 +1747,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "토트백");
+            assert_eq!(token.surface, "토트백");
             assert_eq!(token.byte_start, 21);
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 2);
@@ -1768,7 +1768,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, ".");
+            assert_eq!(token.surface, ".");
             assert_eq!(token.byte_start, 30);
             assert_eq!(token.byte_end, 31);
             assert_eq!(token.position, 3);
@@ -1802,7 +1802,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "羽田机场");
+            assert_eq!(token.surface, "羽田机场");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 0);
@@ -1814,7 +1814,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "限定");
+            assert_eq!(token.surface, "限定");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 1);
@@ -1835,7 +1835,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "托特");
+            assert_eq!(token.surface, "托特");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 2);
@@ -1856,7 +1856,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "包");
+            assert_eq!(token.surface, "包");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 3);
@@ -1878,7 +1878,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 4);
@@ -1911,7 +1911,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "東京スカイツリー");
+            assert_eq!(token.surface, "東京スカイツリー");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 0);
@@ -1933,7 +1933,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "の");
+            assert_eq!(token.surface, "の");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 1);
@@ -1945,7 +1945,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "最寄り駅");
+            assert_eq!(token.surface, "最寄り駅");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 39);
             assert_eq!(token.position, 2);
@@ -1967,7 +1967,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "は");
+            assert_eq!(token.surface, "は");
             assert_eq!(token.byte_start, 39);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 3);
@@ -1979,7 +1979,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "とうきょうスカイツリー駅");
+            assert_eq!(token.surface, "とうきょうスカイツリー駅");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 78);
             assert_eq!(token.position, 4);
@@ -2001,7 +2001,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "です");
+            assert_eq!(token.surface, "です");
             assert_eq!(token.byte_start, 78);
             assert_eq!(token.byte_end, 84);
             assert_eq!(token.position, 5);
@@ -2023,7 +2023,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 84);
             assert_eq!(token.byte_end, 87);
             assert_eq!(token.position, 6);
@@ -2059,7 +2059,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "東京スカイツリー");
+            assert_eq!(token.surface, "東京スカイツリー");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 0);
@@ -2089,7 +2089,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "の");
+            assert_eq!(token.surface, "の");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 1);
@@ -2119,7 +2119,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "最寄り");
+            assert_eq!(token.surface, "最寄り");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 2);
@@ -2149,7 +2149,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "駅");
+            assert_eq!(token.surface, "駅");
             assert_eq!(token.byte_start, 36);
             assert_eq!(token.byte_end, 39);
             assert_eq!(token.position, 3);
@@ -2179,7 +2179,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "は");
+            assert_eq!(token.surface, "は");
             assert_eq!(token.byte_start, 39);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 4);
@@ -2209,7 +2209,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "とうきょうスカイツリー駅");
+            assert_eq!(token.surface, "とうきょうスカイツリー駅");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 78);
             assert_eq!(token.position, 5);
@@ -2239,7 +2239,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "です");
+            assert_eq!(token.surface, "です");
             assert_eq!(token.byte_start, 78);
             assert_eq!(token.byte_end, 84);
             assert_eq!(token.position, 6);
@@ -2269,7 +2269,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 84);
             assert_eq!(token.byte_end, 87);
             assert_eq!(token.position, 7);
@@ -2321,7 +2321,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "하네다공항");
+            assert_eq!(token.surface, "하네다공항");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 15);
             assert_eq!(token.position, 0);
@@ -2333,7 +2333,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "한정");
+            assert_eq!(token.surface, "한정");
             assert_eq!(token.byte_start, 15);
             assert_eq!(token.byte_end, 21);
             assert_eq!(token.position, 1);
@@ -2345,7 +2345,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "토트백");
+            assert_eq!(token.surface, "토트백");
             assert_eq!(token.byte_start, 21);
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 2);
@@ -2366,7 +2366,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, ".");
+            assert_eq!(token.surface, ".");
             assert_eq!(token.byte_start, 30);
             assert_eq!(token.byte_end, 31);
             assert_eq!(token.position, 3);
@@ -2400,7 +2400,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "羽田机场");
+            assert_eq!(token.surface, "羽田机场");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 0);
@@ -2412,7 +2412,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "限定");
+            assert_eq!(token.surface, "限定");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 1);
@@ -2433,7 +2433,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "托特");
+            assert_eq!(token.surface, "托特");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 2);
@@ -2454,7 +2454,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "包");
+            assert_eq!(token.surface, "包");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 3);
@@ -2476,7 +2476,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 4);
@@ -2509,7 +2509,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "東京スカイツリー");
+            assert_eq!(token.surface, "東京スカイツリー");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 24);
             assert_eq!(token.position, 0);
@@ -2531,7 +2531,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "の");
+            assert_eq!(token.surface, "の");
             assert_eq!(token.byte_start, 24);
             assert_eq!(token.byte_end, 27);
             assert_eq!(token.position, 1);
@@ -2543,7 +2543,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "最寄り駅");
+            assert_eq!(token.surface, "最寄り駅");
             assert_eq!(token.byte_start, 27);
             assert_eq!(token.byte_end, 39);
             assert_eq!(token.position, 2);
@@ -2565,7 +2565,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "は");
+            assert_eq!(token.surface, "は");
             assert_eq!(token.byte_start, 39);
             assert_eq!(token.byte_end, 42);
             assert_eq!(token.position, 3);
@@ -2577,7 +2577,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "とうきょうスカイツリー駅");
+            assert_eq!(token.surface, "とうきょうスカイツリー駅");
             assert_eq!(token.byte_start, 42);
             assert_eq!(token.byte_end, 78);
             assert_eq!(token.position, 4);
@@ -2599,7 +2599,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "です");
+            assert_eq!(token.surface, "です");
             assert_eq!(token.byte_start, 78);
             assert_eq!(token.byte_end, 84);
             assert_eq!(token.position, 5);
@@ -2621,7 +2621,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "。");
+            assert_eq!(token.surface, "。");
             assert_eq!(token.byte_start, 84);
             assert_eq!(token.byte_end, 87);
             assert_eq!(token.position, 6);
@@ -2684,7 +2684,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "羽田空港");
+            assert_eq!(token.surface, "羽田空港");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 0);
@@ -2706,7 +2706,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "限定");
+            assert_eq!(token.surface, "限定");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 1);
@@ -2728,7 +2728,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "トートバッグ");
+            assert_eq!(token.surface, "トートバッグ");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 2);
@@ -2761,7 +2761,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "羽田");
+            assert_eq!(token.surface, "羽田");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 6);
             assert_eq!(token.position, 0);
@@ -2783,7 +2783,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "空港");
+            assert_eq!(token.surface, "空港");
             assert_eq!(token.byte_start, 6);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 1);
@@ -2805,7 +2805,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "限定");
+            assert_eq!(token.surface, "限定");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 2);
@@ -2827,7 +2827,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "トートバッグ");
+            assert_eq!(token.surface, "トートバッグ");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 3);
@@ -2854,7 +2854,7 @@ mod tests {
         let mut tokens_iter = tokens.iter_mut();
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "羽田");
+            assert_eq!(token.surface, "羽田");
             assert_eq!(token.byte_start, 0);
             assert_eq!(token.byte_end, 6);
             assert_eq!(token.position, 0);
@@ -2876,7 +2876,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "空港");
+            assert_eq!(token.surface, "空港");
             assert_eq!(token.byte_start, 6);
             assert_eq!(token.byte_end, 12);
             assert_eq!(token.position, 1);
@@ -2898,7 +2898,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "限定");
+            assert_eq!(token.surface, "限定");
             assert_eq!(token.byte_start, 12);
             assert_eq!(token.byte_end, 18);
             assert_eq!(token.position, 2);
@@ -2920,7 +2920,7 @@ mod tests {
         }
         {
             let token = tokens_iter.next().unwrap();
-            assert_eq!(token.text, "トートバッグ");
+            assert_eq!(token.surface, "トートバッグ");
             assert_eq!(token.byte_start, 18);
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 3);

--- a/lindera/src/token_filter/japanese_base_form.rs
+++ b/lindera/src/token_filter/japanese_base_form.rs
@@ -47,10 +47,10 @@ impl TokenFilter for JapaneseBaseFormTokenFilter {
             }
 
             if let Some(base_form) = token.get("base_form") {
-                token.text = Cow::Owned(base_form.to_string());
+                token.surface = Cow::Owned(base_form.to_string());
             }
             if let Some(base_form) = token.get("orthographic_base_form") {
-                token.text = Cow::Owned(base_form.to_string());
+                token.surface = Cow::Owned(base_form.to_string());
             }
         }
 
@@ -76,7 +76,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("羽田空港"),
+                surface: Cow::Borrowed("羽田空港"),
                 byte_start: 0,
                 byte_end: 12,
                 position: 0,
@@ -100,7 +100,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("に"),
+                surface: Cow::Borrowed("に"),
                 byte_start: 12,
                 byte_end: 15,
                 position: 1,
@@ -124,7 +124,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("あり"),
+                surface: Cow::Borrowed("あり"),
                 byte_start: 15,
                 byte_end: 21,
                 position: 2,
@@ -148,7 +148,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("ます"),
+                surface: Cow::Borrowed("ます"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 3,
@@ -176,10 +176,10 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens[0].text, "羽田空港");
-        assert_eq!(tokens[1].text, "に");
-        assert_eq!(tokens[2].text, "ある");
-        assert_eq!(tokens[3].text, "ます");
+        assert_eq!(tokens[0].surface, "羽田空港");
+        assert_eq!(tokens[1].surface, "に");
+        assert_eq!(tokens[2].surface, "ある");
+        assert_eq!(tokens[3].surface, "ます");
     }
 
     #[cfg(feature = "embedded-unidic")]
@@ -198,7 +198,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("羽田"),
+                surface: Cow::Borrowed("羽田"),
                 byte_start: 0,
                 byte_end: 6,
                 position: 0,
@@ -230,7 +230,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("空港"),
+                surface: Cow::Borrowed("空港"),
                 byte_start: 6,
                 byte_end: 12,
                 position: 1,
@@ -262,7 +262,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("に"),
+                surface: Cow::Borrowed("に"),
                 byte_start: 12,
                 byte_end: 15,
                 position: 2,
@@ -294,7 +294,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("あり"),
+                surface: Cow::Borrowed("あり"),
                 byte_start: 15,
                 byte_end: 21,
                 position: 3,
@@ -326,7 +326,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("ます"),
+                surface: Cow::Borrowed("ます"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 4,
@@ -362,10 +362,10 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 5);
-        assert_eq!(&tokens[0].text, "羽田");
-        assert_eq!(&tokens[1].text, "空港");
-        assert_eq!(&tokens[2].text, "に");
-        assert_eq!(&tokens[3].text, "ある");
-        assert_eq!(&tokens[4].text, "ます");
+        assert_eq!(&tokens[0].surface, "羽田");
+        assert_eq!(&tokens[1].surface, "空港");
+        assert_eq!(&tokens[2].surface, "に");
+        assert_eq!(&tokens[3].surface, "ある");
+        assert_eq!(&tokens[4].surface, "ます");
     }
 }

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -75,7 +75,7 @@ impl JapaneseCompoundWordTokenFilter {
 
     // Concatenate two tokens into one.
     fn concat_token<'a>(&self, token1: &mut Token<'a>, token2: &Token<'a>) {
-        token1.text = Cow::Owned(format!("{}{}", token1.text, token2.text));
+        token1.surface = Cow::Owned(format!("{}{}", token1.surface, token2.surface));
         token1.byte_end = token2.byte_end;
         token1.position_length += token2.position_length;
 
@@ -106,7 +106,10 @@ impl JapaneseCompoundWordTokenFilter {
             }
         };
 
-        token1.details = Some(details);
+        // token1.details = Some(details);
+        for (i, detail) in details.iter().enumerate() {
+            token1.set_detail(i, detail.clone());
+        }
     }
 }
 
@@ -269,7 +272,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("１"),
+                surface: Cow::Borrowed("１"),
                 byte_start: 0,
                 byte_end: 3,
                 position: 0,
@@ -293,7 +296,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("０"),
+                surface: Cow::Borrowed("０"),
                 byte_start: 3,
                 byte_end: 6,
                 position: 1,
@@ -317,7 +320,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("０"),
+                surface: Cow::Borrowed("０"),
                 byte_start: 6,
                 byte_end: 9,
                 position: 2,
@@ -341,7 +344,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("円"),
+                surface: Cow::Borrowed("円"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 3,
@@ -365,7 +368,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("玉"),
+                surface: Cow::Borrowed("玉"),
                 byte_start: 12,
                 byte_end: 15,
                 position: 4,
@@ -389,7 +392,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("を"),
+                surface: Cow::Borrowed("を"),
                 byte_start: 15,
                 byte_end: 18,
                 position: 5,
@@ -413,7 +416,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("拾う"),
+                surface: Cow::Borrowed("拾う"),
                 byte_start: 18,
                 byte_end: 24,
                 position: 6,
@@ -441,22 +444,22 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(tokens[0].text, "１００円".to_string());
+        assert_eq!(tokens[0].surface, "１００円".to_string());
         assert_eq!(tokens[0].byte_start, 0);
         assert_eq!(tokens[0].byte_end, 12);
         assert_eq!(tokens[0].position, 0);
         assert_eq!(tokens[0].position_length, 4);
-        assert_eq!(tokens[1].text, "玉".to_string());
+        assert_eq!(tokens[1].surface, "玉".to_string());
         assert_eq!(tokens[1].byte_start, 12);
         assert_eq!(tokens[1].byte_end, 15);
         assert_eq!(tokens[1].position, 4);
         assert_eq!(tokens[1].position_length, 1);
-        assert_eq!(tokens[2].text, "を".to_string());
+        assert_eq!(tokens[2].surface, "を".to_string());
         assert_eq!(tokens[2].byte_start, 15);
         assert_eq!(tokens[2].byte_end, 18);
         assert_eq!(tokens[2].position, 5);
         assert_eq!(tokens[2].position_length, 1);
-        assert_eq!(tokens[3].text, "拾う".to_string());
+        assert_eq!(tokens[3].surface, "拾う".to_string());
         assert_eq!(tokens[3].byte_start, 18);
         assert_eq!(tokens[3].byte_end, 24);
         assert_eq!(tokens[3].position, 6);

--- a/lindera/src/token_filter/japanese_kana.rs
+++ b/lindera/src/token_filter/japanese_kana.rs
@@ -115,15 +115,15 @@ impl TokenFilter for JapaneseKanaTokenFilter {
             let converted_text = match self.kind {
                 KanaKind::Hiragana => {
                     // Convert katakana to hiragana.
-                    UCSStr::from_str(&token.text).hiragana().to_string()
+                    UCSStr::from_str(&token.surface).hiragana().to_string()
                 }
                 KanaKind::Katakana => {
                     // Convert hiragana to katakana.
-                    UCSStr::from_str(&token.text).katakana().to_string()
+                    UCSStr::from_str(&token.surface).katakana().to_string()
                 }
             };
 
-            token.text = Cow::Owned(converted_text);
+            token.surface = Cow::Owned(converted_text);
         }
 
         Ok(())
@@ -236,7 +236,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("羽田空港"),
+                surface: Cow::Borrowed("羽田空港"),
                 byte_start: 0,
                 byte_end: 12,
                 position: 0,
@@ -260,7 +260,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("限定"),
+                surface: Cow::Borrowed("限定"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 1,
@@ -284,7 +284,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("トートバッグ"),
+                surface: Cow::Borrowed("トートバッグ"),
                 byte_start: 18,
                 byte_end: 36,
                 position: 2,
@@ -302,9 +302,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].text, "羽田空港");
-        assert_eq!(&tokens[1].text, "限定");
-        assert_eq!(&tokens[2].text, "とーとばっぐ");
+        assert_eq!(&tokens[0].surface, "羽田空港");
+        assert_eq!(&tokens[1].surface, "限定");
+        assert_eq!(&tokens[2].surface, "とーとばっぐ");
     }
 
     #[test]
@@ -331,7 +331,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("埼玉"),
+                surface: Cow::Borrowed("埼玉"),
                 byte_start: 0,
                 byte_end: 6,
                 position: 0,
@@ -355,7 +355,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("県"),
+                surface: Cow::Borrowed("県"),
                 byte_start: 6,
                 byte_end: 9,
                 position: 1,
@@ -379,7 +379,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("さいたま"),
+                surface: Cow::Borrowed("さいたま"),
                 byte_start: 9,
                 byte_end: 21,
                 position: 2,
@@ -403,7 +403,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("市"),
+                surface: Cow::Borrowed("市"),
                 byte_start: 21,
                 byte_end: 24,
                 position: 3,
@@ -431,10 +431,10 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "埼玉");
-        assert_eq!(&tokens[1].text, "県");
-        assert_eq!(&tokens[2].text, "サイタマ");
-        assert_eq!(&tokens[3].text, "市");
+        assert_eq!(&tokens[0].surface, "埼玉");
+        assert_eq!(&tokens[1].surface, "県");
+        assert_eq!(&tokens[2].surface, "サイタマ");
+        assert_eq!(&tokens[3].surface, "市");
     }
 
     #[test]
@@ -461,7 +461,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("羽田空港"),
+                surface: Cow::Borrowed("羽田空港"),
                 byte_start: 0,
                 byte_end: 12,
                 position: 0,
@@ -485,7 +485,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("限定"),
+                surface: Cow::Borrowed("限定"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 1,
@@ -509,7 +509,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("トートバッグ"),
+                surface: Cow::Borrowed("トートバッグ"),
                 byte_start: 18,
                 byte_end: 36,
                 position: 2,
@@ -527,9 +527,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].text, "羽田空港");
-        assert_eq!(&tokens[1].text, "限定");
-        assert_eq!(&tokens[2].text, "トートバッグ");
+        assert_eq!(&tokens[0].surface, "羽田空港");
+        assert_eq!(&tokens[1].surface, "限定");
+        assert_eq!(&tokens[2].surface, "トートバッグ");
     }
 
     #[test]
@@ -556,7 +556,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("埼玉"),
+                surface: Cow::Borrowed("埼玉"),
                 byte_start: 0,
                 byte_end: 6,
                 position: 0,
@@ -580,7 +580,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("県"),
+                surface: Cow::Borrowed("県"),
                 byte_start: 6,
                 byte_end: 9,
                 position: 1,
@@ -604,7 +604,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("さいたま"),
+                surface: Cow::Borrowed("さいたま"),
                 byte_start: 9,
                 byte_end: 21,
                 position: 2,
@@ -628,7 +628,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("市"),
+                surface: Cow::Borrowed("市"),
                 byte_start: 21,
                 byte_end: 24,
                 position: 3,
@@ -656,10 +656,10 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "埼玉");
-        assert_eq!(&tokens[1].text, "県");
-        assert_eq!(&tokens[2].text, "さいたま");
-        assert_eq!(&tokens[3].text, "市");
+        assert_eq!(&tokens[0].surface, "埼玉");
+        assert_eq!(&tokens[1].surface, "県");
+        assert_eq!(&tokens[2].surface, "さいたま");
+        assert_eq!(&tokens[3].surface, "市");
     }
 
     #[test]
@@ -686,7 +686,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("東京"),
+                surface: Cow::Borrowed("東京"),
                 byte_start: 0,
                 byte_end: 6,
                 position: 0,
@@ -710,7 +710,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("都"),
+                surface: Cow::Borrowed("都"),
                 byte_start: 6,
                 byte_end: 9,
                 position: 1,
@@ -734,7 +734,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("あきる野"),
+                surface: Cow::Borrowed("あきる野"),
                 byte_start: 9,
                 byte_end: 21,
                 position: 2,
@@ -758,7 +758,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("市"),
+                surface: Cow::Borrowed("市"),
                 byte_start: 21,
                 byte_end: 24,
                 position: 3,
@@ -786,10 +786,10 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "東京");
-        assert_eq!(&tokens[1].text, "都");
-        assert_eq!(&tokens[2].text, "アキル野");
-        assert_eq!(&tokens[3].text, "市");
+        assert_eq!(&tokens[0].surface, "東京");
+        assert_eq!(&tokens[1].surface, "都");
+        assert_eq!(&tokens[2].surface, "アキル野");
+        assert_eq!(&tokens[3].surface, "市");
     }
 
     #[test]
@@ -816,7 +816,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("南北線"),
+                surface: Cow::Borrowed("南北線"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -840,7 +840,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("四ツ谷"),
+                surface: Cow::Borrowed("四ツ谷"),
                 byte_start: 9,
                 byte_end: 18,
                 position: 1,
@@ -864,7 +864,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("駅"),
+                surface: Cow::Borrowed("駅"),
                 byte_start: 18,
                 byte_end: 21,
                 position: 2,
@@ -892,8 +892,8 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].text, "南北線");
-        assert_eq!(&tokens[1].text, "四つ谷");
-        assert_eq!(&tokens[2].text, "駅");
+        assert_eq!(&tokens[0].surface, "南北線");
+        assert_eq!(&tokens[1].surface, "四つ谷");
+        assert_eq!(&tokens[2].surface, "駅");
     }
 }

--- a/lindera/src/token_filter/japanese_katakana_stem.rs
+++ b/lindera/src/token_filter/japanese_katakana_stem.rs
@@ -85,20 +85,20 @@ impl TokenFilter for JapaneseKatakanaStemTokenFilter {
 
         for token in tokens.iter_mut() {
             // Skip if the token is not katakana
-            if !is_katakana(&token.text) {
+            if !is_katakana(&token.surface) {
                 continue;
             }
 
             // Check if the token ends with the prolonged sound mark and is longer than the minimum length
             if token
-                .text
+                .surface
                 .ends_with(DEFAULT_HIRAGANA_KATAKANA_PROLONGED_SOUND_MARK)
-                && token.text.chars().count() > min_len
+                && token.surface.chars().count() > min_len
             {
                 // Remove the prolonged sound mark
                 let new_len =
-                    token.text.len() - DEFAULT_HIRAGANA_KATAKANA_PROLONGED_SOUND_MARK.len_utf8();
-                token.text = Cow::Owned(token.text[..new_len].to_string());
+                    token.surface.len() - DEFAULT_HIRAGANA_KATAKANA_PROLONGED_SOUND_MARK.len_utf8();
+                token.surface = Cow::Owned(token.surface[..new_len].to_string());
             }
         }
 
@@ -229,7 +229,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("バター"),
+                surface: Cow::Borrowed("バター"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -253,7 +253,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("メーカー"),
+                surface: Cow::Borrowed("メーカー"),
                 byte_start: 9,
                 byte_end: 21,
                 position: 1,
@@ -281,7 +281,7 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 2);
-        assert_eq!(&tokens[0].text, "バター");
-        assert_eq!(&tokens[1].text, "メーカ");
+        assert_eq!(&tokens[0].surface, "バター");
+        assert_eq!(&tokens[1].surface, "メーカ");
     }
 }

--- a/lindera/src/token_filter/japanese_keep_tags.rs
+++ b/lindera/src/token_filter/japanese_keep_tags.rs
@@ -291,7 +291,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("すもも"),
+                surface: Cow::Borrowed("すもも"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -315,7 +315,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -339,7 +339,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 2,
@@ -363,7 +363,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 18,
                 byte_end: 21,
                 position: 3,
@@ -387,7 +387,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 4,
@@ -411,7 +411,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("の"),
+                surface: Cow::Borrowed("の"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 5,
@@ -435,7 +435,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("うち"),
+                surface: Cow::Borrowed("うち"),
                 byte_start: 30,
                 byte_end: 36,
                 position: 6,
@@ -463,9 +463,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "すもも");
-        assert_eq!(&tokens[1].text, "もも");
-        assert_eq!(&tokens[2].text, "もも");
-        assert_eq!(&tokens[3].text, "うち");
+        assert_eq!(&tokens[0].surface, "すもも");
+        assert_eq!(&tokens[1].surface, "もも");
+        assert_eq!(&tokens[2].surface, "もも");
+        assert_eq!(&tokens[3].surface, "うち");
     }
 }

--- a/lindera/src/token_filter/japanese_number.rs
+++ b/lindera/src/token_filter/japanese_number.rs
@@ -101,8 +101,8 @@ impl TokenFilter for JapaneseNumberTokenFilter {
 
             // If conversion is required, apply the Arabic numeral conversion.
             if should_convert {
-                let text = token.text.as_ref();
-                token.text = Cow::Owned(to_arabic_numerals(text));
+                let text = token.surface.as_ref();
+                token.surface = Cow::Owned(to_arabic_numerals(text));
             }
         }
 
@@ -929,7 +929,7 @@ mod tests {
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("一"),
+                surface: Cow::Borrowed("一"),
                 byte_start: 0,
                 byte_end: 3,
                 position: 0,
@@ -956,12 +956,12 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 1);
-            assert_eq!(&tokens[0].text, "1");
+            assert_eq!(&tokens[0].surface, "1");
         }
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("一二三"),
+                surface: Cow::Borrowed("一二三"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -988,12 +988,12 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 1);
-            assert_eq!(&tokens[0].text, "123");
+            assert_eq!(&tokens[0].surface, "123");
         }
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed(
+                surface: Cow::Borrowed(
                     "一千二百三十四垓五千六百七十八京九千十二兆三千四百五十六億七千八百九十万一千二百三十四",
                 ),
                 byte_start: 0,
@@ -1022,13 +1022,13 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 1);
-            assert_eq!(&tokens[0].text, "123456789012345678901234");
+            assert_eq!(&tokens[0].surface, "123456789012345678901234");
         }
 
         {
             let mut tokens: Vec<Token> = vec![
                 Token {
-                    text: Cow::Borrowed("鈴木"),
+                    surface: Cow::Borrowed("鈴木"),
                     byte_start: 0,
                     byte_end: 6,
                     position: 0,
@@ -1052,7 +1052,7 @@ mod tests {
                     ]),
                 },
                 Token {
-                    text: Cow::Borrowed("一郎"),
+                    surface: Cow::Borrowed("一郎"),
                     byte_start: 6,
                     byte_end: 12,
                     position: 0,
@@ -1080,8 +1080,8 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 2);
-            assert_eq!(&tokens[0].text, "鈴木");
-            assert_eq!(&tokens[1].text, "一郎");
+            assert_eq!(&tokens[0].surface, "鈴木");
+            assert_eq!(&tokens[1].surface, "一郎");
         }
     }
 
@@ -1103,7 +1103,7 @@ mod tests {
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("一"),
+                surface: Cow::Borrowed("一"),
                 byte_start: 0,
                 byte_end: 3,
                 position: 0,
@@ -1130,12 +1130,12 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 1);
-            assert_eq!(&tokens[0].text, "1");
+            assert_eq!(&tokens[0].surface, "1");
         }
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("一二三"),
+                surface: Cow::Borrowed("一二三"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -1162,12 +1162,12 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 1);
-            assert_eq!(&tokens[0].text, "123");
+            assert_eq!(&tokens[0].surface, "123");
         }
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed(
+                surface: Cow::Borrowed(
                     "一千二百三十四垓五千六百七十八京九千十二兆三千四百五十六億七千八百九十万一千二百三十四",
                 ),
                 byte_start: 0,
@@ -1196,13 +1196,13 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 1);
-            assert_eq!(&tokens[0].text, "123456789012345678901234");
+            assert_eq!(&tokens[0].surface, "123456789012345678901234");
         }
 
         {
             let mut tokens: Vec<Token> = vec![
                 Token {
-                    text: Cow::Borrowed("鈴木"),
+                    surface: Cow::Borrowed("鈴木"),
                     byte_start: 0,
                     byte_end: 6,
                     position: 0,
@@ -1226,7 +1226,7 @@ mod tests {
                     ]),
                 },
                 Token {
-                    text: Cow::Borrowed("一郎"),
+                    surface: Cow::Borrowed("一郎"),
                     byte_start: 6,
                     byte_end: 12,
                     position: 0,
@@ -1254,8 +1254,8 @@ mod tests {
             filter.apply(&mut tokens).unwrap();
 
             assert_eq!(tokens.len(), 2);
-            assert_eq!(&tokens[0].text, "鈴木");
-            assert_eq!(&tokens[1].text, "1郎");
+            assert_eq!(&tokens[0].surface, "鈴木");
+            assert_eq!(&tokens[1].surface, "1郎");
         }
     }
 }

--- a/lindera/src/token_filter/japanese_reading_form.rs
+++ b/lindera/src/token_filter/japanese_reading_form.rs
@@ -80,7 +80,7 @@ impl TokenFilter for JapaneseReadingFormTokenFilter {
             }
 
             if let Some(reading) = token.get("reading") {
-                token.text = Cow::Owned(reading.to_string());
+                token.surface = Cow::Owned(reading.to_string());
             }
         }
 
@@ -106,7 +106,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("羽田空港"),
+                surface: Cow::Borrowed("羽田空港"),
                 byte_start: 0,
                 byte_end: 12,
                 position: 0,
@@ -130,7 +130,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("限定"),
+                surface: Cow::Borrowed("限定"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 1,
@@ -154,7 +154,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("トートバッグ"),
+                surface: Cow::Borrowed("トートバッグ"),
                 byte_start: 18,
                 byte_end: 36,
                 position: 2,
@@ -172,9 +172,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].text, "ハネダクウコウ");
-        assert_eq!(&tokens[1].text, "ゲンテイ");
-        assert_eq!(&tokens[2].text, "トートバッグ");
+        assert_eq!(&tokens[0].surface, "ハネダクウコウ");
+        assert_eq!(&tokens[1].surface, "ゲンテイ");
+        assert_eq!(&tokens[2].surface, "トートバッグ");
     }
 
     #[cfg(feature = "embedded-unidic")]
@@ -193,7 +193,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("羽田"),
+                surface: Cow::Borrowed("羽田"),
                 byte_start: 0,
                 byte_end: 6,
                 position: 0,
@@ -225,7 +225,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("空港"),
+                surface: Cow::Borrowed("空港"),
                 byte_start: 6,
                 byte_end: 12,
                 position: 1,
@@ -257,7 +257,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("限定"),
+                surface: Cow::Borrowed("限定"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 2,
@@ -289,7 +289,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("トート"),
+                surface: Cow::Borrowed("トート"),
                 byte_start: 18,
                 byte_end: 27,
                 position: 3,
@@ -321,7 +321,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("バッグ"),
+                surface: Cow::Borrowed("バッグ"),
                 byte_start: 27,
                 byte_end: 36,
                 position: 4,
@@ -357,10 +357,10 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 5);
-        assert_eq!(&tokens[0].text, "ハタ");
-        assert_eq!(&tokens[1].text, "クウコウ");
-        assert_eq!(&tokens[2].text, "ゲンテイ");
-        assert_eq!(&tokens[3].text, "トート");
-        assert_eq!(&tokens[4].text, "バッグ");
+        assert_eq!(&tokens[0].surface, "ハタ");
+        assert_eq!(&tokens[1].surface, "クウコウ");
+        assert_eq!(&tokens[2].surface, "ゲンテイ");
+        assert_eq!(&tokens[3].surface, "トート");
+        assert_eq!(&tokens[4].surface, "バッグ");
     }
 }

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -249,7 +249,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("すもも"),
+                surface: Cow::Borrowed("すもも"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -273,7 +273,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -297,7 +297,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 2,
@@ -321,7 +321,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 18,
                 byte_end: 21,
                 position: 3,
@@ -345,7 +345,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 4,
@@ -369,7 +369,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("の"),
+                surface: Cow::Borrowed("の"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 5,
@@ -393,7 +393,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("うち"),
+                surface: Cow::Borrowed("うち"),
                 byte_start: 30,
                 byte_end: 36,
                 position: 6,
@@ -421,9 +421,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "すもも");
-        assert_eq!(&tokens[1].text, "もも");
-        assert_eq!(&tokens[2].text, "もも");
-        assert_eq!(&tokens[3].text, "うち");
+        assert_eq!(&tokens[0].surface, "すもも");
+        assert_eq!(&tokens[1].surface, "もも");
+        assert_eq!(&tokens[2].surface, "もも");
+        assert_eq!(&tokens[3].surface, "うち");
     }
 }

--- a/lindera/src/token_filter/keep_words.rs
+++ b/lindera/src/token_filter/keep_words.rs
@@ -77,7 +77,7 @@ impl TokenFilter for KeepWordsTokenFilter {
     ///
     /// The function will return an error in the form of `LinderaResult<()>` if any issues arise during the filtering process, though normally no errors are expected in this operation.
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
-        tokens.retain(|token| self.words.contains(token.text.as_ref()));
+        tokens.retain(|token| self.words.contains(token.surface.as_ref()));
 
         Ok(())
     }
@@ -141,7 +141,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("すもも"),
+                surface: Cow::Borrowed("すもも"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -165,7 +165,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -189,7 +189,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 2,
@@ -213,7 +213,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 18,
                 byte_end: 21,
                 position: 3,
@@ -237,7 +237,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 4,
@@ -261,7 +261,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("の"),
+                surface: Cow::Borrowed("の"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 5,
@@ -285,7 +285,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("うち"),
+                surface: Cow::Borrowed("うち"),
                 byte_start: 30,
                 byte_end: 36,
                 position: 6,
@@ -313,8 +313,8 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 3);
-        assert_eq!(&tokens[0].text, "すもも");
-        assert_eq!(&tokens[1].text, "もも");
-        assert_eq!(&tokens[2].text, "もも");
+        assert_eq!(&tokens[0].surface, "すもも");
+        assert_eq!(&tokens[1].surface, "もも");
+        assert_eq!(&tokens[2].surface, "もも");
     }
 }

--- a/lindera/src/token_filter/korean_keep_tags.rs
+++ b/lindera/src/token_filter/korean_keep_tags.rs
@@ -155,7 +155,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("한국어"),
+                surface: Cow::Borrowed("한국어"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -178,7 +178,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("의"),
+                surface: Cow::Borrowed("의"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -201,7 +201,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("형태소"),
+                surface: Cow::Borrowed("형태소"),
                 byte_start: 12,
                 byte_end: 21,
                 position: 2,
@@ -224,7 +224,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("분석"),
+                surface: Cow::Borrowed("분석"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 3,
@@ -247,7 +247,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("을"),
+                surface: Cow::Borrowed("을"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 4,
@@ -270,7 +270,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("할"),
+                surface: Cow::Borrowed("할"),
                 byte_start: 30,
                 byte_end: 33,
                 position: 5,
@@ -293,7 +293,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("수"),
+                surface: Cow::Borrowed("수"),
                 byte_start: 33,
                 byte_end: 36,
                 position: 6,
@@ -316,7 +316,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("있"),
+                surface: Cow::Borrowed("있"),
                 byte_start: 36,
                 byte_end: 39,
                 position: 7,
@@ -339,7 +339,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("습니다"),
+                surface: Cow::Borrowed("습니다"),
                 byte_start: 39,
                 byte_end: 48,
                 position: 8,
@@ -366,9 +366,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "한국어");
-        assert_eq!(&tokens[1].text, "형태소");
-        assert_eq!(&tokens[2].text, "분석");
-        assert_eq!(&tokens[3].text, "수");
+        assert_eq!(&tokens[0].surface, "한국어");
+        assert_eq!(&tokens[1].surface, "형태소");
+        assert_eq!(&tokens[2].surface, "분석");
+        assert_eq!(&tokens[3].surface, "수");
     }
 }

--- a/lindera/src/token_filter/korean_reading_form.rs
+++ b/lindera/src/token_filter/korean_reading_form.rs
@@ -45,7 +45,7 @@ impl TokenFilter for KoreanReadingFormTokenFilter {
             }
 
             if let Some(reading) = token.get("reading") {
-                token.text = Cow::Owned(reading.to_string());
+                token.surface = Cow::Owned(reading.to_string());
             }
         }
 
@@ -71,7 +71,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("한국어"),
+                surface: Cow::Borrowed("한국어"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -94,7 +94,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("의"),
+                surface: Cow::Borrowed("의"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -117,7 +117,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("형태소"),
+                surface: Cow::Borrowed("형태소"),
                 byte_start: 12,
                 byte_end: 21,
                 position: 2,
@@ -140,7 +140,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("분석"),
+                surface: Cow::Borrowed("분석"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 3,
@@ -163,7 +163,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("을"),
+                surface: Cow::Borrowed("을"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 4,
@@ -186,7 +186,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("할"),
+                surface: Cow::Borrowed("할"),
                 byte_start: 30,
                 byte_end: 33,
                 position: 5,
@@ -209,7 +209,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("수"),
+                surface: Cow::Borrowed("수"),
                 byte_start: 33,
                 byte_end: 36,
                 position: 6,
@@ -232,7 +232,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("있"),
+                surface: Cow::Borrowed("있"),
                 byte_start: 36,
                 byte_end: 39,
                 position: 7,
@@ -255,7 +255,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("습니다"),
+                surface: Cow::Borrowed("습니다"),
                 byte_start: 39,
                 byte_end: 48,
                 position: 8,
@@ -282,14 +282,14 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 9);
-        assert_eq!(&tokens[0].text, "한국어");
-        assert_eq!(&tokens[1].text, "의");
-        assert_eq!(&tokens[2].text, "형태소");
-        assert_eq!(&tokens[3].text, "분석");
-        assert_eq!(&tokens[4].text, "을");
-        assert_eq!(&tokens[5].text, "할");
-        assert_eq!(&tokens[6].text, "수");
-        assert_eq!(&tokens[7].text, "있");
-        assert_eq!(&tokens[8].text, "습니다");
+        assert_eq!(&tokens[0].surface, "한국어");
+        assert_eq!(&tokens[1].surface, "의");
+        assert_eq!(&tokens[2].surface, "형태소");
+        assert_eq!(&tokens[3].surface, "분석");
+        assert_eq!(&tokens[4].surface, "을");
+        assert_eq!(&tokens[5].surface, "할");
+        assert_eq!(&tokens[6].surface, "수");
+        assert_eq!(&tokens[7].surface, "있");
+        assert_eq!(&tokens[8].surface, "습니다");
     }
 }

--- a/lindera/src/token_filter/korean_stop_tags.rs
+++ b/lindera/src/token_filter/korean_stop_tags.rs
@@ -215,7 +215,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("한국어"),
+                surface: Cow::Borrowed("한국어"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -238,7 +238,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("의"),
+                surface: Cow::Borrowed("의"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -261,7 +261,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("형태소"),
+                surface: Cow::Borrowed("형태소"),
                 byte_start: 12,
                 byte_end: 21,
                 position: 2,
@@ -284,7 +284,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("분석"),
+                surface: Cow::Borrowed("분석"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 3,
@@ -307,7 +307,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("을"),
+                surface: Cow::Borrowed("을"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 4,
@@ -330,7 +330,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("할"),
+                surface: Cow::Borrowed("할"),
                 byte_start: 30,
                 byte_end: 33,
                 position: 5,
@@ -353,7 +353,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("수"),
+                surface: Cow::Borrowed("수"),
                 byte_start: 33,
                 byte_end: 36,
                 position: 6,
@@ -376,7 +376,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("있"),
+                surface: Cow::Borrowed("있"),
                 byte_start: 36,
                 byte_end: 39,
                 position: 7,
@@ -399,7 +399,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("습니다"),
+                surface: Cow::Borrowed("습니다"),
                 byte_start: 39,
                 byte_end: 48,
                 position: 8,
@@ -426,11 +426,11 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 6);
-        assert_eq!(&tokens[0].text, "한국어");
-        assert_eq!(&tokens[1].text, "형태소");
-        assert_eq!(&tokens[2].text, "분석");
-        assert_eq!(&tokens[3].text, "할");
-        assert_eq!(&tokens[4].text, "수");
-        assert_eq!(&tokens[5].text, "있");
+        assert_eq!(&tokens[0].surface, "한국어");
+        assert_eq!(&tokens[1].surface, "형태소");
+        assert_eq!(&tokens[2].surface, "분석");
+        assert_eq!(&tokens[3].surface, "할");
+        assert_eq!(&tokens[4].surface, "수");
+        assert_eq!(&tokens[5].surface, "있");
     }
 }

--- a/lindera/src/token_filter/length.rs
+++ b/lindera/src/token_filter/length.rs
@@ -42,7 +42,7 @@ impl TokenFilter for LengthTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         tokens.retain(|token| {
-            let len = token.text.chars().count();
+            let len = token.surface.chars().count();
             if let Some(min) = self.min {
                 if len < min {
                     return false;
@@ -145,7 +145,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("すもも"),
+                surface: Cow::Borrowed("すもも"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -169,7 +169,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -193,7 +193,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 2,
@@ -217,7 +217,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 18,
                 byte_end: 21,
                 position: 3,
@@ -241,7 +241,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 4,
@@ -265,7 +265,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("の"),
+                surface: Cow::Borrowed("の"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 5,
@@ -289,7 +289,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("うち"),
+                surface: Cow::Borrowed("うち"),
                 byte_start: 30,
                 byte_end: 36,
                 position: 6,
@@ -317,9 +317,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "すもも");
-        assert_eq!(&tokens[1].text, "もも");
-        assert_eq!(&tokens[2].text, "もも");
-        assert_eq!(&tokens[3].text, "うち");
+        assert_eq!(&tokens[0].surface, "すもも");
+        assert_eq!(&tokens[1].surface, "もも");
+        assert_eq!(&tokens[2].surface, "もも");
+        assert_eq!(&tokens[3].surface, "うち");
     }
 }

--- a/lindera/src/token_filter/lowercase.rs
+++ b/lindera/src/token_filter/lowercase.rs
@@ -38,7 +38,7 @@ impl TokenFilter for LowercaseTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            token.text = Cow::Owned(token.text.to_lowercase());
+            token.surface = Cow::Owned(token.surface.to_lowercase());
         }
 
         Ok(())
@@ -62,7 +62,7 @@ mod tests {
         let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![Token {
-            text: Cow::Borrowed("Rust"),
+            surface: Cow::Borrowed("Rust"),
             byte_start: 0,
             byte_end: 4,
             position: 0,
@@ -79,6 +79,6 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 1);
-        assert_eq!(&tokens[0].text, "rust");
+        assert_eq!(&tokens[0].surface, "rust");
     }
 }

--- a/lindera/src/token_filter/mapping.rs
+++ b/lindera/src/token_filter/mapping.rs
@@ -64,10 +64,10 @@ impl TokenFilter for MappingTokenFilter {
         for token in tokens.iter_mut() {
             let mut result = String::new();
             let mut start = 0_usize;
-            let len = token.text.len();
+            let len = token.surface.len();
 
             while start < len {
-                let suffix = &token.text[start..];
+                let suffix = &token.surface[start..];
                 match self
                     .trie
                     .common_prefix_search(suffix.as_bytes())
@@ -75,7 +75,7 @@ impl TokenFilter for MappingTokenFilter {
                     .map(|(_offset_len, prefix_len)| prefix_len)
                 {
                     Some(prefix_len) => {
-                        let surface = &token.text[start..start + prefix_len];
+                        let surface = &token.surface[start..start + prefix_len];
                         let replacement = &self.mapping[surface];
 
                         result.push_str(replacement);
@@ -97,7 +97,7 @@ impl TokenFilter for MappingTokenFilter {
                 }
             }
 
-            token.text = Cow::Owned(result);
+            token.surface = Cow::Owned(result);
         }
 
         Ok(())
@@ -168,7 +168,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("籠原"),
+                surface: Cow::Borrowed("籠原"),
                 byte_start: 0,
                 byte_end: 6,
                 position: 0,
@@ -192,7 +192,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("駅"),
+                surface: Cow::Borrowed("駅"),
                 byte_start: 6,
                 byte_end: 9,
                 position: 1,
@@ -220,7 +220,7 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 2);
-        assert_eq!(&tokens[0].text, "篭原");
-        assert_eq!(&tokens[1].text, "駅");
+        assert_eq!(&tokens[0].surface, "篭原");
+        assert_eq!(&tokens[1].surface, "駅");
     }
 }

--- a/lindera/src/token_filter/remove_diacritical_mark.rs
+++ b/lindera/src/token_filter/remove_diacritical_mark.rs
@@ -92,7 +92,7 @@ impl TokenFilter for RemoveDiacriticalMarkTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            token.text = Cow::Owned(self.remove_diacritic(token.text.as_ref()));
+            token.surface = Cow::Owned(self.remove_diacritic(token.surface.as_ref()));
         }
 
         Ok(())
@@ -153,7 +153,7 @@ mod tests {
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("café"),
+                surface: Cow::Borrowed("café"),
                 byte_start: 0,
                 byte_end: 4,
                 position: 0,
@@ -169,12 +169,12 @@ mod tests {
 
             filter.apply(&mut tokens).unwrap();
 
-            assert_eq!(tokens[0].text, "cafe");
+            assert_eq!(tokens[0].surface, "cafe");
         }
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("ガソリン"),
+                surface: Cow::Borrowed("ガソリン"),
                 byte_start: 0,
                 byte_end: 12,
                 position: 0,
@@ -200,7 +200,7 @@ mod tests {
 
             filter.apply(&mut tokens).unwrap();
 
-            assert_eq!(tokens[0].text, "ガソリン");
+            assert_eq!(tokens[0].surface, "ガソリン");
         }
     }
 
@@ -226,7 +226,7 @@ mod tests {
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("café"),
+                surface: Cow::Borrowed("café"),
                 byte_start: 0,
                 byte_end: 4,
                 position: 0,
@@ -242,12 +242,12 @@ mod tests {
 
             filter.apply(&mut tokens).unwrap();
 
-            assert_eq!(tokens[0].text, "cafe");
+            assert_eq!(tokens[0].surface, "cafe");
         }
 
         {
             let mut tokens: Vec<Token> = vec![Token {
-                text: Cow::Borrowed("ガソリン"),
+                surface: Cow::Borrowed("ガソリン"),
                 byte_start: 0,
                 byte_end: 12,
                 position: 0,
@@ -273,7 +273,7 @@ mod tests {
 
             filter.apply(&mut tokens).unwrap();
 
-            assert_eq!(tokens[0].text, "カソリン");
+            assert_eq!(tokens[0].surface, "カソリン");
         }
     }
 }

--- a/lindera/src/token_filter/stop_words.rs
+++ b/lindera/src/token_filter/stop_words.rs
@@ -50,7 +50,7 @@ impl TokenFilter for StopWordsTokenFilter {
     }
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
-        tokens.retain(|token| !self.words.contains(token.text.as_ref()));
+        tokens.retain(|token| !self.words.contains(token.surface.as_ref()));
 
         Ok(())
     }
@@ -114,7 +114,7 @@ mod tests {
 
         let mut tokens: Vec<Token> = vec![
             Token {
-                text: Cow::Borrowed("すもも"),
+                surface: Cow::Borrowed("すもも"),
                 byte_start: 0,
                 byte_end: 9,
                 position: 0,
@@ -138,7 +138,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 9,
                 byte_end: 12,
                 position: 1,
@@ -162,7 +162,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 12,
                 byte_end: 18,
                 position: 2,
@@ -186,7 +186,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("も"),
+                surface: Cow::Borrowed("も"),
                 byte_start: 18,
                 byte_end: 21,
                 position: 3,
@@ -210,7 +210,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("もも"),
+                surface: Cow::Borrowed("もも"),
                 byte_start: 21,
                 byte_end: 27,
                 position: 4,
@@ -234,7 +234,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("の"),
+                surface: Cow::Borrowed("の"),
                 byte_start: 27,
                 byte_end: 30,
                 position: 5,
@@ -258,7 +258,7 @@ mod tests {
                 ]),
             },
             Token {
-                text: Cow::Borrowed("うち"),
+                surface: Cow::Borrowed("うち"),
                 byte_start: 30,
                 byte_end: 36,
                 position: 6,
@@ -286,9 +286,9 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 4);
-        assert_eq!(&tokens[0].text, "すもも");
-        assert_eq!(&tokens[1].text, "もも");
-        assert_eq!(&tokens[2].text, "もも");
-        assert_eq!(&tokens[3].text, "うち");
+        assert_eq!(&tokens[0].surface, "すもも");
+        assert_eq!(&tokens[1].surface, "もも");
+        assert_eq!(&tokens[2].surface, "もも");
+        assert_eq!(&tokens[3].surface, "うち");
     }
 }

--- a/lindera/src/token_filter/uppercase.rs
+++ b/lindera/src/token_filter/uppercase.rs
@@ -38,7 +38,7 @@ impl TokenFilter for UppercaseTokenFilter {
 
     fn apply(&self, tokens: &mut Vec<Token<'_>>) -> LinderaResult<()> {
         for token in tokens.iter_mut() {
-            token.text = Cow::Owned(token.text.to_uppercase());
+            token.surface = Cow::Owned(token.surface.to_uppercase());
         }
 
         Ok(())
@@ -62,7 +62,7 @@ mod tests {
         let dictionary = load_embedded_dictionary(DictionaryKind::IPADIC).unwrap();
 
         let mut tokens: Vec<Token> = vec![Token {
-            text: Cow::Borrowed("Rust"),
+            surface: Cow::Borrowed("Rust"),
             byte_start: 0,
             byte_end: 4,
             position: 0,
@@ -79,6 +79,6 @@ mod tests {
         filter.apply(&mut tokens).unwrap();
 
         assert_eq!(tokens.len(), 1);
-        assert_eq!(&tokens[0].text, "RUST");
+        assert_eq!(&tokens[0].surface, "RUST");
     }
 }

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -461,7 +461,7 @@ mod tests {
             let mut tokens_iter = tokens.iter_mut();
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("Lindera"));
+                assert_eq!(token.surface, Cow::Borrowed("Lindera"));
                 assert_eq!(token.byte_start, 0);
                 assert_eq!(token.byte_end, 15);
                 assert_eq!(token.position, 0);
@@ -470,7 +470,7 @@ mod tests {
             }
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("形態素"));
+                assert_eq!(token.surface, Cow::Borrowed("形態素"));
                 assert_eq!(token.byte_start, 18);
                 assert_eq!(token.byte_end, 27);
                 assert_eq!(token.position, 2);
@@ -492,7 +492,7 @@ mod tests {
             }
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("解析"));
+                assert_eq!(token.surface, Cow::Borrowed("解析"));
                 assert_eq!(token.byte_start, 27);
                 assert_eq!(token.byte_end, 33);
                 assert_eq!(token.position, 3);
@@ -514,7 +514,7 @@ mod tests {
             }
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("エンジン"));
+                assert_eq!(token.surface, Cow::Borrowed("エンジン"));
                 assert_eq!(token.byte_start, 33);
                 assert_eq!(token.byte_end, 48);
                 assert_eq!(token.position, 4);
@@ -540,7 +540,7 @@ mod tests {
                 let token = tokens_iter.next().unwrap();
                 let start = token.byte_start;
                 let end = token.byte_end;
-                assert_eq!(token.text, Cow::Borrowed("Lindera"));
+                assert_eq!(token.surface, Cow::Borrowed("Lindera"));
                 assert_eq!(&text[start..end], "ﾘﾝﾃﾞﾗ");
             }
         }
@@ -551,7 +551,7 @@ mod tests {
             let mut tokens_iter = tokens.iter_mut();
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("10"));
+                assert_eq!(token.surface, Cow::Borrowed("10"));
                 assert_eq!(token.byte_start, 0);
                 assert_eq!(token.byte_end, 6);
                 assert_eq!(token.position, 0);
@@ -560,7 +560,7 @@ mod tests {
             }
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("ガロン"));
+                assert_eq!(token.surface, Cow::Borrowed("ガロン"));
                 assert_eq!(token.byte_start, 6);
                 assert_eq!(token.byte_end, 9);
                 assert_eq!(token.position, 1);
@@ -582,7 +582,7 @@ mod tests {
             }
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("ガソリン"));
+                assert_eq!(token.surface, Cow::Borrowed("ガソリン"));
                 assert_eq!(token.byte_start, 12);
                 assert_eq!(token.byte_end, 27);
                 assert_eq!(token.position, 3);
@@ -608,21 +608,21 @@ mod tests {
                 let token = tokens_iter.next().unwrap();
                 let start = token.byte_start;
                 let end = token.byte_end;
-                assert_eq!(token.text, Cow::Borrowed("10"));
+                assert_eq!(token.surface, Cow::Borrowed("10"));
                 assert_eq!(&text[start..end], "１０");
             }
             {
                 let token = tokens_iter.next().unwrap();
                 let start = token.byte_start;
                 let end = token.byte_end;
-                assert_eq!(token.text, Cow::Borrowed("ガロン"));
+                assert_eq!(token.surface, Cow::Borrowed("ガロン"));
                 assert_eq!(&text[start..end], "㌎");
             }
             {
                 let token = tokens_iter.next().unwrap();
                 let start = token.byte_start;
                 let end = token.byte_end;
-                assert_eq!(token.text, Cow::Borrowed("ガソリン"));
+                assert_eq!(token.surface, Cow::Borrowed("ガソリン"));
                 assert_eq!(&text[start..end], "ｶﾞｿﾘﾝ");
             }
         }
@@ -633,7 +633,7 @@ mod tests {
             let mut tokens_iter = tokens.iter_mut();
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("お釣り"));
+                assert_eq!(token.surface, Cow::Borrowed("お釣り"));
                 assert_eq!(token.byte_start, 0);
                 assert_eq!(token.byte_end, 9);
                 assert_eq!(token.position, 0);
@@ -655,7 +655,7 @@ mod tests {
             }
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("134円"));
+                assert_eq!(token.surface, Cow::Borrowed("134円"));
                 assert_eq!(token.byte_start, 12);
                 assert_eq!(token.byte_end, 27);
                 assert_eq!(token.position, 2);
@@ -683,7 +683,7 @@ mod tests {
             let mut tokens_iter = tokens.iter_mut();
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("ここ"));
+                assert_eq!(token.surface, Cow::Borrowed("ここ"));
                 assert_eq!(token.byte_start, 0);
                 assert_eq!(token.byte_end, 6);
                 assert_eq!(token.position, 0);
@@ -705,7 +705,7 @@ mod tests {
             }
             {
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.text, Cow::Borrowed("騒騒しい"));
+                assert_eq!(token.surface, Cow::Borrowed("騒騒しい"));
                 assert_eq!(token.byte_start, 9);
                 assert_eq!(token.byte_end, 21);
                 assert_eq!(token.position, 2);


### PR DESCRIPTION
refactor: Replace as_map() with as_value() for proper JSON type handling

- Add Token::as_value() method that returns serde_json::Value
- Numeric fields (byte_start, byte_end, word_id) are properly represented as JSON numbers
- Text fields remain as strings
- Custom fields are parsed as numbers when possible, otherwise kept as strings
- Remove deprecated as_map() method that returned all values as strings
- Update CLI to use as_value() instead of as_map() for JSON output

This change ensures that JSON output maintains proper type information,
making it easier for downstream consumers to process numeric data without
string-to-number conversions.