### PR TITLE
feat(lindera-wasm): Add OPFS-based external dictionary loading support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -860,11 +860,31 @@ jobs:
           cd lindera-wasm
           wasm-pack build --release --target ${{ matrix.target.value }} ${{ matrix.features.value != '' && format('--features {0}', matrix.features.value) || '' }}
 
+      - name: Copy JS helpers to pkg
+        shell: bash
+        run: |
+          cp lindera-wasm/js/opfs.js lindera-wasm/pkg/
+          cp lindera-wasm/js/opfs.d.ts lindera-wasm/pkg/
+
       - name: Update package.json
         shell: bash
         run: |
           cd lindera-wasm/pkg
-          jq '.name = "lindera-wasm-${{ matrix.target.name }}${{ matrix.features.package_suffix }}" | .description = "${{ matrix.features.package_description }} (${{ matrix.target.name }} target)"' package.json > package.json.tmp
+          jq '
+            .name = "lindera-wasm-${{ matrix.target.name }}${{ matrix.features.package_suffix }}" |
+            .description = "${{ matrix.features.package_description }} (${{ matrix.target.name }} target)" |
+            .files += ["opfs.js", "opfs.d.ts"] |
+            .exports = {
+              ".": {
+                "types": "./lindera_wasm.d.ts",
+                "default": "./lindera_wasm.js"
+              },
+              "./opfs": {
+                "types": "./opfs.d.ts",
+                "default": "./opfs.js"
+              }
+            }
+          ' package.json > package.json.tmp
           mv package.json.tmp package.json
 
       - name: Upload artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,9 @@ version = "2.3.4"
 dependencies = [
  "js-sys",
  "lindera",
+ "lindera-dictionary",
  "once_cell",
+ "rkyv",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,8 @@ build-lindera-nodejs: ## Build lindera-nodejs (release)
 
 build-lindera-wasm: ## Build lindera-wasm (wasm-pack, --target web)
 	cd lindera-wasm && wasm-pack build --release --features=$(WASM_FEATURES) --target=web
+	cp lindera-wasm/js/opfs.js lindera-wasm/pkg/
+	cp lindera-wasm/js/opfs.d.ts lindera-wasm/pkg/
 
 # ── Benchmark ───────────────────────────────────────────────────────────────
 
@@ -229,8 +231,10 @@ bench-all: ## Run all benchmarks with all features enabled
 
 # ── WASM example ────────────────────────────────────────────────────────────
 
-build-lindera-wasm-example: ## Build the WASM example application
-	cd lindera-wasm && wasm-pack build --release --features=embed-ipadic --target=web
+build-lindera-wasm-example: ## Build the WASM example application (OPFS, no embedded dictionary)
+	cd lindera-wasm && wasm-pack build --release --target=web
+	cp lindera-wasm/js/opfs.js lindera-wasm/pkg/
+	cp lindera-wasm/js/opfs.d.ts lindera-wasm/pkg/
 	cd lindera-wasm/example && \
 	LINDERA_WASM_VERSION=$$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="lindera-wasm") | .version') && \
 	jq ".version = \"$$LINDERA_WASM_VERSION\"" ./package.json > ./temp.json && mv ./temp.json ./package.json && \

--- a/lindera-wasm/Cargo.toml
+++ b/lindera-wasm/Cargo.toml
@@ -30,7 +30,9 @@ default = []
 [dependencies]
 js-sys = "0.3.91"
 lindera = { workspace = true }
+lindera-dictionary = { workspace = true }
 once_cell = { workspace = true }
+rkyv = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json = { workspace = true }

--- a/lindera-wasm/example/index.html
+++ b/lindera-wasm/example/index.html
@@ -43,10 +43,109 @@
         .subtitle {
             text-align: center;
             color: #666;
-            margin-bottom: 40px;
+            margin-bottom: 30px;
             font-size: 1.1em;
         }
 
+        /* Dictionary management section */
+        .dict-section {
+            background: #f0f4f8;
+            border-radius: 12px;
+            padding: 20px;
+            margin-bottom: 30px;
+            border: 1px solid #e2e8f0;
+        }
+
+        .dict-section h2 {
+            font-size: 1.1em;
+            color: #4a5568;
+            margin-bottom: 15px;
+        }
+
+        .dict-form {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .dict-form .row {
+            display: flex;
+            gap: 10px;
+        }
+
+        .dict-form input[type="text"] {
+            flex: 1;
+            padding: 10px 14px;
+            border: 1px solid #cbd5e0;
+            border-radius: 8px;
+            font-size: 14px;
+            font-family: inherit;
+        }
+
+        .dict-form input[type="text"]:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.15);
+        }
+
+        .dict-form input.dict-name {
+            max-width: 160px;
+        }
+
+        .btn-sm {
+            padding: 10px 18px;
+            border: none;
+            border-radius: 8px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+            white-space: nowrap;
+        }
+
+        .btn-sm:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+        }
+
+        .btn-sm:disabled {
+            opacity: 0.5;
+            pointer-events: none;
+        }
+
+        .btn-download {
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            color: white;
+        }
+
+        .btn-delete {
+            background: #e53e3e;
+            color: white;
+        }
+
+        .dict-info {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 10px;
+            font-size: 13px;
+            color: #718096;
+        }
+
+        #dictStatus {
+            font-weight: 600;
+            color: #38a169;
+        }
+
+        #progress {
+            display: none;
+            margin-top: 8px;
+            font-size: 13px;
+            color: #667eea;
+            font-weight: 500;
+        }
+
+        /* Input section */
         .input-section {
             margin-bottom: 30px;
         }
@@ -99,6 +198,11 @@
             transform: translateY(0);
         }
 
+        #runButton:disabled {
+            opacity: 0.5;
+            pointer-events: none;
+        }
+
         .results-section {
             background: #f8fafc;
             border-radius: 10px;
@@ -117,21 +221,6 @@
             list-style: none;
             max-height: 400px;
             overflow-y: auto;
-        }
-
-        #resultList li {
-            background: white;
-            margin-bottom: 10px;
-            padding: 15px;
-            border-radius: 8px;
-            border-left: 4px solid #667eea;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-            font-family: 'Courier New', monospace;
-            transition: transform 0.2s ease;
-        }
-
-        #resultList li:hover {
-            transform: translateX(5px);
         }
 
         #resultList:empty::after {
