### PR TITLE
Bump up version to 1.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           generate_release_notes: true
           make_latest: true
 
-  dictionary:
+  build-dictionary:
     name: Build Dictionary
     needs: [create-release]
     strategy:
@@ -122,7 +122,7 @@ jobs:
           files: ${{ matrix.dictionary.name }}-${{ steps.get_version.outputs.version }}.zip
           tag_name: ${{ github.ref_name }}
 
-  release:
+  build:
     name: Build
     needs: [create-release]
     strategy:
@@ -228,7 +228,7 @@ jobs:
 
   publish-crates:
     name: Publish crate
-    needs: [release]
+    needs: [build]
     strategy:
       matrix:
         platform:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,55 @@ jobs:
           generate_release_notes: true
           make_latest: true
 
+  dictionary:
+    name: Build Dictionary
+    needs: [create-release]
+    strategy:
+      matrix:
+        dictionary:
+          - name: "lindera-ipadic"
+            feature: "embedded-ipadic"
+          - name: "lindera-unidic"
+            feature: "embedded-unidic"
+          - name: "lindera-ko-dic"
+            feature: "embedded-ko-dic"
+          - name: "lindera-cc-cedict"
+            feature: "embedded-cc-cedict"
+          - name: "lindera-ipadic-neologd"
+            feature: "embedded-ipadic-neologd"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v6
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Build dictionary
+        run: |
+          LINDERA_CACHE=dictionaries cargo build -p ${{ matrix.dictionary.name }} --features ${{ matrix.dictionary.feature }}
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="${{ matrix.dictionary.name }}") | .version')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Create artifact
+        run: |
+          cd dictionaries/${{ steps.get_version.outputs.version }}
+          zip -r ../../${{ matrix.dictionary.name }}-${{ steps.get_version.outputs.version }}.zip ${{ matrix.dictionary.name }}
+
+      - name: Upload artifact
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: ${{ matrix.dictionary.name }}-${{ steps.get_version.outputs.version }}.zip
+          tag_name: ${{ github.ref_name }}
+
   release:
     name: Build
     needs: [create-release]

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ flamegraph.svg
 .claude
 .mcp.json
 .serena
+
+tmp/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.5.0"
+version = "1.5.1"
 edition = "2024"
 description = "A morphological analysis libraries and command line interface."
 documentation = "https://docs.rs/lindera"
@@ -24,17 +24,17 @@ categories = ["text-processing"]
 license = "MIT"
 
 [workspace.dependencies]
-lindera-dictionary = { version = "1.5.0", path = "lindera-dictionary" }
-lindera-cc-cedict = { version = "1.5.0", path = "lindera-cc-cedict" }
-lindera-ipadic = { version = "1.5.0", path = "lindera-ipadic" }
-lindera-ipadic-neologd = { version = "1.5.0", path = "lindera-ipadic-neologd" }
-lindera-ko-dic = { version = "1.5.0", path = "lindera-ko-dic" }
-lindera-unidic = { version = "1.5.0", path = "lindera-unidic" }
-lindera = { version = "1.5.0", path = "lindera" }
+lindera-dictionary = { version = "1.5.1", path = "lindera-dictionary" }
+lindera-cc-cedict = { version = "1.5.1", path = "lindera-cc-cedict" }
+lindera-ipadic = { version = "1.5.1", path = "lindera-ipadic" }
+lindera-ipadic-neologd = { version = "1.5.1", path = "lindera-ipadic-neologd" }
+lindera-ko-dic = { version = "1.5.1", path = "lindera-ko-dic" }
+lindera-unidic = { version = "1.5.1", path = "lindera-unidic" }
+lindera = { version = "1.5.1", path = "lindera" }
 
 anyhow = "1.0.100"
 byteorder = "1.5.0"
-clap = { version = "4.5.53", features = ["derive", "cargo"] }
+clap = { version = "4.5.54", features = ["derive", "cargo"] }
 criterion = { version = "0.8.1", default-features = false, features = [
     "html_reports",
 ] }
@@ -56,8 +56,8 @@ rand = { version = "0.9.2", default-features = false, features = [
     "small_rng",
 ] } # Specify `default-features` and `features` to support WebAssembly
 regex = "1.12.2"
