### PR TITLE
feat: Add APIs to reuse Lattice for performance optimization

### DIFF
--- a/lindera/benches/bench_ipadic.rs
+++ b/lindera/benches/bench_ipadic.rs
@@ -74,6 +74,20 @@ fn bench_tokenize_ipadic(c: &mut Criterion) {
 }
 
 #[cfg(feature = "embedded-ipadic")]
+fn bench_tokenize_with_lattice_ipadic(c: &mut Criterion) {
+    use lindera::dictionary::Lattice;
+
+    let dictionary = load_dictionary("embedded://ipadic").unwrap();
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+    let tokenizer = Tokenizer::new(segmenter);
+
+    c.bench_function("bench-tokenize-with-lattice-ipadic", |b| {
+        let mut lattice = Lattice::default();
+        b.iter(|| tokenizer.tokenize_with_lattice("検索エンジン（けんさくエンジン、英語: search engine）は、狭義にはインターネットに存在する情報（ウェブページ、ウェブサイト、画像ファイル、ネットニュースなど）を検索する機能およびそのプログラム。", &mut lattice))
+    });
+}
+
+#[cfg(feature = "embedded-ipadic")]
 fn bench_tokenize_with_simple_userdic_ipadic(c: &mut Criterion) {
     use std::fs::File;
 
@@ -161,6 +175,7 @@ criterion_group!(
     bench_constructor_ipadic,
     bench_constructor_with_simple_userdic_ipadic,
     bench_tokenize_ipadic,
+    bench_tokenize_with_lattice_ipadic,
     bench_tokenize_with_simple_userdic_ipadic,
     bench_tokenize_long_text_ipadic,
     bench_tokenize_details_long_text_ipadic,

--- a/lindera/src/dictionary.rs
+++ b/lindera/src/dictionary.rs
@@ -41,6 +41,7 @@ use crate::error::{LinderaError, LinderaErrorKind};
 pub type Dictionary = lindera_dictionary::dictionary::Dictionary;
 pub type Metadata = lindera_dictionary::dictionary::metadata::Metadata;
 pub type UserDictionary = lindera_dictionary::dictionary::UserDictionary;
+pub type Lattice = lindera_dictionary::viterbi::Lattice;
 pub type WordId = lindera_dictionary::viterbi::WordId;
 pub type DictionaryBuilder = lindera_dictionary::builder::DictionaryBuilder;
 pub type DictionaryConfig = Value;

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -8,12 +8,12 @@ use serde_json::{Value, json};
 
 use crate::LinderaResult;
 use crate::character_filter::{BoxCharacterFilter, CharacterFilterLoader, OffsetMapping};
+use crate::dictionary::Lattice;
 use crate::error::LinderaErrorKind;
 use crate::mode::Mode;
 use crate::segmenter::Segmenter;
 use crate::token::Token;
 use crate::token_filter::{BoxTokenFilter, TokenFilterLoader};
-use crate::dictionary::Lattice;
 
 pub type TokenizerConfig = Value;
 
@@ -420,7 +420,9 @@ impl Tokenizer {
 
         // Segment a text.
         // Segment a text.
-        let mut tokens = self.segmenter.segment_with_lattice(normalized_text, lattice)?;
+        let mut tokens = self
+            .segmenter
+            .segment_with_lattice(normalized_text, lattice)?;
 
         // Apply token filters to the tokens if they are not empty.
         for token_filter in &self.token_filters {

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -13,6 +13,7 @@ use crate::mode::Mode;
 use crate::segmenter::Segmenter;
 use crate::token::Token;
 use crate::token_filter::{BoxTokenFilter, TokenFilterLoader};
+use crate::dictionary::Lattice;
 
 pub type TokenizerConfig = Value;
 
@@ -317,7 +318,81 @@ impl Tokenizer {
     /// - `Cow<'a, str>` is used for the `normalized_text`, allowing the function to either borrow the original text or create an owned version if the text needs modification.
     /// - If no character filters are applied, the original `text` is used as-is for segmentation.
     /// - Token offsets are adjusted after the tokenization process if character filters were applied to ensure the byte positions of each token are accurate relative to the original text.
+    /// Tokenizes the input text using the tokenizer's segmenter, character filters, and token filters.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - A reference to the input text (`&str`) that will be tokenized.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `LinderaResult` containing a vector of `Token`s, where each `Token` represents a segment of the tokenized text.
+    ///
+    /// # Process
+    ///
+    /// 1. **Apply character filters**:
+    ///    - If any character filters are defined, they are applied to the input text before tokenization.
+    ///    - The `offsets`, `diffs`, and `text_len` are recorded for each character filter.
+    /// 2. **Segment the text**:
+    ///    - The `segmenter` divides the (potentially filtered) text into tokens.
+    /// 3. **Apply token filters**:
+    ///    - If any token filters are defined, they are applied to the segmented tokens.
+    /// 4. **Correct token offsets**:
+    ///    - If character filters were applied, the byte offsets of each token are corrected to account for changes introduced by those filters.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error if any of the character or token filters fail during processing.
+    /// - Returns an error if the segmentation process fails.
+    ///
+    /// # Details
+    ///
+    /// - `Cow<'a, str>` is used for the `normalized_text`, allowing the function to either borrow the original text or create an owned version if the text needs modification.
+    /// - If no character filters are applied, the original `text` is used as-is for segmentation.
+    /// - Token offsets are adjusted after the tokenization process if character filters were applied to ensure the byte positions of each token are accurate relative to the original text.
     pub fn tokenize<'a>(&'a self, text: &'a str) -> LinderaResult<Vec<Token<'a>>> {
+        let mut lattice = Lattice::default();
+        self.tokenize_with_lattice(text, &mut lattice)
+    }
+
+    /// Tokenizes the input text using the tokenizer's segmenter, character filters, and token filters.
+    ///
+    /// # Arguments
+    ///
+    /// * `text` - A reference to the input text (`&str`) that will be tokenized.
+    /// * `lattice` - A mutable reference to a `Lattice` structure. This allows reusing the lattice across multiple calls to avoid memory allocation.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `LinderaResult` containing a vector of `Token`s, where each `Token` represents a segment of the tokenized text.
+    ///
+    /// # Process
+    ///
+    /// 1. **Apply character filters**:
+    ///    - If any character filters are defined, they are applied to the input text before tokenization.
+    ///    - The `offsets`, `diffs`, and `text_len` are recorded for each character filter.
+    /// 2. **Segment the text**:
+    ///    - The `segmenter` divides the (potentially filtered) text into tokens.
+    /// 3. **Apply token filters**:
+    ///    - If any token filters are defined, they are applied to the segmented tokens.
+    /// 4. **Correct token offsets**:
+    ///    - If character filters were applied, the byte offsets of each token are corrected to account for changes introduced by those filters.
+    ///
+    /// # Errors
+    ///
+    /// - Returns an error if any of the character or token filters fail during processing.
+    /// - Returns an error if the segmentation process fails.
+    ///
+    /// # Details
+    ///
+    /// - `Cow<'a, str>` is used for the `normalized_text`, allowing the function to either borrow the original text or create an owned version if the text needs modification.
+    /// - If no character filters are applied, the original `text` is used as-is for segmentation.
+    /// - Token offsets are adjusted after the tokenization process if character filters were applied to ensure the byte positions of each token are accurate relative to the original text.
+    pub fn tokenize_with_lattice<'a>(
+        &'a self,
+        text: &'a str,
+        lattice: &mut Lattice,
+    ) -> LinderaResult<Vec<Token<'a>>> {
         let mut normalized_text: Cow<'a, str> = Cow::Borrowed(text);
 
         let mut offset_mappings: Vec<OffsetMapping> =
@@ -344,7 +419,8 @@ impl Tokenizer {
         let final_text_len = normalized_text.len();
 
         // Segment a text.
-        let mut tokens = self.segmenter.segment(normalized_text)?;
+        // Segment a text.
+        let mut tokens = self.segmenter.segment_with_lattice(normalized_text, lattice)?;
 
         // Apply token filters to the tokens if they are not empty.
         for token_filter in &self.token_filters {


### PR DESCRIPTION
This commit introduces segment_with_lattice and tokenize_with_lattice methods
to allow reusing the Lattice structure across multiple tokenization calls.
This avoids repeated memory allocations for the Lattice, significantly improving
performance in high-throughput scenarios.
Changes:
- Export Lattice type in lindera/src/dictionary.rs.
- Add segment_with_lattice to Segmenter.
- Add tokenize_with_lattice to Tokenizer.
- Add benchmark bench_tokenize_with_lattice_ipadic.
Benchmark results (IPADIC):
- `tokenize`: ~16.6 µs
- `tokenize_with_lattice`: ~10.3 µs (~38% improvement)
