### PR TITLE
Refactor environment variables and update docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build dictionary
         run: |
-          LINDERA_CACHE=dictionaries cargo build -p ${{ matrix.dictionary.name }} --features ${{ matrix.dictionary.feature }}
+          LINDERA_DICTS=dictionaries cargo build -p ${{ matrix.dictionary.name }} --features ${{ matrix.dictionary.feature }}
 
       - name: Get version
         id: get_version

--- a/docs/ja/src/configuration.md
+++ b/docs/ja/src/configuration.md
@@ -1,7 +1,7 @@
 # 設定
 
 LinderaはYAML形式の設定ファイルを読み込むことができます。
-環境変数 `LINDERA_CONFIG_PATH` にファイルのパスを指定してください。Rustコードでトークナイザーの動作をコーディングすることなく、簡単に利用できます。
+環境変数 `LINDERA_CONFIG` にファイルのパスを指定してください。Rustコードでトークナイザーの動作をコーディングすることなく、簡単に利用できます。
 
 ```yaml
 segmenter:
@@ -73,7 +73,7 @@ token_filters:
 ```
 
 ```shell
-% export LINDERA_CONFIG_PATH=./resources/config/lindera.yml
+% export LINDERA_CONFIG=./resources/config/lindera.yml
 ```
 
 ```rust

--- a/docs/ja/src/installation.md
+++ b/docs/ja/src/installation.md
@@ -9,9 +9,9 @@ lindera = { version = "1.2.0", features = ["embedded-ipadic"] }
 
 ## 環境変数
 
-### LINDERA_CACHE
+### LINDERA_DICTS
 
-`LINDERA_CACHE` 環境変数は、辞書ソースファイルをキャッシュするディレクトリを指定します。これにより以下のメリットがあります：
+`LINDERA_DICTS` 環境変数は、辞書ソースファイルをキャッシュするディレクトリを指定します。これにより以下のメリットがあります：
 
 - **オフラインビルド**: 一度ダウンロードすれば、将来のビルドのために辞書ソースファイルが保存されます
 - **ビルドの高速化**: 有効なキャッシュファイルが存在する場合、次回のビルドではダウンロードがスキップされます
@@ -20,21 +20,27 @@ lindera = { version = "1.2.0", features = ["embedded-ipadic"] }
 使用方法：
 
 ```shell
-export LINDERA_CACHE=/path/to/cache
+export LINDERA_DICTS=/path/to/dicts
 cargo build --features=ipadic
 ```
 
-設定された場合、辞書ソースファイルは `$LINDERA_CACHE/<version>/` （`<version>` は lindera-dictionary クレートのバージョン）に保存されます。キャッシュはMD5チェックサムを使用してファイルを検証し、無効なファイルは自動的に再ダウンロードされます。
+設定された場合、辞書ソースファイルは `$LINDERA_DICTS/<version>/` （`<version>` は lindera-dictionary クレートのバージョン）に保存されます。キャッシュはMD5チェックサムを使用してファイルを検証し、無効なファイルは自動的に再ダウンロードされます。
 
-### LINDERA_CONFIG_PATH
+> [!NOTE]
+> `LINDERA_CACHE` は非推奨ですが、後方互換性のために引き続きサポートされています。`LINDERA_DICTS` が設定されていない場合に使用されます。
 
-`LINDERA_CONFIG_PATH` 環境変数は、トークナイザーの設定ファイル（YAML形式）へのパスを指定します。これにより、Rustコードを変更せずにトークナイザーの動作を設定できます。
+### LINDERA_CONFIG
+
+`LINDERA_CONFIG` 環境変数は、トークナイザーの設定ファイル（YAML形式）へのパスを指定します。これにより、Rustコードを変更せずにトークナイザーの動作を設定できます。
 
 ```shell
-export LINDERA_CONFIG_PATH=./resources/config/lindera.yml
+export LINDERA_CONFIG=./resources/config/lindera.yml
 ```
 
 設定フォーマットの詳細は [設定](./configuration.md) セクションを参照してください。
+
+> [!NOTE]
+> `LINDERA_CONFIG_PATH` は非推奨ですが、後方互換性のために引き続きサポートされています。`LINDERA_CONFIG` が設定されていない場合に使用されます。
 
 ### DOCS_RS
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 Lindera is able to read YAML format configuration files.
-Specify the path to the following file in the environment variable `LINDERA_CONFIG_PATH`. You can use it easily without having to code the behavior of the tokenizer in Rust code.
+Specify the path to the following file in the environment variable `LINDERA_CONFIG`. You can use it easily without having to code the behavior of the tokenizer in Rust code.
 
 ```yaml
 segmenter:
@@ -73,7 +73,7 @@ token_filters:
 ```
 
 ```shell
-% export LINDERA_CONFIG_PATH=./resources/config/lindera.yml
+% export LINDERA_CONFIG=./resources/config/lindera.yml
 ```
 
 ```rust

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -9,9 +9,9 @@ lindera = { version = "1.2.0", features = ["embedded-ipadic"] }
 
 ## Environment Variables
 
-### LINDERA_CACHE
+### LINDERA_DICTS
 
-The `LINDERA_CACHE` environment variable specifies a directory for caching dictionary source files. This enables:
+The `LINDERA_DICTS` environment variable specifies a directory for caching dictionary source files. This enables:
 
 - **Offline builds**: Once downloaded, dictionary source files are preserved for future builds
 - **Faster builds**: Subsequent builds skip downloading if valid cached files exist
@@ -20,21 +20,27 @@ The `LINDERA_CACHE` environment variable specifies a directory for caching dicti
 Usage:
 
 ```shell
-export LINDERA_CACHE=/path/to/cache
+export LINDERA_DICTS=/path/to/dicts
 cargo build --features=ipadic
 ```
 
-When set, dictionary source files are stored in `$LINDERA_CACHE/<version>/` where `<version>` is the lindera-dictionary crate version. The cache validates files using MD5 checksums - invalid files are automatically re-downloaded.
+When set, dictionary source files are stored in `$LINDERA_DICTS/<version>/` where `<version>` is the lindera-dictionary crate version. The cache validates files using MD5 checksums - invalid files are automatically re-downloaded.
 
-### LINDERA_CONFIG_PATH
+> [!NOTE]
+> `LINDERA_CACHE` is deprecated but still supported for backward compatibility. It will be used if `LINDERA_DICTS` is not set.
 
-The `LINDERA_CONFIG_PATH` environment variable specifies the path to a YAML configuration file for the tokenizer. This allows you to configure tokenizer behavior without modifying Rust code.
+### LINDERA_CONFIG
+
+The `LINDERA_CONFIG` environment variable specifies the path to a YAML configuration file for the tokenizer. This allows you to configure tokenizer behavior without modifying Rust code.
 
 ```shell
-export LINDERA_CONFIG_PATH=./resources/config/lindera.yml
+export LINDERA_CONFIG=./resources/config/lindera.yml
 ```
 
 See the [Configuration](./configuration.md) section for details on the configuration format.
+
+> [!NOTE]
+> `LINDERA_CONFIG_PATH` is deprecated but still supported for backward compatibility. It will be used if `LINDERA_CONFIG` is not set.
 
 ### DOCS_RS
 

--- a/lindera/Cargo.toml
+++ b/lindera/Cargo.toml
@@ -59,6 +59,7 @@ anyhow = { workspace = true }
 byteorder = { workspace = true }
 csv = { workspace = true }
 kanaria = { workspace = true }
+log = { workspace = true }
 once_cell = { workspace = true }
 percent-encoding = { workspace = true }
 regex = { workspace = true }

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -97,7 +97,10 @@ pub struct TokenizerBuilder {
 
 impl TokenizerBuilder {
     pub fn new() -> LinderaResult<Self> {
-        if let Ok(config_path) = env::var("LINDERA_CONFIG_PATH") {
+        if let Ok(config_path) = env::var("LINDERA_CONFIG") {
+            Self::from_file(Path::new(&config_path))
+        } else if let Ok(config_path) = env::var("LINDERA_CONFIG_PATH") {
+            log::warn!("LINDERA_CONFIG_PATH is deprecated. Please use LINDERA_CONFIG instead.");
             Self::from_file(Path::new(&config_path))
         } else {
             Ok(Self {


### PR DESCRIPTION
Refactor environment variables and update docs

- Rename LINDERA_CACHE to LINDERA_DICTS for clarity
- Rename LINDERA_CONFIG_PATH to LINDERA_CONFIG for consistency
- Maintain backward compatibility for old variables with deprecation warnings
- Refactor lindera-dictionary asset building to deduplicate path resolution logic
- Update English and Japanese documentation to reflect changes
- Add log dependency to lindera crate for runtime warnings