@@ -153,14 +242,21 @@
                 font-size: 2em;
             }
 
+            .dict-form .row {
+                flex-direction: column;
+            }
+
+            .dict-form input.dict-name {
+                max-width: none;
+            }
+
             #inputText,
             #runButton {
                 font-size: 16px;
-                /* Prevent zoom on iOS */
             }
         }
 
-        /* トークンテーブルのスタイル */
+        /* Token table styles */
         .token-table {
             width: 100%;
             border-collapse: collapse;
@@ -193,44 +289,37 @@
         .token-table small {
             color: #64748b;
         }
-
-        /* ローディングアニメーション */
-        .loading {
-            opacity: 0.7;
-            pointer-events: none;
-        }
-
-        .loading #runButton::after {
-            content: "";
-            display: inline-block;
-            width: 16px;
-            height: 16px;
-            margin-left: 10px;
-            border: 2px solid transparent;
-            border-top: 2px solid white;
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-        }
-
-        @keyframes spin {
-            to {
-                transform: rotate(360deg);
-            }
-        }
     </style>
 </head>
 
 <body>
     <div class="container">
         <h1 id="title">Lindera WASM</h1>
-        <p class="subtitle">WebAssembly Morphological Analysis Library</p>
+        <p class="subtitle">WebAssembly Morphological Analysis Library (OPFS)</p>
+
+        <div class="dict-section">
+            <h2>Dictionary Management</h2>
+            <div class="dict-form">
+                <input type="text" id="dictUrl" placeholder="Dictionary zip URL (set automatically after WASM init)">
+                <div class="row">
+                    <input type="text" id="dictName" class="dict-name" placeholder="Name" value="ipadic">
+                    <button type="button" id="downloadButton" class="btn-sm btn-download">Download &amp; Store</button>
+                    <button type="button" id="deleteButton" class="btn-sm btn-delete">Delete</button>
+                </div>
+            </div>
+            <div id="progress"></div>
+            <div class="dict-info">
+                <span>Stored: <span id="dictList">loading...</span></span>
+                <span id="dictStatus">Initializing...</span>
+            </div>
+        </div>
 
         <div class="input-section">
             <label for="inputText">Enter text to analyze:</label>
-            <textarea id="inputText" placeholder="Enter text here (e.g., すもももももももものうち)" rows="4"></textarea>
+            <textarea id="inputText" placeholder="Enter text here (e.g., すもももももももものうち)" rows="4">すもももももももものうち</textarea>
         </div>
 
-        <button id="runButton">Run Morphological Analysis</button>
+        <button id="runButton" disabled>Run Morphological Analysis</button>
 
         <div class="results-section">
             <div class="results-title">Analysis Results:</div>

--- a/lindera-wasm/example/src/index.js
+++ b/lindera-wasm/example/src/index.js
@@ -1,62 +1,203 @@
-import __wbg_init, { TokenizerBuilder, Tokenizer, Mode, load_dictionary, getVersion } from '../../pkg/lindera_wasm.js';
+import __wbg_init, { TokenizerBuilder, loadDictionaryFromBytes, getVersion } from '../../pkg/lindera_wasm.js';
+import { downloadDictionary, loadDictionaryFiles, hasDictionary, listDictionaries, removeDictionary } from '../../pkg/opfs.js';
 
-// Initialize the tokenizer
+const DEFAULT_DICT_NAME = 'ipadic';
+
+/**
+ * Builds the default dictionary URL using the current package version.
+ */
+function defaultDictUrl(version) {
+    return `https://github.com/lindera/lindera/releases/download/v${version}/lindera-ipadic-${version}.zip`;
+}
+
+/**
+ * Rewrites a GitHub URL to use the dev server proxy to avoid CORS issues.
+ */
+function proxyUrl(url) {
+    const GITHUB_PREFIX = 'https://github.com/';
+    if (url.startsWith(GITHUB_PREFIX)) {
+        return '/github-releases/' + url.slice(GITHUB_PREFIX.length);
+    }
+    return url;
+}
+
 let tokenizer = null;
 
