### PR TITLE
Add unknown word POS estimation from unk.def

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ mecab-ipadic-neologd-0.0.7
 CC-CEDICT-MeCab-master
 
 # Temporary files
-tmp/
+.tmp/

--- a/lindera-dictionary/src/dictionary.rs
+++ b/lindera-dictionary/src/dictionary.rs
@@ -39,6 +39,14 @@ pub struct Dictionary {
 }
 
 impl Dictionary {
+    /// Retrieve the detail fields (POS, etc.) for an unknown word entry.
+    pub fn unknown_word_details(&self, word_id: usize) -> Vec<&str> {
+        match self.unknown_dictionary.word_details(word_id as u32) {
+            Some(details) => details,
+            None => UNK.to_vec(),
+        }
+    }
+
     pub fn word_details(&self, word_id: usize) -> Vec<&str> {
         if 4 * word_id >= self.prefix_dictionary.words_idx_data.len() {
             return vec![];

--- a/lindera-dictionary/src/dictionary/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/unknown_dictionary.rs
@@ -48,8 +48,7 @@ impl UnknownDictionary {
         if offset + 4 > self.words_data.len() {
             return None;
         }
-        let len =
-            u32::from_le_bytes(self.words_data[offset..offset + 4].try_into().ok()?) as usize;
+        let len = u32::from_le_bytes(self.words_data[offset..offset + 4].try_into().ok()?) as usize;
         if offset + 4 + len > self.words_data.len() {
             return None;
         }

--- a/lindera-dictionary/src/dictionary/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/unknown_dictionary.rs
@@ -14,6 +14,11 @@ use crate::viterbi::WordEntry;
 pub struct UnknownDictionary {
     pub category_references: Vec<Vec<u32>>,
     pub costs: Vec<WordEntry>,
+    /// Byte offset for each entry's details in `words_data`.
+    pub words_idx_data: Vec<u32>,
+    /// Packed details bytes: for each entry, 4-byte LE length followed by
+    /// NUL-separated detail fields (e.g. "名詞\0一般\0*\0...").
+    pub words_data: Vec<u8>,
 }
 
 impl UnknownDictionary {
@@ -31,6 +36,25 @@ impl UnknownDictionary {
 
     pub fn lookup_word_ids(&self, category_id: CategoryId) -> &[u32] {
         &self.category_references[category_id.0][..]
+    }
+
+    /// Retrieve the detail fields (POS, etc.) for an unknown word entry.
+    pub fn word_details(&self, word_id: u32) -> Option<Vec<&str>> {
+        let idx = word_id as usize;
+        if idx >= self.words_idx_data.len() {
+            return None;
+        }
+        let offset = self.words_idx_data[idx] as usize;
+        if offset + 4 > self.words_data.len() {
+            return None;
+        }
+        let len =
+            u32::from_le_bytes(self.words_data[offset..offset + 4].try_into().ok()?) as usize;
+        if offset + 4 + len > self.words_data.len() {
+            return None;
+        }
+        let text = std::str::from_utf8(&self.words_data[offset + 4..offset + 4 + len]).ok()?;
+        Some(text.split('\0').collect())
     }
 
     /// Unknown word generation with callback system
@@ -230,14 +254,15 @@ fn make_category_references(
 fn make_costs_array(entries: &[UnknownDictionaryEntry]) -> Vec<WordEntry> {
     entries
         .iter()
-        .map(|e| {
+        .enumerate()
+        .map(|(i, e)| {
             // Do not perform strict checks on left context id and right context id in unk.def.
             // Just output a warning.
             if e.left_id != e.right_id {
                 warn!("left id and right id are not same: {e:?}");
             }
             WordEntry {
-                word_id: crate::viterbi::WordId::new(crate::viterbi::LexType::Unknown, u32::MAX),
+                word_id: crate::viterbi::WordId::new(crate::viterbi::LexType::Unknown, i as u32),
                 left_id: e.left_id as u16,
                 right_id: e.right_id as u16,
                 word_cost: e.word_cost as i16,
@@ -248,10 +273,27 @@ fn make_costs_array(entries: &[UnknownDictionaryEntry]) -> Vec<WordEntry> {
 
 pub fn parse_unk(categories: &[String], file_content: &str) -> LinderaResult<UnknownDictionary> {
     let mut unknown_dict_entries = Vec::new();
+    let mut words_idx_data = Vec::new();
+    let mut words_data: Vec<u8> = Vec::new();
+
     for line in file_content.lines() {
         let fields: Vec<&str> = line.split(',').collect::<Vec<&str>>();
         let entry = parse_dictionary_entry(&fields[..], fields.len())?;
         unknown_dict_entries.push(entry);
+
+        // Store detail fields (columns after the first 4: category, left_id, right_id, cost)
+        let offset = words_data.len() as u32;
+        words_idx_data.push(offset);
+
+        let details = if fields.len() > 4 {
+            fields[4..].join("\0")
+        } else {
+            String::new()
+        };
+        let details_bytes = details.as_bytes();
+        let len = details_bytes.len() as u32;
+        words_data.extend_from_slice(&len.to_le_bytes());
+        words_data.extend_from_slice(details_bytes);
     }
 
     let category_references = make_category_references(categories, &unknown_dict_entries[..]);
@@ -259,6 +301,8 @@ pub fn parse_unk(categories: &[String], file_content: &str) -> LinderaResult<Unk
     Ok(UnknownDictionary {
         category_references,
         costs,
+        words_idx_data,
+        words_data,
     })
 }
 
@@ -274,5 +318,24 @@ impl ArchivedUnknownDictionary {
 
     pub fn lookup_word_ids(&self, category_id: CategoryId) -> &[rkyv::rend::u32_le] {
         self.category_references[category_id.0].as_slice()
+    }
+
+    /// Retrieve the detail fields (POS, etc.) for an unknown word entry.
+    pub fn word_details(&self, word_id: u32) -> Option<Vec<&str>> {
+        let idx = word_id as usize;
+        if idx >= self.words_idx_data.len() {
+            return None;
+        }
+        let offset = u32::from(self.words_idx_data[idx]) as usize;
+        if offset + 4 > self.words_data.len() {
+            return None;
+        }
+        let len_bytes: [u8; 4] = self.words_data[offset..offset + 4].try_into().ok()?;
+        let len = u32::from_le_bytes(len_bytes) as usize;
+        if offset + 4 + len > self.words_data.len() {
+            return None;
+        }
+        let text = std::str::from_utf8(&self.words_data[offset + 4..offset + 4 + len]).ok()?;
+        Some(text.split('\0').collect())
     }
 }

--- a/lindera-dictionary/src/trainer/config.rs
+++ b/lindera-dictionary/src/trainer/config.rs
@@ -456,6 +456,8 @@ impl TrainerConfig {
         Ok(UnknownDictionary {
             category_references: vec![vec![0]; 6], // One for each category
             costs: vec![],                         // Will be filled during training
+            words_idx_data: vec![],
+            words_data: vec![],
         })
     }
 

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -65,7 +65,7 @@ impl WordId {
     }
 
     pub fn is_unknown(&self) -> bool {
-        self.id == u32::MAX || matches!(self.lex_type, LexType::Unknown)
+        matches!(self.lex_type, LexType::Unknown)
     }
 
     pub fn is_system(&self) -> bool {

--- a/lindera-ko-dic/README.md
+++ b/lindera-ko-dic/README.md
@@ -22,7 +22,7 @@ The dictionary format is specified fully (in Korean) in tab `사전 형식 v2.0`
 | 1 | 왼쪽 문맥 ID | Left context ID | |
 | 2 | 오른쪽 문맥 ID | Right context ID | |
 | 3 | 비용 | Cost | |
-| 4 | 품사 태그 | Part-of-speech tag | See `태그 v2.0` tab on spreadsheet  |
+| 4 | 품사 태그 | Part-of-speech tag | See `태그 v2.0` tab on spreadsheet |
 | 5 | 의미 부류 | Meaning | (too few examples for me to be sure) |
 | 6 | 종성 유무 | Presence or absence | `T` for true; `F` for false; else `*` |
 | 7 | 읽기 | Reading | usually matches surface, but may differ for foreign words e.g. Chinese character words |
@@ -38,7 +38,7 @@ The dictionary format is specified fully (in Korean) in tab `사전 형식 v2.0`
 | Index | Name (Japanese) | Name (English) | Notes |
 | --- | --- | --- | --- |
 | 0 | 표면 | Surface | |
-| 1 | 품사 태그 | part-of-speech tag | See `태그 v2.0` tab on spreadsheet  |
+| 1 | 품사 태그 | part-of-speech tag | See `태그 v2.0` tab on spreadsheet |
 | 2 | 읽기 | reading | usually matches surface, but may differ for foreign words e.g. Chinese character words |
 
 ### Detailed version
@@ -49,7 +49,7 @@ The dictionary format is specified fully (in Korean) in tab `사전 형식 v2.0`
 | 1 | 왼쪽 문맥 ID | Left context ID | |
 | 2 | 오른쪽 문맥 ID | Right context ID | |
 | 3 | 비용 | Cost | |
-| 4 | 품사 태그 | part-of-speech tag | See `태그 v2.0` tab on spreadsheet  |
+| 4 | 품사 태그 | part-of-speech tag | See `태그 v2.0` tab on spreadsheet |
 | 5 | 의미 부류 | meaning | (too few examples for me to be sure) |
 | 6 | 종성 유무 | presence or absence | `T` for true; `F` for false; else `*` |
 | 7 | 읽기 | reading | usually matches surface, but may differ for foreign words e.g. Chinese character words |

--- a/lindera-python/src/token.rs
+++ b/lindera-python/src/token.rs
@@ -56,7 +56,12 @@ impl PyToken {
     fn __repr__(&self) -> String {
         format!(
             "<Token surface='{}', start={}, end={}, position={}, word_id={}, is_unknown={}>",
-            self.surface, self.byte_start, self.byte_end, self.position, self.word_id, self.is_unknown
+            self.surface,
+            self.byte_start,
+            self.byte_end,
+            self.position,
+            self.word_id,
+            self.is_unknown
         )
     }
 }

--- a/lindera-python/src/token.rs
+++ b/lindera-python/src/token.rs
@@ -27,6 +27,10 @@ pub struct PyToken {
     #[pyo3(get)]
     pub word_id: u32,
 
+    /// Whether this token is an unknown word (not found in the dictionary).
+    #[pyo3(get)]
+    pub is_unknown: bool,
+
     /// Morphological details of the token.
     #[pyo3(get)]
     pub details: Option<Vec<String>>,
@@ -51,8 +55,8 @@ impl PyToken {
     /// Returns a string representation of the token.
     fn __repr__(&self) -> String {
         format!(
-            "<Token surface='{}', start={}, end={}, position={}, word_id={}>",
-            self.surface, self.byte_start, self.byte_end, self.position, self.word_id
+            "<Token surface='{}', start={}, end={}, position={}, word_id={}, is_unknown={}>",
+            self.surface, self.byte_start, self.byte_end, self.position, self.word_id, self.is_unknown
         )
     }
 }
@@ -69,6 +73,7 @@ impl PyToken {
             byte_end: token.byte_end,
             position: token.position,
             word_id: token.word_id.id,
+            is_unknown: token.word_id.is_unknown(),
             details: Some(details),
         }
     }

--- a/lindera-unidic/README.md
+++ b/lindera-unidic/README.md
@@ -31,8 +31,8 @@ Refer to the [manual](ftp://ftp.jaist.ac.jp/pub/sourceforge.jp/unidic/57618/unid
 | 16 | 語種 | Word type | |
 | 17 | 語頭変化型 | Initial mutation type | |
 | 18 | 語頭変化形 | Initial mutation form | |
-| 19 | 語末変化型 | Final mutation type  | |
-| 20 | 語末変化形 | Final mutation form  | |
+| 19 | 語末変化型 | Final mutation type | |
+| 20 | 語末変化形 | Final mutation form | |
 
 ## User dictionary format (CSV)
 
@@ -67,8 +67,8 @@ Refer to the [manual](ftp://ftp.jaist.ac.jp/pub/sourceforge.jp/unidic/57618/unid
 | 16 | 語種 | Word type | |
 | 17 | 語頭変化型 | Initial mutation type | |
 | 18 | 語頭変化形 | Initial mutation form | |
-| 19 | 語末変化型 | Final mutation type  | |
-| 20 | 語末変化形 | Final mutation form  | |
+| 19 | 語末変化型 | Final mutation type | |
+| 20 | 語末変化形 | Final mutation form | |
 | 21 | - | - | After 21, it can be freely expanded. |
 
 ## API reference

--- a/lindera-wasm/src/token.rs
+++ b/lindera-wasm/src/token.rs
@@ -23,6 +23,9 @@ pub struct JsToken {
     /// Word ID in the dictionary.
     pub word_id: u32,
 
+    /// Whether this token is an unknown word (not found in the dictionary).
+    pub is_unknown: bool,
+
     /// Morphological details of the token.
     #[wasm_bindgen(getter_with_clone)]
     pub details: Vec<String>,
@@ -56,6 +59,11 @@ impl JsToken {
         let _ = js_sys::Reflect::set(&js_obj, &"byteEnd".into(), &(self.byte_end as f64).into());
         let _ = js_sys::Reflect::set(&js_obj, &"position".into(), &(self.position as f64).into());
         let _ = js_sys::Reflect::set(&js_obj, &"wordId".into(), &(self.word_id as f64).into());
+        let _ = js_sys::Reflect::set(
+            &js_obj,
+            &"isUnknown".into(),
+            &self.is_unknown.into(),
+        );
 
         let js_details = js_sys::Array::new();
         for detail in &self.details {
@@ -77,6 +85,7 @@ impl JsToken {
             byte_end: token.byte_end,
             position: token.position,
             word_id: token.word_id.id,
+            is_unknown: token.word_id.is_unknown(),
             details,
         }
     }

--- a/lindera-wasm/src/token.rs
+++ b/lindera-wasm/src/token.rs
@@ -59,11 +59,7 @@ impl JsToken {
         let _ = js_sys::Reflect::set(&js_obj, &"byteEnd".into(), &(self.byte_end as f64).into());
         let _ = js_sys::Reflect::set(&js_obj, &"position".into(), &(self.position as f64).into());
         let _ = js_sys::Reflect::set(&js_obj, &"wordId".into(), &(self.word_id as f64).into());
-        let _ = js_sys::Reflect::set(
-            &js_obj,
-            &"isUnknown".into(),
-            &self.is_unknown.into(),
-        );
+        let _ = js_sys::Reflect::set(&js_obj, &"isUnknown".into(), &self.is_unknown.into());
 
         let js_details = js_sys::Array::new();
         for detail in &self.details {

--- a/lindera/src/segmenter.rs
+++ b/lindera/src/segmenter.rs
@@ -1431,7 +1431,11 @@ mod tests {
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 5);
             assert_eq!(token.position_length, 1);
-            assert_eq!(token.details(), vec!["UNK"]);
+            assert!(token.word_id.is_unknown());
+            assert_eq!(
+                token.details(),
+                vec!["*", "*", "*", "*", "*", "*", "*", "*"]
+            );
         }
     }
 
@@ -2033,7 +2037,11 @@ mod tests {
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 4);
             assert_eq!(token.position_length, 1);
-            assert_eq!(token.details(), vec!["UNK"]);
+            assert!(token.word_id.is_unknown());
+            assert_eq!(
+                token.details(),
+                vec!["*", "*", "*", "*", "*", "*", "*", "*"]
+            );
         }
     }
 
@@ -2635,7 +2643,11 @@ mod tests {
             assert_eq!(token.byte_end, 30);
             assert_eq!(token.position, 4);
             assert_eq!(token.position_length, 1);
-            assert_eq!(token.details(), vec!["UNK"]);
+            assert!(token.word_id.is_unknown());
+            assert_eq!(
+                token.details(),
+                vec!["*", "*", "*", "*", "*", "*", "*", "*"]
+            );
         }
     }
 
@@ -2890,7 +2902,11 @@ mod tests {
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 2);
             assert_eq!(token.position_length, 1);
-            assert_eq!(token.details(), vec!["UNK"]);
+            assert!(token.word_id.is_unknown());
+            assert_eq!(
+                token.details(),
+                vec!["名詞", "一般", "*", "*", "*", "*", "*", "*", "*"]
+            );
         }
     }
 
@@ -2989,7 +3005,11 @@ mod tests {
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 3);
             assert_eq!(token.position_length, 1);
-            assert_eq!(token.details(), vec!["UNK"]);
+            assert!(token.word_id.is_unknown());
+            assert_eq!(
+                token.details(),
+                vec!["名詞", "一般", "*", "*", "*", "*", "*", "*", "*"]
+            );
         }
     }
 
@@ -3082,7 +3102,11 @@ mod tests {
             assert_eq!(token.byte_end, 36);
             assert_eq!(token.position, 3);
             assert_eq!(token.position_length, 1);
-            assert_eq!(token.details(), vec!["UNK"]);
+            assert!(token.word_id.is_unknown());
+            assert_eq!(
+                token.details(),
+                vec!["名詞", "一般", "*", "*", "*", "*", "*", "*", "*"]
+            );
         }
     }
 

--- a/lindera/src/token.rs
+++ b/lindera/src/token.rs
@@ -138,7 +138,8 @@ impl<'a> Token<'a> {
     fn ensure_details(&mut self) {
         if self.details.is_none() {
             let tmp = if self.word_id.is_unknown() {
-                self.dictionary.unknown_word_details(self.word_id.id as usize)
+                self.dictionary
+                    .unknown_word_details(self.word_id.id as usize)
             } else if self.word_id.is_system() {
                 self.dictionary.word_details(self.word_id.id as usize)
             } else {
@@ -148,8 +149,7 @@ impl<'a> Token<'a> {
                 }
             };
 
-            let mut details: Vec<Cow<'a, str>> =
-                tmp.into_iter().map(Cow::Borrowed).collect();
+            let mut details: Vec<Cow<'a, str>> = tmp.into_iter().map(Cow::Borrowed).collect();
 
             // Pad details to match the dictionary schema's custom field count so that
             // token filters can safely access any field by index.

--- a/lindera/src/tokenizer.rs
+++ b/lindera/src/tokenizer.rs
@@ -519,7 +519,21 @@ mod tests {
                 assert_eq!(token.byte_end, 15);
                 assert_eq!(token.position, 0);
                 assert_eq!(token.position_length, 1);
-                assert_eq!(token.details, Some(vec![Cow::Borrowed("UNK")]));
+                assert!(token.word_id.is_unknown());
+                assert_eq!(
+                    token.details,
+                    Some(vec![
+                        Cow::Borrowed("名詞"),
+                        Cow::Borrowed("固有名詞"),
+                        Cow::Borrowed("組織"),
+                        Cow::Borrowed("*"),
+                        Cow::Borrowed("*"),
+                        Cow::Borrowed("*"),
+                        Cow::Borrowed("*"),
+                        Cow::Borrowed("*"),
+                        Cow::Borrowed("*"),
+                    ])
+                );
             }
             {
                 let token = tokens_iter.next().unwrap();
@@ -603,35 +617,14 @@ mod tests {
             let mut tokens = tokenizer.tokenize(text).unwrap();
             let mut tokens_iter = tokens.iter_mut();
             {
+                // "10" (unknown NUMERIC) and "ガロン" (名詞,接尾,助数詞) are merged
+                // by the japanese_compound_word filter into "10ガロン" with tag "名詞,数".
                 let token = tokens_iter.next().unwrap();
-                assert_eq!(token.surface, Cow::Borrowed("10"));
+                assert_eq!(token.surface, Cow::Owned::<str>("10ガロン".into()));
                 assert_eq!(token.byte_start, 0);
-                assert_eq!(token.byte_end, 6);
-                assert_eq!(token.position, 0);
-                assert_eq!(token.position_length, 1);
-                assert_eq!(token.details, Some(vec![Cow::Borrowed("UNK")]));
-            }
-            {
-                let token = tokens_iter.next().unwrap();
-                assert_eq!(token.surface, Cow::Borrowed("ガロン"));
-                assert_eq!(token.byte_start, 6);
                 assert_eq!(token.byte_end, 9);
-                assert_eq!(token.position, 1);
-                assert_eq!(token.position_length, 1);
-                assert_eq!(
-                    token.details,
-                    Some(vec![
-                        Cow::Borrowed("名詞"),
-                        Cow::Borrowed("接尾"),
-                        Cow::Borrowed("助数詞"),
-                        Cow::Borrowed("*"),
-                        Cow::Borrowed("*"),
-                        Cow::Borrowed("*"),
-                        Cow::Borrowed("ガロン"),
-                        Cow::Borrowed("ガロン"),
-                        Cow::Borrowed("ガロン"),
-                    ])
-                );
+                assert_eq!(token.position, 0);
+                assert_eq!(token.position_length, 2);
             }
             {
                 let token = tokens_iter.next().unwrap();
@@ -658,18 +651,12 @@ mod tests {
 
             let mut tokens_iter = tokens.iter();
             {
+                // "10" and "ガロン" are merged by the japanese_compound_word filter
                 let token = tokens_iter.next().unwrap();
                 let start = token.byte_start;
                 let end = token.byte_end;
-                assert_eq!(token.surface, Cow::Borrowed("10"));
-                assert_eq!(&text[start..end], "１０");
-            }
-            {
-                let token = tokens_iter.next().unwrap();
-                let start = token.byte_start;
-                let end = token.byte_end;
-                assert_eq!(token.surface, Cow::Borrowed("ガロン"));
-                assert_eq!(&text[start..end], "㌎");
+                assert_eq!(token.surface, Cow::Owned::<str>("10ガロン".into()));
+                assert_eq!(&text[start..end], "１０㌎");
             }
             {
                 let token = tokens_iter.next().unwrap();


### PR DESCRIPTION
Store POS detail fields from unk.def into UnknownDictionary during dictionary build, and return them via Token::details() instead of ["UNK"]. Unknown word entries now use their entry index as word_id.id (previously u32::MAX), enabling POS lookup at tokenization time. Details are padded with "*" to match the dictionary schema field count so that token filters can safely access any field by index.

Also expose is_unknown flag in lindera-wasm and lindera-python bindings.