-reqwest = { version = "0.12.28", features = [
-    "rustls-tls",
+reqwest = { version = "0.13.1", features = [
+    "rustls",
 ], default-features = false }
 rkyv = { version = "0.8.12", features = ["bytecheck"] }
 rucrf = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ strum = { version = "0.27.2", features = ["derive"] }
 strum_macros = "0.27.2"
 tar = "0.4.44"
 thiserror = "2.0.17"
-tokio = { version = "1.48.0", features = [
+tokio = { version = "1.49.0", features = [
     "rt",
     "macros",
     "time",

--- a/lindera-cc-cedict/build.rs
+++ b/lindera-cc-cedict/build.rs
@@ -28,7 +28,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let builder = DictionaryBuilder::new(metadata);
 
-    fetch(fetch_params, builder).await
+    fetch(fetch_params, builder).await?;
+
+    Ok(())
 }
 
 #[cfg(not(feature = "embedded-cc-cedict"))]

--- a/lindera-ipadic-neologd/build.rs
+++ b/lindera-ipadic-neologd/build.rs
@@ -28,7 +28,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let builder = DictionaryBuilder::new(metadata);
 
-    fetch(fetch_params, builder).await
+    fetch(fetch_params, builder).await?;
+
+    Ok(())
 }
 
 #[cfg(not(feature = "embedded-ipadic-neologd"))]

--- a/lindera-ipadic/build.rs
+++ b/lindera-ipadic/build.rs
@@ -28,7 +28,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let builder = DictionaryBuilder::new(metadata);
 
-    fetch(fetch_params, builder).await
+    fetch(fetch_params, builder).await?;
+
+    Ok(())
 }
 
 #[cfg(not(feature = "embedded-ipadic"))]

--- a/lindera-ko-dic/build.rs
+++ b/lindera-ko-dic/build.rs
@@ -28,7 +28,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let builder = DictionaryBuilder::new(metadata);
 
-    fetch(fetch_params, builder).await
+    fetch(fetch_params, builder).await?;
+
+    Ok(())
 }
 
 #[cfg(not(feature = "embedded-ko-dic"))]

--- a/lindera-unidic/build.rs
+++ b/lindera-unidic/build.rs
@@ -28,7 +28,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let builder = DictionaryBuilder::new(metadata);
 
-    fetch(fetch_params, builder).await
+    fetch(fetch_params, builder).await?;
+
+    Ok(())
 }
 
 #[cfg(not(feature = "embedded-unidic"))]


### PR DESCRIPTION
Refactor dictionary asset fetching and improve build script robustness

- Refactor [assets.rs](cci:7://file:///home/minoru/src/github.com/lindera/lindera/lindera-dictionary/src/assets.rs:0:0-0:0) helper functions ([empty_directory](cci:1://file:///home/minoru/src/github.com/lindera/lindera/lindera-dictionary/src/assets.rs:79:0-95:1), [rename_directory](cci:1://file:///home/minoru/src/github.com/lindera/lindera/lindera-dictionary/src/assets.rs:97:0-136:1)) for better cross-platform compatibility and robustness.
- Unify [copy_dir_all](cci:1://file:///home/minoru/src/github.com/lindera/lindera/lindera-dictionary/src/assets.rs:41:0-77:1) return type to `LinderaResult` to ensure consistent error handling.
- Improve `LINDERA_CACHE` environment variable handling:
  - Add `cargo:rerun-if-env-changed` to properly trigger rebuilds when the variable changes.
  - Implement logic to resolve relative paths against the workspace root (detecting parent Cargo.toml), preventing cache directories from being created inside individual crate folders.
- Update [build.rs](cci:7://file:///home/minoru/src/github.com/lindera/lindera/lindera-ipadic/build.rs:0:0-0:0) in all dictionary crates (`lindera-ipadic`, `lindera-unidic`, etc.) to adapt to the updated [fetch](cci:1://file:///home/minoru/src/github.com/lindera/lindera/lindera-dictionary/src/assets.rs:216:0-533:1) function signature.
- Update [.gitignore](cci:7://file:///home/minoru/src/github.com/lindera/lindera/.gitignore:0:0-0:0) to exclude the temporary `tmp/` directory.
- Bump `tokio` dependency version.