### PR TITLE
Fix all clippy warnings with --all-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,10 @@ lindera-cli = { version = "2.1.1", path = "lindera-cli" }
 lindera-python = { version = "2.1.1", path = "lindera-python" }
 lindera-wasm = { version = "2.1.1", path = "lindera-wasm" }
 
-anyhow = "1.0.100"
+anyhow = "1.0.101"
 byteorder = "1.5.0"
-clap = { version = "4.5.56", features = ["derive", "cargo"] }
-criterion = { version = "0.8.1", default-features = false, features = [
+clap = { version = "4.5.57", features = ["derive", "cargo"] }
+criterion = { version = "0.8.2", default-features = false, features = [
     "html_reports",
 ] }
 csv = "1.4.0"
@@ -58,11 +58,9 @@ memmap2 = "0.9.9"
 num_cpus = "1.17.0"
 once_cell = "1.21.3"
 percent-encoding = "2.3.2"
-rand = { version = "0.9.2", default-features = false, features = [
-    "small_rng",
-] } # Specify `default-features` and `features` to support WebAssembly
+rand = { version = "0.10.0", default-features = false } # Specify `default-features` to support WebAssembly
 regex = "1.12.3"
-reqwest = { version = "0.13.1", features = [
+reqwest = { version = "0.13.2", features = [
     "rustls",
 ], default-features = false }
 rkyv = { version = "0.8.14", features = ["bytecheck"] }

--- a/lindera-dictionary/src/assets.rs
+++ b/lindera-dictionary/src/assets.rs
@@ -229,25 +229,24 @@ pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaRe
     // otherwise, keeps behavior of always redownloading and rebuilding
     let (build_dir, is_cache) = if let Some(path) = std::env::var_os("LINDERA_DICTIONARIES_PATH")
         .or_else(|| {
-            std::env::var_os("LINDERA_CACHE").map(|p| {
+            std::env::var_os("LINDERA_CACHE").inspect(|_| {
                 println!(
                     "cargo:warning=LINDERA_CACHE is deprecated. Please use LINDERA_DICTIONARIES_PATH instead."
                 );
-                p
             })
         }) {
         let mut cache_dir = PathBuf::from(path);
-        if !cache_dir.is_absolute() {
-            if let Ok(current_dir) = std::env::current_dir() {
-                // If current_dir is a crate directory in a workspace, try to find the workspace root
-                let mut root_dir = current_dir.clone();
-                if let Some(parent) = current_dir.parent() {
-                    if parent.join("Cargo.toml").exists() {
-                        root_dir = parent.to_path_buf();
-                    }
-                }
-                cache_dir = root_dir.join(cache_dir);
+        if !cache_dir.is_absolute()
+            && let Ok(current_dir) = std::env::current_dir()
+        {
+            // If current_dir is a crate directory in a workspace, try to find the workspace root
+            let mut root_dir = current_dir.clone();
+            if let Some(parent) = current_dir.parent()
+                && parent.join("Cargo.toml").exists()
+            {
+                root_dir = parent.to_path_buf();
             }
+            cache_dir = root_dir.join(cache_dir);
         }
 
         (

--- a/lindera-dictionary/src/compress.rs
+++ b/lindera-dictionary/src/compress.rs
@@ -35,7 +35,7 @@ pub fn compress(data: &[u8], algorithm: Algorithm) -> anyhow::Result<CompressedD
 
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, SeedableRng, rngs::SmallRng};
+    use rand::{RngExt, SeedableRng, rngs::SmallRng};
 
     use crate::decompress::decompress;
 

--- a/lindera-dictionary/src/decompress.rs
+++ b/lindera-dictionary/src/decompress.rs
@@ -23,7 +23,6 @@ use crate::error::{LinderaError, LinderaErrorKind};
 )]
 #[repr(u32)] // explicit representation for consistency
 #[serde(rename_all = "lowercase")]
-
 pub enum Algorithm {
     Deflate = 0,
     Zlib = 1,

--- a/lindera-dictionary/src/dictionary/metadata.rs
+++ b/lindera-dictionary/src/dictionary/metadata.rs
@@ -121,12 +121,11 @@ impl Metadata {
 
             if let Ok(compressed_data) =
                 rkyv::from_bytes::<CompressedData, rkyv::rancor::Error>(data)
+                && let Ok(decompressed) = decompress(compressed_data)
             {
-                if let Ok(decompressed) = decompress(compressed_data) {
-                    // Try to parse the decompressed data as JSON
-                    if let Ok(metadata) = serde_json::from_slice(&decompressed) {
-                        return Ok(metadata);
-                    }
+                // Try to parse the decompressed data as JSON
+                if let Ok(metadata) = serde_json::from_slice(&decompressed) {
+                    return Ok(metadata);
                 }
             }
         }

--- a/lindera-dictionary/src/loader/character_definition.rs
+++ b/lindera-dictionary/src/loader/character_definition.rs
@@ -38,7 +38,7 @@ impl CharacterDefinitionLoader {
             let mut aligned_decompressed = rkyv::util::AlignedVec::<16>::new();
             aligned_decompressed.extend_from_slice(&decompressed_data);
 
-            return CharacterDefinition::load(&aligned_decompressed);
+            CharacterDefinition::load(&aligned_decompressed)
         }
 
         #[cfg(not(feature = "compress"))]

--- a/lindera-dictionary/src/loader/unknown_dictionary.rs
+++ b/lindera-dictionary/src/loader/unknown_dictionary.rs
@@ -38,7 +38,7 @@ impl UnknownDictionaryLoader {
             let mut aligned_decompressed = rkyv::util::AlignedVec::<16>::new();
             aligned_decompressed.extend_from_slice(&decompressed_data);
 
-            return UnknownDictionary::load(&aligned_decompressed);
+            UnknownDictionary::load(&aligned_decompressed)
         }
 
         #[cfg(not(feature = "compress"))]

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -257,6 +257,7 @@ impl Lattice {
     // Forward Viterbi implementation:
     // Constructs the lattice and calculates the path costs simultaneously.
     // This improves performance by avoiding a separate lattice traversal pass.
+    #[allow(clippy::too_many_arguments)]
     pub fn set_text(
         &mut self,
         dict: &PrefixDictionary,
@@ -330,9 +331,11 @@ impl Lattice {
             }
         }
 
-        let mut start_edge = Edge::default();
-        start_edge.path_cost = 0;
-        start_edge.left_index = u16::MAX;
+        let start_edge = Edge {
+            path_cost: 0,
+            left_index: u16::MAX,
+            ..Default::default()
+        };
         self.ends_at[0].push(start_edge);
 
         // Index of the last character of unknown word
@@ -454,9 +457,11 @@ impl Lattice {
 
         // Connect EOS
         if !self.ends_at[len].is_empty() {
-            let mut eos_edge = Edge::default();
-            eos_edge.start_index = len as u32;
-            eos_edge.stop_index = len as u32;
+            let mut eos_edge = Edge {
+                start_index: len as u32,
+                stop_index: len as u32,
+                ..Default::default()
+            };
             // Calculate cost for EOS
             let left_edges = &self.ends_at[len];
             let mut best_cost = i32::MAX;

--- a/lindera-python/src/dictionary.rs
+++ b/lindera-python/src/dictionary.rs
@@ -50,7 +50,7 @@ use crate::metadata::PyMetadata;
 /// print(dictionary.metadata_name())
 /// print(dictionary.metadata_encoding())
 /// ```
-#[pyclass(name = "Dictionary")]
+#[pyclass(name = "Dictionary", from_py_object)]
 #[derive(Clone)]
 pub struct PyDictionary {
     pub inner: Dictionary,
@@ -104,7 +104,7 @@ impl PyDictionary {
 /// metadata = lindera.Metadata()
 /// user_dict = lindera.load_user_dictionary("/path/to/output", metadata)
 /// ```
-#[pyclass(name = "UserDictionary")]
+#[pyclass(name = "UserDictionary", from_py_object)]
 #[derive(Clone)]
 pub struct PyUserDictionary {
     pub inner: UserDictionary,

--- a/lindera-python/src/error.rs
+++ b/lindera-python/src/error.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 ///
 /// Represents errors that can occur during tokenization, dictionary operations,
 /// or other Lindera functionality.
-#[pyclass(name = "LinderaError")]
+#[pyclass(name = "LinderaError", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyLinderaError {
     message: String,

--- a/lindera-python/src/metadata.rs
+++ b/lindera-python/src/metadata.rs
@@ -31,7 +31,7 @@ use crate::schema::PySchema;
 /// Compression algorithm for dictionary data.
 ///
 /// Determines how dictionary data is compressed when saved to disk.
-#[pyclass(name = "CompressionAlgorithm")]
+#[pyclass(name = "CompressionAlgorithm", from_py_object)]
 #[derive(Debug, Clone)]
 pub enum PyCompressionAlgorithm {
     /// DEFLATE compression algorithm
@@ -100,7 +100,7 @@ impl From<CompressionAlgorithm> for PyCompressionAlgorithm {
 /// * `normalize_details` - Normalize morphological details (default: false)
 /// * `dictionary_schema` - Schema for main dictionary
 /// * `user_dictionary_schema` - Schema for user dictionary
-#[pyclass(name = "Metadata")]
+#[pyclass(name = "Metadata", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyMetadata {
     name: String,

--- a/lindera-python/src/mode.rs
+++ b/lindera-python/src/mode.rs
@@ -31,7 +31,7 @@ use lindera::mode::{Mode as LinderaMode, Penalty as LinderaPenalty};
 /// Tokenization mode.
 ///
 /// Determines how text is segmented into tokens.
-#[pyclass(name = "Mode")]
+#[pyclass(name = "Mode", from_py_object)]
 #[derive(Debug, Clone, Copy)]
 pub enum PyMode {
     /// Standard tokenization based on dictionary cost
@@ -112,7 +112,7 @@ impl From<LinderaMode> for PyMode {
 ///     other_penalty_length_penalty=1700
 /// )
 /// ```
-#[pyclass(name = "Penalty")]
+#[pyclass(name = "Penalty", from_py_object)]
 #[derive(Debug, Clone, Copy)]
 pub struct PyPenalty {
     kanji_penalty_length_threshold: usize,

--- a/lindera-python/src/schema.rs
+++ b/lindera-python/src/schema.rs
@@ -32,7 +32,7 @@ use lindera::dictionary::{FieldDefinition, FieldType, Schema};
 /// Field type in dictionary schema.
 ///
 /// Defines the type of a field in the dictionary entry.
-#[pyclass(name = "FieldType")]
+#[pyclass(name = "FieldType", from_py_object)]
 #[derive(Debug, Clone)]
 pub enum PyFieldType {
     /// Surface form (word text)
@@ -91,7 +91,7 @@ impl From<PyFieldType> for FieldType {
 /// Field definition in dictionary schema.
 ///
 /// Describes a single field in the dictionary entry format.
-#[pyclass(name = "FieldDefinition")]
+#[pyclass(name = "FieldDefinition", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyFieldDefinition {
     #[pyo3(get)]
@@ -169,7 +169,7 @@ impl From<PyFieldDefinition> for FieldDefinition {
 /// index = schema.get_field_index("pos")
 /// field = schema.get_field_by_name("reading")
 /// ```
-#[pyclass(name = "Schema")]
+#[pyclass(name = "Schema", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PySchema {
     #[pyo3(get)]

--- a/lindera-python/src/segmenter.rs
+++ b/lindera-python/src/segmenter.rs
@@ -3,7 +3,7 @@
 use pyo3::prelude::*;
 
 /// Core segmenter for morphological analysis.
-#[pyclass(name = "Segmenter")]
+#[pyclass(name = "Segmenter", from_py_object)]
 #[derive(Clone)]
 pub struct PySegmenter {
     pub inner: lindera::segmenter::Segmenter,

--- a/lindera-wasm/src/error.rs
+++ b/lindera-wasm/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use wasm_bindgen::prelude::*;
 
 /// Error type for Lindera operations.
@@ -8,6 +10,12 @@ pub struct JsLinderaError {
     pub message: String,
 }
 
+impl fmt::Display for JsLinderaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
 #[wasm_bindgen]
 impl JsLinderaError {
     #[wasm_bindgen(constructor)]
@@ -16,7 +24,7 @@ impl JsLinderaError {
     }
 
     #[wasm_bindgen(js_name = "toString")]
-    pub fn to_string(&self) -> String {
-        self.message.clone()
+    pub fn js_to_string(&self) -> String {
+        self.to_string()
     }
 }

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -349,22 +349,22 @@ impl Segmenter {
                 let absolute_end = sentence_start + byte_end;
 
                 // Skip whitespace tokens if keep_whitespace is false (default MeCab behavior)
-                if !self.keep_whitespace {
-                    if let Some(space_category_id) = self.space_category_id {
-                        // Check if this token consists only of whitespace characters
-                        let token_text = &sentence[byte_start..byte_end];
-                        let is_space = token_text.chars().all(|c| {
-                            self.dictionary
-                                .character_definition
-                                .lookup_categories(c)
-                                .contains(&space_category_id)
-                        });
+                if !self.keep_whitespace
+                    && let Some(space_category_id) = self.space_category_id
+                {
+                    // Check if this token consists only of whitespace characters
+                    let token_text = &sentence[byte_start..byte_end];
+                    let is_space = token_text.chars().all(|c| {
+                        self.dictionary
+                            .character_definition
+                            .lookup_categories(c)
+                            .contains(&space_category_id)
+                    });
 
-                        if is_space {
-                            // Update byte_position to maintain correct offsets
-                            byte_position += byte_end - byte_start;
-                            continue;
-                        }
+                    if is_space {
+                        // Update byte_position to maintain correct offsets
+                        byte_position += byte_end - byte_start;
+                        continue;
                     }
                 }
 

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -318,38 +318,6 @@ impl Tokenizer {
     /// - `Cow<'a, str>` is used for the `normalized_text`, allowing the function to either borrow the original text or create an owned version if the text needs modification.
     /// - If no character filters are applied, the original `text` is used as-is for segmentation.
     /// - Token offsets are adjusted after the tokenization process if character filters were applied to ensure the byte positions of each token are accurate relative to the original text.
-    /// Tokenizes the input text using the tokenizer's segmenter, character filters, and token filters.
-    ///
-    /// # Arguments
-    ///
-    /// * `text` - A reference to the input text (`&str`) that will be tokenized.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `LinderaResult` containing a vector of `Token`s, where each `Token` represents a segment of the tokenized text.
-    ///
-    /// # Process
-    ///
-    /// 1. **Apply character filters**:
-    ///    - If any character filters are defined, they are applied to the input text before tokenization.
-    ///    - The `offsets`, `diffs`, and `text_len` are recorded for each character filter.
-    /// 2. **Segment the text**:
-    ///    - The `segmenter` divides the (potentially filtered) text into tokens.
-    /// 3. **Apply token filters**:
-    ///    - If any token filters are defined, they are applied to the segmented tokens.
-    /// 4. **Correct token offsets**:
-    ///    - If character filters were applied, the byte offsets of each token are corrected to account for changes introduced by those filters.
-    ///
-    /// # Errors
-    ///
-    /// - Returns an error if any of the character or token filters fail during processing.
-    /// - Returns an error if the segmentation process fails.
-    ///
-    /// # Details
-    ///
-    /// - `Cow<'a, str>` is used for the `normalized_text`, allowing the function to either borrow the original text or create an owned version if the text needs modification.
-    /// - If no character filters are applied, the original `text` is used as-is for segmentation.
-    /// - Token offsets are adjusted after the tokenization process if character filters were applied to ensure the byte positions of each token are accurate relative to the original text.
     pub fn tokenize<'a>(&'a self, text: &'a str) -> LinderaResult<Vec<Token<'a>>> {
         let mut lattice = Lattice::default();
         self.tokenize_with_lattice(text, &mut lattice)


### PR DESCRIPTION
- lindera-dictionary: fix empty_line_after_outer_attr, manual_inspect,
  collapsible_if, needless_return, field_reassign_with_default, and
  suppress too_many_arguments
- lindera: fix collapsible_if and remove duplicate doc comment
- lindera-python: add from_py_object to all pyclass attributes for
  pyo3 0.28 deprecation
- lindera-wasm: implement Display trait for JsLinderaError instead of
  inherent to_string