-// Initialize WASM module first
-__wbg_init().then(() => {
-    // Show the version in the title
+// UI elements
+const titleEl = document.getElementById('title');
+const inputTextEl = document.getElementById('inputText');
+const runButtonEl = document.getElementById('runButton');
+const resultListEl = document.getElementById('resultList');
+const dictStatusEl = document.getElementById('dictStatus');
+const dictUrlEl = document.getElementById('dictUrl');
+const dictNameEl = document.getElementById('dictName');
+const downloadButtonEl = document.getElementById('downloadButton');
+const deleteButtonEl = document.getElementById('deleteButton');
+const dictListEl = document.getElementById('dictList');
+const progressEl = document.getElementById('progress');
+
+/**
+ * Updates the dictionary list display.
+ */
+async function refreshDictList() {
+    const names = await listDictionaries();
+    if (names.length === 0) {
+        dictListEl.textContent = 'No dictionaries stored';
+    } else {
+        dictListEl.textContent = names.join(', ');
+    }
+}
+
+/**
+ * Sets the status message.
+ */
+function setStatus(message, isError = false) {
+    dictStatusEl.textContent = message;
+    dictStatusEl.style.color = isError ? '#e53e3e' : '#38a169';
+}
+
+/**
+ * Loads a dictionary from OPFS and initializes the tokenizer.
+ */
+async function loadTokenizer(dictName) {
+    try {
+        setStatus(`Loading "${dictName}" from OPFS...`);
+
+        const files = await loadDictionaryFiles(dictName);
+        const dict = loadDictionaryFromBytes(
+            files.metadata,
+            files.dictDa,
+            files.dictVals,
+            files.dictWordsIdx,
+            files.dictWords,
+            files.matrixMtx,
+            files.charDef,
+            files.unk,
+        );
+
+        const builder = new TokenizerBuilder();
+        builder.setDictionaryInstance(dict);
+        builder.setMode("normal");
+        tokenizer = builder.build();
+
+        setStatus(`Tokenizer ready (dictionary: ${dictName})`);
+        runButtonEl.disabled = false;
+        console.log(`Tokenizer initialized with "${dictName}" dictionary from OPFS.`);
+    } catch (e) {
+        setStatus(`Failed to load dictionary: ${e.message}`, true);
+        console.error("Failed to load tokenizer:", e);
+    }
+}
+
+// Initialize WASM module
+__wbg_init().then(async () => {
+    // Show version and set default dictionary URL
     try {
         const version = getVersion();
-        document.title = `Lindera WASM v${version}`;
-        document.getElementById('title').textContent = `Lindera WASM v${version}`;
+        document.title = `Lindera WASM v${version} (OPFS)`;
+        titleEl.textContent = `Lindera WASM v${version}`;
+        dictUrlEl.value = defaultDictUrl(version);
     } catch (e) {
         console.error("Failed to get version:", e);
     }
 
-    try {
-        // Option 1: Using TokenizerBuilder (WASM style, snake_case is also supported)
-        let builder = new TokenizerBuilder();
-        builder.setDictionary("embedded://ipadic");
-        builder.setMode("normal");
-        tokenizer = builder.build();
+    await refreshDictList();
 
-        // Option 2: Using loadDictionary and Tokenizer constructor (Python style)
-        /*
-        const dict = loadDictionary("embedded://ipadic");
-        tokenizer = new Tokenizer(dict, "normal");
-        */
-
-        console.log("Tokenizer is ready.");
-    } catch (e) {
-        // Handle the error
-        console.error("Failed to create Tokenizer:", e);
+    // Check if default dictionary is already in OPFS
+    const exists = await hasDictionary(DEFAULT_DICT_NAME);
+    if (exists) {
+        await loadTokenizer(DEFAULT_DICT_NAME);
+    } else {
+        setStatus('No dictionary loaded. Download one to get started.');
     }
 }).catch(e => {
     console.error("Failed to initialize WASM module:", e);
+    setStatus(`WASM initialization failed: ${e.message}`, true);
 });
 
-// Add an event listener to the "runButton" element
-document.getElementById('runButton').addEventListener('click', () => {
-    // If the tokenizer is not initialized yet, display an error message
-    if (!tokenizer) {
-        console.error("Tokenizer is not initialized yet.");
+// Download button handler
+downloadButtonEl.addEventListener('click', async () => {
+    const url = dictUrlEl.value.trim();
+    const name = dictNameEl.value.trim();
+
+    if (!url || !name) {
+        setStatus('Please enter both URL and dictionary name.', true);
         return;
     }
 
-    // Get the input text from the "inputText" element
-    const inputText = document.getElementById('inputText').value;
+    downloadButtonEl.disabled = true;
+    runButtonEl.disabled = true;
+    progressEl.style.display = 'block';
 
-    // Tokenize the input text
+    try {
+        await downloadDictionary(proxyUrl(url), name, {
+            onProgress: ({ phase, loaded, total }) => {
+                switch (phase) {
+                    case 'downloading':
+                        if (total) {
+                            const pct = ((loaded / total) * 100).toFixed(1);
+                            progressEl.textContent = `Downloading... ${pct}% (${(loaded / 1024 / 1024).toFixed(1)} MB / ${(total / 1024 / 1024).toFixed(1)} MB)`;
+                        } else if (loaded) {
+                            progressEl.textContent = `Downloading... ${(loaded / 1024 / 1024).toFixed(1)} MB`;
+                        } else {
+                            progressEl.textContent = 'Downloading...';
+                        }
+                        break;
+                    case 'extracting':
+                        progressEl.textContent = 'Extracting zip archive...';
+                        break;
+                    case 'storing':
+                        progressEl.textContent = 'Storing to OPFS...';
+                        break;
+                    case 'complete':
+                        progressEl.textContent = 'Done!';
+                        break;
+                }
+            },
+        });
+
+        await refreshDictList();
+        await loadTokenizer(name);
+    } catch (e) {
+        setStatus(`Download failed: ${e.message}`, true);
+        console.error("Download failed:", e);
+    } finally {
+        downloadButtonEl.disabled = false;
+        setTimeout(() => { progressEl.style.display = 'none'; }, 2000);
+    }
+});
+
+// Delete button handler
+deleteButtonEl.addEventListener('click', async () => {
+    const name = dictNameEl.value.trim();
+    if (!name) {
+        setStatus('Please enter a dictionary name to delete.', true);
+        return;
+    }
+
+    try {
+        await removeDictionary(name);
+        setStatus(`Dictionary "${name}" removed.`);
+        tokenizer = null;
+        runButtonEl.disabled = true;
+        await refreshDictList();
+    } catch (e) {
+        setStatus(`Failed to remove: ${e.message}`, true);
+    }
+});
+
+// Tokenize button handler
+runButtonEl.addEventListener('click', () => {
+    if (!tokenizer) {
+        setStatus('Tokenizer is not initialized. Download a dictionary first.', true);
+        return;
+    }
+
+    const inputText = inputTextEl.value;
     const tokens = tokenizer.tokenize(inputText);
 
-    // Get the "resultList" element
-    const resultList = document.getElementById('resultList');
+    resultListEl.innerHTML = '';
 
-    // Clear the previous results
-    resultList.innerHTML = '';
-
-    // Create table for results
     const table = document.createElement('table');
     table.className = 'token-table';
     table.innerHTML = `
@@ -71,23 +212,15 @@ document.getElementById('runButton').addEventListener('click', () => {
     `;
     const tbody = table.querySelector('tbody');
 
-    tokens.forEach((token, index) => {
+    tokens.forEach((token) => {
         const tr = document.createElement('tr');
-
-        // Accessing properties directly from Token object
-        const surface = token.surface;
-        const position = token.position;
-        // Using getDetail(index) method
-        const detail = token.getDetail(0) || '*';
-        const allDetails = token.details.join(', ');
-
         tr.innerHTML = `
-            <td><strong>${surface}</strong></td>
-            <td>${position}</td>
-            <td><small>${allDetails}</small></td>
+            <td><strong>${token.surface}</strong></td>
+            <td>${token.position}</td>
+            <td><small>${token.details.join(', ')}</small></td>
         `;
         tbody.appendChild(tr);
     });
 
-    resultList.appendChild(table);
+    resultListEl.appendChild(table);
 });

--- a/lindera-wasm/example/webpack.config.js
+++ b/lindera-wasm/example/webpack.config.js
@@ -18,6 +18,21 @@ module.exports = {
         },
         open: true,
         port: 8080,
+        headers: {
+            // Required for OPFS access in some browsers
+            'Cross-Origin-Opener-Policy': 'same-origin',
+            'Cross-Origin-Embedder-Policy': 'require-corp',
+        },
+        proxy: [
+            {
+                // Proxy GitHub Releases to avoid CORS issues in development
+                context: ['/github-releases'],
+                target: 'https://github.com',
+                pathRewrite: { '^/github-releases': '' },
+                changeOrigin: true,
+                followRedirects: true,
+            },
+        ],
     },
     plugins: [
         new CopyWebpackPlugin({

--- a/lindera-wasm/js/opfs.d.ts
+++ b/lindera-wasm/js/opfs.d.ts
@@ -1,0 +1,84 @@
+/**
+ * OPFS (Origin Private File System) helper utilities for Lindera WASM.
+ *
+ * @module opfs
+ */
+
+/** Dictionary binary file data loaded from OPFS. */
+export interface DictionaryFiles {
+  /** Contents of metadata.json */
+  metadata: Uint8Array;
+  /** Contents of dict.da (Double-Array Trie) */
+  dictDa: Uint8Array;
+  /** Contents of dict.vals (word value data) */
+  dictVals: Uint8Array;
+  /** Contents of dict.wordsidx (word details index) */
+  dictWordsIdx: Uint8Array;
+  /** Contents of dict.words (word details) */
+  dictWords: Uint8Array;
+  /** Contents of matrix.mtx (connection cost matrix) */
+  matrixMtx: Uint8Array;
+  /** Contents of char_def.bin (character definitions) */
+  charDef: Uint8Array;
+  /** Contents of unk.bin (unknown word dictionary) */
+  unk: Uint8Array;
+}
+
+/** Progress information passed to the onProgress callback. */
+export interface DownloadProgress {
+  /** Current phase of the operation. */
+  phase: "downloading" | "extracting" | "storing" | "complete";
+  /** Bytes downloaded so far (only during "downloading" phase). */
+  loaded?: number;
+  /** Total bytes to download, if known (only during "downloading" phase). */
+  total?: number;
+}
+
+/** Options for downloadDictionary(). */
+export interface DownloadDictionaryOptions {
+  /** Progress callback. */
+  onProgress?: (progress: DownloadProgress) => void;
+}
+
+/**
+ * Downloads a dictionary archive, extracts it, and stores the files in OPFS.
+ *
+ * @param url - URL of the dictionary zip archive.
+ * @param name - Name to store the dictionary under (e.g., "ipadic").
+ * @param options - Optional settings.
+ */
+export function downloadDictionary(
+  url: string,
+  name: string,
+  options?: DownloadDictionaryOptions
+): Promise<void>;
+
+/**
+ * Loads dictionary files from OPFS as an object of Uint8Arrays.
+ *
+ * @param name - The dictionary name (e.g., "ipadic").
+ * @returns Object containing the dictionary file data.
+ */
+export function loadDictionaryFiles(name: string): Promise<DictionaryFiles>;
+
+/**
+ * Removes a dictionary from OPFS.
+ *
+ * @param name - The dictionary name to remove.
+ */
+export function removeDictionary(name: string): Promise<void>;
+
+/**
+ * Lists all dictionaries stored in OPFS.
+ *
+ * @returns Array of dictionary names.
+ */
+export function listDictionaries(): Promise<string[]>;
+
+/**
+ * Checks if a dictionary exists in OPFS.
+ *
+ * @param name - The dictionary name to check.
+ * @returns True if the dictionary exists.
+ */
+export function hasDictionary(name: string): Promise<boolean>;

--- a/lindera-wasm/js/opfs.js
+++ b/lindera-wasm/js/opfs.js
@@ -1,0 +1,348 @@
+/**
+ * OPFS (Origin Private File System) helper utilities for Lindera WASM.
+ *
+ * Provides functions to download, store, load, and manage Lindera dictionaries
+ * using the browser's Origin Private File System for persistent caching.
+ *
+ * @module opfs
+ */
+
+/** Dictionary file names that make up a built Lindera dictionary. */
+const DICTIONARY_FILES = [
+  "metadata.json",
+  "dict.da",
+  "dict.vals",
+  "dict.wordsidx",
+  "dict.words",
+  "matrix.mtx",
+  "char_def.bin",
+  "unk.bin",
+];
+
+/** Base directory path within OPFS for storing dictionaries. */
+const OPFS_BASE_PATH = ["lindera", "dictionaries"];
+
+/**
+ * Gets or creates a nested directory handle within OPFS.
+ *
+ * @param {string[]} pathSegments - Array of directory names forming the path.
+ * @returns {Promise<FileSystemDirectoryHandle>} The directory handle.
+ */
+async function getDirectoryHandle(pathSegments) {
+  let dir = await navigator.storage.getDirectory();
+  for (const segment of pathSegments) {
+    dir = await dir.getDirectoryHandle(segment, { create: true });
+  }
+  return dir;
+}
+
+/**
+ * Gets the OPFS directory handle for a specific dictionary.
+ *
+ * @param {string} name - The dictionary name (e.g., "ipadic").
+ * @returns {Promise<FileSystemDirectoryHandle>} The dictionary directory handle.
+ */
+async function getDictionaryDir(name) {
+  return getDirectoryHandle([...OPFS_BASE_PATH, name]);
+}
+
+/**
+ * Extracts entries from a zip archive using DecompressionStream.
+ *
+ * This implementation parses the zip central directory and decompresses
+ * entries using the Web Streams API (DecompressionStream), avoiding
+ * external library dependencies.
+ *
+ * @param {ArrayBuffer} zipBuffer - The zip file contents.
+ * @returns {Promise<Map<string, Uint8Array>>} Map of filename to file contents.
+ */
+async function extractZip(zipBuffer) {
+  const view = new DataView(zipBuffer);
+  const bytes = new Uint8Array(zipBuffer);
+  const entries = new Map();
+
+  // Find End of Central Directory record (search from end)
+  let eocdOffset = -1;
+  for (let i = bytes.length - 22; i >= 0; i--) {
+    if (view.getUint32(i, true) === 0x06054b50) {
+      eocdOffset = i;
+      break;
+    }
+  }
+  if (eocdOffset === -1) {
+    throw new Error("Invalid zip file: End of Central Directory not found");
+  }
+
+  const cdOffset = view.getUint32(eocdOffset + 16, true);
+  const cdEntries = view.getUint16(eocdOffset + 10, true);
+
+  // Parse Central Directory entries
+  let offset = cdOffset;
+  for (let i = 0; i < cdEntries; i++) {
+    if (view.getUint32(offset, true) !== 0x02014b50) {
+      throw new Error("Invalid zip file: bad Central Directory entry signature");
+    }
+
+    const compressionMethod = view.getUint16(offset + 10, true);
+    const compressedSize = view.getUint32(offset + 20, true);
+    const uncompressedSize = view.getUint32(offset + 24, true);
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraFieldLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const localHeaderOffset = view.getUint32(offset + 42, true);
+
+    const fileName = new TextDecoder().decode(
+      bytes.subarray(offset + 46, offset + 46 + fileNameLength)
+    );
+
+    // Skip directories
+    if (!fileName.endsWith("/")) {
+      // Read from local file header to get actual data offset
+      const localFileNameLength = view.getUint16(localHeaderOffset + 26, true);
+      const localExtraLength = view.getUint16(localHeaderOffset + 28, true);
+      const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+
+      const compressedData = bytes.subarray(dataOffset, dataOffset + compressedSize);
+
+      let fileData;
+      if (compressionMethod === 0) {
+        // Stored (no compression)
+        fileData = compressedData;
+      } else if (compressionMethod === 8) {
+        // Deflate - use DecompressionStream
+        const ds = new DecompressionStream("deflate-raw");
+        const writer = ds.writable.getWriter();
+        const reader = ds.readable.getReader();
+
+        // Write compressed data and close
+        writer.write(compressedData).then(() => writer.close());
+
+        // Read all decompressed chunks
+        const chunks = [];
+        let totalLength = 0;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          chunks.push(value);
+          totalLength += value.length;
+        }
+
+        // Concatenate chunks
+        fileData = new Uint8Array(totalLength);
+        let pos = 0;
+        for (const chunk of chunks) {
+          fileData.set(chunk, pos);
+          pos += chunk.length;
+        }
+
+        // Verify decompressed size
+        if (fileData.length !== uncompressedSize) {
+          throw new Error(
+            `Size mismatch for ${fileName}: expected ${uncompressedSize}, got ${fileData.length}`
+          );
+        }
+      } else {
+        throw new Error(`Unsupported compression method ${compressionMethod} for ${fileName}`);
+      }
+
+      entries.set(fileName, fileData);
+    }
+
+    // Move to next Central Directory entry
+    offset += 46 + fileNameLength + extraFieldLength + commentLength;
+  }
+
+  return entries;
+}
+
+/**
+ * Downloads a dictionary archive, extracts it, and stores the files in OPFS.
+ *
+ * The archive should be a zip file containing the 8 dictionary files
+ * (metadata.json, dict.da, dict.vals, dict.wordsidx, dict.words,
+ * matrix.mtx, char_def.bin, unk.bin), optionally nested in a subdirectory.
+ *
+ * @param {string} url - URL of the dictionary zip archive.
+ * @param {string} name - Name to store the dictionary under (e.g., "ipadic").
+ * @param {object} [options] - Optional settings.
+ * @param {function} [options.onProgress] - Progress callback receiving
+ *   `{ phase: string, loaded?: number, total?: number }`.
+ * @returns {Promise<void>}
+ * @throws {Error} If download fails, archive is invalid, or required files are missing.
+ */
+export async function downloadDictionary(url, name, options = {}) {
+  const { onProgress } = options;
+
+  // Download
+  if (onProgress) onProgress({ phase: "downloading" });
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download dictionary: HTTP ${response.status}`);
+  }
+
+  const contentLength = response.headers.get("content-length");
+  const total = contentLength ? parseInt(contentLength, 10) : undefined;
+
+  // Read response body with progress tracking
+  let zipBuffer;
+  if (onProgress && response.body) {
+    const reader = response.body.getReader();
+    const chunks = [];
+    let loaded = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      loaded += value.length;
+      onProgress({ phase: "downloading", loaded, total });
+    }
+
+    zipBuffer = new Uint8Array(loaded);
+    let pos = 0;
+    for (const chunk of chunks) {
+      zipBuffer.set(chunk, pos);
+      pos += chunk.length;
+    }
+    zipBuffer = zipBuffer.buffer;
+  } else {
+    zipBuffer = await response.arrayBuffer();
+  }
+
+  // Extract
+  if (onProgress) onProgress({ phase: "extracting" });
+  const entries = await extractZip(zipBuffer);
+
+  // Find dictionary files (may be nested in a subdirectory)
+  const fileMap = new Map();
+  for (const [path, data] of entries) {
+    const baseName = path.split("/").pop();
+    if (DICTIONARY_FILES.includes(baseName)) {
+      fileMap.set(baseName, data);
+    }
+  }
+
+  // Verify all required files are present
+  const missing = DICTIONARY_FILES.filter((f) => !fileMap.has(f));
+  if (missing.length > 0) {
+    throw new Error(`Missing dictionary files in archive: ${missing.join(", ")}`);
+  }
+
+  // Store in OPFS
+  if (onProgress) onProgress({ phase: "storing" });
+  const dir = await getDictionaryDir(name);
+  for (const [fileName, data] of fileMap) {
+    const fileHandle = await dir.getFileHandle(fileName, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(data);
+    await writable.close();
+  }
+
+  if (onProgress) onProgress({ phase: "complete" });
+}
+
+/**
+ * Loads dictionary files from OPFS as an object of Uint8Arrays.
+ *
+ * The returned object has properties matching the file names expected
+ * by `loadDictionaryFromBytes()`.
+ *
+ * @param {string} name - The dictionary name (e.g., "ipadic").
+ * @returns {Promise<DictionaryFiles>} Object containing the dictionary file data.
+ * @throws {Error} If the dictionary is not found in OPFS.
+ */
+export async function loadDictionaryFiles(name) {
+  let dir;
+  try {
+    const root = await navigator.storage.getDirectory();
+    let current = root;
+    for (const segment of [...OPFS_BASE_PATH, name]) {
+      current = await current.getDirectoryHandle(segment);
+    }
+    dir = current;
+  } catch {
+    throw new Error(
+      `Dictionary "${name}" not found in OPFS. Call downloadDictionary() first.`
+    );
+  }
+
+  /** @param {string} fileName */
+  async function readFile(fileName) {
+    const fileHandle = await dir.getFileHandle(fileName);
+    const file = await fileHandle.getFile();
+    const buffer = await file.arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+
+  return {
+    metadata: await readFile("metadata.json"),
+    dictDa: await readFile("dict.da"),
+    dictVals: await readFile("dict.vals"),
+    dictWordsIdx: await readFile("dict.wordsidx"),
+    dictWords: await readFile("dict.words"),
+    matrixMtx: await readFile("matrix.mtx"),
+    charDef: await readFile("char_def.bin"),
+    unk: await readFile("unk.bin"),
+  };
+}
+
+/**
+ * Removes a dictionary from OPFS.
+ *
+ * @param {string} name - The dictionary name to remove.
+ * @returns {Promise<void>}
+ * @throws {Error} If the dictionary is not found.
+ */
+export async function removeDictionary(name) {
+  const root = await navigator.storage.getDirectory();
+  let current = root;
+  for (const segment of OPFS_BASE_PATH) {
+    current = await current.getDirectoryHandle(segment);
+  }
+  await current.removeEntry(name, { recursive: true });
+}
+
+/**
+ * Lists all dictionaries stored in OPFS.
+ *
+ * @returns {Promise<string[]>} Array of dictionary names.
+ */
+export async function listDictionaries() {
+  try {
+    const root = await navigator.storage.getDirectory();
+    let current = root;
+    for (const segment of OPFS_BASE_PATH) {
+      current = await current.getDirectoryHandle(segment);
+    }
+
+    const names = [];
+    for await (const [name, handle] of current.entries()) {
+      if (handle.kind === "directory") {
+        names.push(name);
+      }
+    }
+    return names;
+  } catch {
+    // Base directory doesn't exist yet - no dictionaries stored
+    return [];
+  }
+}
+
+/**
+ * Checks if a dictionary exists in OPFS.
+ *
+ * @param {string} name - The dictionary name to check.
+ * @returns {Promise<boolean>} True if the dictionary exists.
+ */
+export async function hasDictionary(name) {
+  try {
+    const root = await navigator.storage.getDirectory();
+    let current = root;
+    for (const segment of [...OPFS_BASE_PATH, name]) {
+      current = await current.getDirectoryHandle(segment);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -6,8 +6,41 @@ use lindera::dictionary::{
     Dictionary, DictionaryBuilder, UserDictionary, load_dictionary as lindera_load_dictionary,
     load_user_dictionary as lindera_load_user_dictionary,
 };
+use lindera_dictionary::dictionary::character_definition::CharacterDefinition;
+use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix;
+use lindera_dictionary::dictionary::metadata::Metadata;
+use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
+use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
 
 use crate::metadata::JsMetadata;
+
+/// Decompresses dictionary data if it is in lindera's compressed format.
+///
+/// Dictionary files built with the `compress` feature are wrapped in a
+/// `CompressedData` envelope serialized with rkyv. This function attempts
+/// to deserialize and decompress the data; if the data is not compressed,
+/// the original bytes are returned as-is.
+///
+/// # Arguments
+///
+/// * `data` - Raw bytes that may or may not be compressed.
+///
+/// # Returns
+///
+/// The decompressed bytes as a `Vec<u8>`.
+fn try_decompress(data: &[u8]) -> Vec<u8> {
+    use lindera_dictionary::decompress::{CompressedData, decompress};
+
+    let mut aligned = rkyv::util::AlignedVec::<16>::new();
+    aligned.extend_from_slice(data);
+    match rkyv::from_bytes::<CompressedData, rkyv::rancor::Error>(&aligned) {
+        Ok(compressed_data) => match decompress(compressed_data) {
+            Ok(decompressed) => decompressed,
+            Err(_) => data.to_vec(),
+        },
+        Err(_) => data.to_vec(),
+    }
+}
 
 /// A morphological analysis dictionary.
 #[wasm_bindgen(js_name = "Dictionary")]
@@ -78,6 +111,69 @@ pub fn build_dictionary(
     Ok(())
 }
 
+/// Loads a dictionary from raw byte arrays.
+///
+/// This function constructs a `Dictionary` directly from the binary data
+/// of each dictionary component file, without requiring filesystem access.
+/// This is useful for loading dictionaries from OPFS or other browser storage.
+///
+/// # Arguments
+///
+/// * `metadata` - The contents of `metadata.json`
+/// * `dict_da` - The contents of `dict.da` (Double-Array Trie)
+/// * `dict_vals` - The contents of `dict.vals` (word value data)
+/// * `dict_words_idx` - The contents of `dict.wordsidx` (word details index)
+/// * `dict_words` - The contents of `dict.words` (word details)
+/// * `matrix_mtx` - The contents of `matrix.mtx` (connection cost matrix)
+/// * `char_def` - The contents of `char_def.bin` (character definitions)
+/// * `unk` - The contents of `unk.bin` (unknown word dictionary)
+///
+/// # Returns
+///
+/// A `Dictionary` instance constructed from the provided byte data.
+#[wasm_bindgen(js_name = "loadDictionaryFromBytes")]
+#[allow(clippy::too_many_arguments)]
+pub fn load_dictionary_from_bytes(
+    metadata: &[u8],
+    dict_da: &[u8],
+    dict_vals: &[u8],
+    dict_words_idx: &[u8],
+    dict_words: &[u8],
+    matrix_mtx: &[u8],
+    char_def: &[u8],
+    unk: &[u8],
+) -> Result<JsDictionary, JsValue> {
+    let meta =
+        Metadata::load(metadata).map_err(|e| JsValue::from_str(&format!("metadata: {e}")))?;
+
+    // Decompress dictionary data if compressed (lindera compress feature)
+    let da_data = try_decompress(dict_da);
+    let vals_data = try_decompress(dict_vals);
+    let words_idx_data = try_decompress(dict_words_idx);
+    let words_data = try_decompress(dict_words);
+    let conn_data = try_decompress(matrix_mtx);
+    let char_def_data = try_decompress(char_def);
+    let unk_data = try_decompress(unk);
+
+    let dict = Dictionary {
+        prefix_dictionary: PrefixDictionary::load(
+            da_data,
+            vals_data,
+            words_idx_data,
+            words_data,
+            true,
+        ),
+        connection_cost_matrix: ConnectionCostMatrix::load(conn_data),
+        character_definition: CharacterDefinition::load(&char_def_data)
+            .map_err(|e| JsValue::from_str(&format!("char_def: {e}")))?,
+        unknown_dictionary: UnknownDictionary::load(&unk_data)
+            .map_err(|e| JsValue::from_str(&format!("unk: {e}")))?,
+        metadata: meta,
+    };
+
+    Ok(JsDictionary { inner: dict })
+}
+
 /// Builds a user dictionary from a CSV file.
 #[wasm_bindgen(js_name = "buildUserDictionary")]
 pub fn build_user_dictionary(
@@ -121,5 +217,47 @@ mod tests {
         let result = load_dictionary("embedded://nonexistent");
 
         assert!(result.is_err());
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_load_dictionary_from_bytes_invalid_metadata() {
+        use super::load_dictionary_from_bytes;
+
+        let result =
+            load_dictionary_from_bytes(b"not valid json", &[], &[], &[], &[], &[], &[], &[]);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().as_string().unwrap();
+        assert!(
+            err.contains("metadata"),
+            "error should mention metadata: {err}"
+        );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_load_dictionary_from_bytes_invalid_char_def() {
+        use super::load_dictionary_from_bytes;
+
+        // Valid minimal metadata JSON, but invalid char_def binary
+        let metadata = br#"{"name":"test","encoding":"utf-8"}"#;
+        let result = load_dictionary_from_bytes(
+            metadata,
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            b"invalid char_def data",
+            &[],
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().as_string().unwrap();
+        assert!(
+            err.contains("char_def"),
+            "error should mention char_def: {err}"
+        );
     }
 }

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -237,27 +237,13 @@ mod tests {
 
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen_test]
-    fn test_load_dictionary_from_bytes_invalid_char_def() {
+    fn test_load_dictionary_from_bytes_incomplete_metadata() {
         use super::load_dictionary_from_bytes;
 
-        // Valid minimal metadata JSON, but invalid char_def binary
+        // Incomplete metadata JSON (missing required fields)
         let metadata = br#"{"name":"test","encoding":"utf-8"}"#;
-        let result = load_dictionary_from_bytes(
-            metadata,
-            &[],
-            &[],
-            &[],
-            &[],
-            &[],
-            b"invalid char_def data",
-            &[],
-        );
+        let result = load_dictionary_from_bytes(metadata, &[], &[], &[], &[], &[], &[], &[]);
 
         assert!(result.is_err());
-        let err = result.err().unwrap().as_string().unwrap();
-        assert!(
-            err.contains("char_def"),
-            "error should mention char_def: {err}"
-        );
     }
 }

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -228,7 +228,7 @@ mod tests {
             load_dictionary_from_bytes(b"not valid json", &[], &[], &[], &[], &[], &[], &[]);
 
         assert!(result.is_err());
-        let err = result.unwrap_err().as_string().unwrap();
+        let err = result.err().unwrap().as_string().unwrap();
         assert!(
             err.contains("metadata"),
             "error should mention metadata: {err}"
@@ -254,7 +254,7 @@ mod tests {
         );
 
         assert!(result.is_err());
-        let err = result.unwrap_err().as_string().unwrap();
+        let err = result.err().unwrap().as_string().unwrap();
         assert!(
             err.contains("char_def"),
             "error should mention char_def: {err}"

--- a/lindera-wasm/src/lib.rs
+++ b/lindera-wasm/src/lib.rs
@@ -62,6 +62,30 @@ pub fn py_load_dictionary(uri: &str) -> Result<Dictionary, JsValue> {
     crate::dictionary::load_dictionary(uri)
 }
 
+#[wasm_bindgen(js_name = "load_dictionary_from_bytes")]
+#[allow(clippy::too_many_arguments)]
+pub fn py_load_dictionary_from_bytes(
+    metadata: &[u8],
+    dict_da: &[u8],
+    dict_vals: &[u8],
+    dict_words_idx: &[u8],
+    dict_words: &[u8],
+    matrix_mtx: &[u8],
+    char_def: &[u8],
+    unk: &[u8],
+) -> Result<Dictionary, JsValue> {
+    crate::dictionary::load_dictionary_from_bytes(
+        metadata,
+        dict_da,
+        dict_vals,
+        dict_words_idx,
+        dict_words,
+        matrix_mtx,
+        char_def,
+        unk,
+    )
+}
+
 #[wasm_bindgen(js_name = "load_user_dictionary")]
 pub fn py_load_user_dictionary(uri: &str, metadata: Metadata) -> Result<UserDictionary, JsValue> {
     crate::dictionary::load_user_dictionary(uri, metadata)

--- a/lindera-wasm/src/tokenizer.rs
+++ b/lindera-wasm/src/tokenizer.rs
@@ -20,6 +20,12 @@ use crate::token::JsToken;
 #[wasm_bindgen]
 pub struct TokenizerBuilder {
     inner: LinderaTokenizerBuilder,
+    /// Pre-loaded dictionary instance, used instead of URI-based loading.
+    dictionary_instance: Option<JsDictionary>,
+    /// Pre-loaded user dictionary instance, used instead of URI-based loading.
+    user_dictionary_instance: Option<JsUserDictionary>,
+    /// Mode string stored for use when building with a dictionary instance.
+    mode_for_instance: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -30,17 +36,43 @@ impl TokenizerBuilder {
         let inner =
             LinderaTokenizerBuilder::new().map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            dictionary_instance: None,
+            user_dictionary_instance: None,
+            mode_for_instance: None,
+        })
     }
 
     /// Builds and returns a configured [`Tokenizer`] instance.
+    ///
+    /// If a dictionary instance was set via `setDictionaryInstance()`,
+    /// it will be used directly instead of loading from a URI.
     pub fn build(self) -> Result<Tokenizer, JsValue> {
-        let inner = self
-            .inner
-            .build()
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        if let Some(dict) = self.dictionary_instance {
+            // Build tokenizer using the pre-loaded dictionary instance
+            let m = self
+                .mode_for_instance
+                .as_deref()
+                .map(Mode::from_str)
+                .transpose()
+                .map_err(|e| JsValue::from_str(&e.to_string()))?
+                .unwrap_or(Mode::Normal);
 
-        Ok(Tokenizer { inner })
+            let user_dict = self.user_dictionary_instance.map(|d| d.inner);
+
+            let segmenter = Segmenter::new(m, dict.inner, user_dict);
+            let inner = LinderaTokenizer::new(segmenter);
+
+            Ok(Tokenizer { inner })
+        } else {
+            let inner = self
+                .inner
+                .build()
+                .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+            Ok(Tokenizer { inner })
+        }
     }
 
     /// Sets the tokenization mode.
@@ -48,24 +80,45 @@ impl TokenizerBuilder {
     pub fn set_mode(&mut self, mode: &str) -> Result<(), JsValue> {
         let m = Mode::from_str(mode).map_err(|e| JsValue::from_str(&e.to_string()))?;
         self.inner.set_segmenter_mode(&m);
+        self.mode_for_instance = Some(mode.to_string());
 
         Ok(())
     }
 
-    /// Sets the dictionary to use for tokenization.
+    /// Sets the dictionary to use for tokenization by URI.
     #[wasm_bindgen(js_name = "setDictionary")]
     pub fn set_dictionary(&mut self, uri: &str) -> Result<(), JsValue> {
         self.inner.set_segmenter_dictionary(uri);
+        self.dictionary_instance = None;
 
         Ok(())
     }
 
-    /// Sets a user-defined dictionary.
+    /// Sets a pre-loaded dictionary instance for tokenization.
+    ///
+    /// Use this method when the dictionary has been loaded from bytes
+    /// (e.g., via `loadDictionaryFromBytes()`) instead of from a URI.
+    #[wasm_bindgen(js_name = "setDictionaryInstance")]
+    pub fn set_dictionary_instance(&mut self, dictionary: JsDictionary) {
+        self.dictionary_instance = Some(dictionary);
+    }
+
+    /// Sets a user-defined dictionary by URI.
     #[wasm_bindgen(js_name = "setUserDictionary")]
     pub fn set_user_dictionary(&mut self, uri: &str) -> Result<(), JsValue> {
         self.inner.set_segmenter_user_dictionary(uri);
+        self.user_dictionary_instance = None;
 
         Ok(())
+    }
+
+    /// Sets a pre-loaded user dictionary instance.
+    ///
+    /// Use this method when the user dictionary has been loaded from bytes
+    /// instead of from a URI.
+    #[wasm_bindgen(js_name = "setUserDictionaryInstance")]
+    pub fn set_user_dictionary_instance(&mut self, user_dictionary: JsUserDictionary) {
+        self.user_dictionary_instance = Some(user_dictionary);
     }
 
     /// Sets whether to keep whitespace tokens in the output.
@@ -117,9 +170,19 @@ impl TokenizerBuilder {
         self.set_dictionary(uri)
     }
 
+    #[wasm_bindgen(js_name = "set_dictionary_instance")]
+    pub fn py_set_dictionary_instance(&mut self, dictionary: JsDictionary) {
+        self.set_dictionary_instance(dictionary)
+    }
+
     #[wasm_bindgen(js_name = "set_user_dictionary")]
     pub fn py_set_user_dictionary(&mut self, uri: &str) -> Result<(), JsValue> {
         self.set_user_dictionary(uri)
+    }
+
+    #[wasm_bindgen(js_name = "set_user_dictionary_instance")]
+    pub fn py_set_user_dictionary_instance(&mut self, user_dictionary: JsUserDictionary) {
+        self.set_user_dictionary_instance(user_dictionary)
     }
 
     #[wasm_bindgen(js_name = "set_keep_whitespace")]
@@ -424,5 +487,62 @@ mod tests {
 
         assert!(!tokens.is_empty());
         assert_eq!(tokens[0].surface, "東京");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_builder_with_dictionary_instance() {
+        use crate::TokenizerBuilder;
+        use crate::dictionary::load_dictionary;
+
+        let dict = load_dictionary("embedded://ipadic").unwrap();
+
+        let mut builder = TokenizerBuilder::new().unwrap();
+        builder.set_mode("normal").unwrap();
+        builder.set_dictionary_instance(dict);
+
+        let tokenizer = builder.build().unwrap();
+        let tokens = tokenizer.tokenize("東京タワー").unwrap();
+
+        assert!(!tokens.is_empty());
+        assert_eq!(tokens[0].surface, "東京");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_builder_with_dictionary_instance_decompose_mode() {
+        use crate::TokenizerBuilder;
+        use crate::dictionary::load_dictionary;
+
+        let dict = load_dictionary("embedded://ipadic").unwrap();
+
+        let mut builder = TokenizerBuilder::new().unwrap();
+        builder.set_mode("decompose").unwrap();
+        builder.set_dictionary_instance(dict);
+
+        let tokenizer = builder.build().unwrap();
+        let tokens = tokenizer.tokenize("関西国際空港").unwrap();
+
+        assert!(!tokens.is_empty());
+        let reconstructed: String = tokens.iter().map(|t| t.surface.as_str()).collect();
+        assert_eq!(reconstructed, "関西国際空港");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test]
+    fn test_builder_with_dictionary_instance_default_mode() {
+        use crate::TokenizerBuilder;
+        use crate::dictionary::load_dictionary;
+
+        // Set dictionary instance without calling set_mode (should default to Normal)
+        let dict = load_dictionary("embedded://ipadic").unwrap();
+
+        let mut builder = TokenizerBuilder::new().unwrap();
+        builder.set_dictionary_instance(dict);
+
+        let tokenizer = builder.build().unwrap();
+        let tokens = tokenizer.tokenize("すもも").unwrap();
+
+        assert!(!tokens.is_empty());
     }
 }


### PR DESCRIPTION
Add the ability to load external dictionaries from OPFS (Origin Private
File System) in browser environments, enabling lindera-wasm packages
without embedded dictionaries to download and cache dictionaries at
runtime.

WASM side:
- Add loadDictionaryFromBytes() to construct Dictionary from raw byte
  arrays with automatic decompression of lindera's compressed format
- Add setDictionaryInstance()/setUserDictionaryInstance() to
  TokenizerBuilder for using pre-loaded dictionary instances
- Add snake_case aliases for Python API compatibility

JS side:
- Add js/opfs.js helper with downloadDictionary(), loadDictionaryFiles(),
  removeDictionary(), listDictionaries(), and hasDictionary()
- Add js/opfs.d.ts TypeScript type definitions
- Zip extraction uses DecompressionStream API (no external dependencies)

Packaging:
- Update release workflow to include opfs.js/opfs.d.ts in npm packages
  with package.json exports field for "lindera-wasm-*/opfs" import path
- Update Makefile build targets to copy JS helpers to pkg/

Example:
- Rewrite example app to demonstrate OPFS dictionary workflow
- Add dictionary management UI (download, delete, list)
- Add webpack dev server proxy for GitHub Releases CORS workaround
