### PR TITLE
Replace unsafe DAAC deserialization with safe method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,9 +664,9 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "daachorse"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
+checksum = "8aeeee06247cda0cae43eb40dd19dcb5360e38e839f870df54a97ca1be4cf1a7"
 
 [[package]]
 name = "darling"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ license = "MIT"
 anyhow = "1.0.102"
 byteorder = "1.5.0"
 csv = "1.4.0"
-daachorse = "1.0.1"
+daachorse = "2.0.0"
 lindera = { version = "3.0.4", path = "lindera" }
 lindera-crf = { version = "3.0.4", path = "lindera-crf" }
 lindera-cc-cedict = { version = "3.0.4", path = "lindera-cc-cedict" }

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -60,7 +60,8 @@ impl<D: Fallible + ?Sized>
         archived: &rkyv::vec::ArchivedVec<u8>,
         _deserializer: &mut D,
     ) -> Result<DoubleArrayAhoCorasick<u32>, D::Error> {
-        let (da, _) = DoubleArrayAhoCorasick::deserialize(archived.as_slice());
+        let (da, _) = DoubleArrayAhoCorasick::deserialize(archived.as_slice())
+            .expect("Failed to deserialize DoubleArrayAhoCorasick");
         Ok(da)
     }
 }
@@ -82,7 +83,8 @@ mod double_array_serde {
         D: Deserializer<'de>,
     {
         let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
-        let (da, _) = DoubleArrayAhoCorasick::deserialize(&bytes);
+        let (da, _) = DoubleArrayAhoCorasick::deserialize(&bytes)
+            .expect("Failed to deserialize DoubleArrayAhoCorasick");
         Ok(da)
     }
 }
@@ -107,7 +109,8 @@ impl PrefixDictionary {
         is_system: bool,
     ) -> PrefixDictionary {
         let da_bytes = da_data.into();
-        let (da, _) = DoubleArrayAhoCorasick::deserialize(&da_bytes[..]);
+        let (da, _) = DoubleArrayAhoCorasick::deserialize(&da_bytes[..])
+            .expect("Failed to deserialize DoubleArrayAhoCorasick");
 
         PrefixDictionary {
             da,
@@ -238,8 +241,8 @@ impl PrefixDictionary {
 impl ArchivedPrefixDictionary {
     pub fn prefix<'a>(&'a self, s: &'a str) -> impl Iterator<Item = (usize, WordEntry)> + 'a {
         // Deserialize on the fly. Performance warning: this is slow.
-        let (da, _) =
-            unsafe { DoubleArrayAhoCorasick::<u32>::deserialize_unchecked(self.da.as_slice()) };
+        let (da, _) = DoubleArrayAhoCorasick::<u32>::deserialize(self.da.as_slice())
+            .expect("Failed to deserialize DoubleArrayAhoCorasick");
 
         let matches: Vec<_> = da
             .find_overlapping_iter(s)
@@ -275,8 +278,8 @@ impl ArchivedPrefixDictionary {
     }
 
     pub fn find_surface(&self, surface: &str) -> Vec<WordEntry> {
-        let (da, _) =
-            unsafe { DoubleArrayAhoCorasick::<u32>::deserialize_unchecked(self.da.as_slice()) };
+        let (da, _) = DoubleArrayAhoCorasick::<u32>::deserialize(self.da.as_slice())
+            .expect("Failed to deserialize DoubleArrayAhoCorasick");
 
         // Check if there is a match with start=0 and end=surface.len()
         let matches: Vec<_> = da

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -60,10 +60,8 @@ impl<D: Fallible + ?Sized>
         archived: &rkyv::vec::ArchivedVec<u8>,
         _deserializer: &mut D,
     ) -> Result<DoubleArrayAhoCorasick<u32>, D::Error> {
-        unsafe {
-            let (da, _) = DoubleArrayAhoCorasick::deserialize_unchecked(archived.as_slice());
-            Ok(da)
-        }
+        let (da, _) = DoubleArrayAhoCorasick::deserialize(archived.as_slice());
+        Ok(da)
     }
 }
 
@@ -84,10 +82,8 @@ mod double_array_serde {
         D: Deserializer<'de>,
     {
         let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
-        unsafe {
-            let (da, _) = DoubleArrayAhoCorasick::deserialize_unchecked(&bytes);
-            Ok(da)
-        }
+        let (da, _) = DoubleArrayAhoCorasick::deserialize(&bytes);
+        Ok(da)
     }
 }
 
@@ -111,7 +107,7 @@ impl PrefixDictionary {
         is_system: bool,
     ) -> PrefixDictionary {
         let da_bytes = da_data.into();
-        let (da, _) = unsafe { DoubleArrayAhoCorasick::deserialize_unchecked(&da_bytes[..]) };
+        let (da, _) = DoubleArrayAhoCorasick::deserialize(&da_bytes[..]);
 
         PrefixDictionary {
             da,


### PR DESCRIPTION
We released daachorse 2.0.0 featuring a safe [`deserialize()`](https://docs.rs/daachorse/2.0.0/daachorse/bytewise/struct.DoubleArrayAhoCorasick.html#method.deserialize) function with built-in checks.

Simply wrapping an unsafe function in a safe one can introduce potential security vulnerabilities. Therefore, we recommend migrating from `deserialize_unchecked()` to `deserialize()`.