### PR TITLE
refactor(dictionary): encapsulate viterbi internal structs behind accessors

### DIFF
--- a/lindera-binding-core/src/token.rs
+++ b/lindera-binding-core/src/token.rs
@@ -26,7 +26,7 @@ impl TokenView {
             byte_start: token.byte_start,
             byte_end: token.byte_end,
             position: token.position,
-            word_id: token.word_id.id,
+            word_id: token.word_id.id(),
             is_unknown: token.word_id.is_unknown(),
             details,
         }

--- a/lindera-dictionary/src/builder/prefix_dictionary.rs
+++ b/lindera-dictionary/src/builder/prefix_dictionary.rs
@@ -207,15 +207,12 @@ impl PrefixDictionaryBuilder {
                 continue;
             };
 
-            word_entry_map.entry(key).or_default().push(WordEntry {
-                word_id: crate::viterbi::WordId::new(
-                    crate::viterbi::LexType::System,
-                    row_id as u32,
-                ),
+            word_entry_map.entry(key).or_default().push(WordEntry::new(
+                crate::viterbi::WordId::new(crate::viterbi::LexType::System, row_id as u32),
                 word_cost,
                 left_id,
                 right_id,
-            });
+            ));
         }
 
         Ok(word_entry_map)
@@ -473,7 +470,7 @@ impl PrefixDictionaryBuilder {
                         .with_error(anyhow::anyhow!(err))
                         .add_context(format!(
                             "Failed to serialize word entry (id: {})",
-                            word_entry.word_id.id
+                            word_entry.word_id().id()
                         ))
                 })?;
             }

--- a/lindera-dictionary/src/builder/user_dictionary.rs
+++ b/lindera-dictionary/src/builder/user_dictionary.rs
@@ -116,12 +116,15 @@ impl UserDictionaryBuilder {
                 )
             };
 
-            word_entry_map.entry(surface).or_default().push(WordEntry {
-                word_id: crate::viterbi::WordId::new(crate::viterbi::LexType::User, row_id as u32),
-                word_cost,
-                left_id,
-                right_id,
-            });
+            word_entry_map
+                .entry(surface)
+                .or_default()
+                .push(WordEntry::new(
+                    crate::viterbi::WordId::new(crate::viterbi::LexType::User, row_id as u32),
+                    word_cost,
+                    left_id,
+                    right_id,
+                ));
         }
 
         let mut words_data = Vec::<u8>::new();
@@ -230,7 +233,7 @@ impl UserDictionaryBuilder {
                         .with_error(anyhow::anyhow!(err))
                         .add_context(format!(
                             "Failed to serialize user dictionary word entry (id: {})",
-                            word_entry.word_id.id
+                            word_entry.word_id().id()
                         ))
                 })?;
             }

--- a/lindera-dictionary/src/dictionary/prefix_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/prefix_dictionary.rs
@@ -236,7 +236,7 @@ impl PrefixDictionary {
                                 self.is_system,
                             );
                             Some(Match {
-                                word_idx: WordIdx::new(word_entry.word_id.id),
+                                word_idx: WordIdx::new(word_entry.word_id().id()),
                                 end_char: m.end(), // prefix_len in bytes? No, m.end() is byte index.
                                                    // Match expects char length?
                                                    // Original code: end_char: prefix_len

--- a/lindera-dictionary/src/dictionary/unknown_dictionary.rs
+++ b/lindera-dictionary/src/dictionary/unknown_dictionary.rs
@@ -260,12 +260,12 @@ fn make_costs_array(entries: &[UnknownDictionaryEntry]) -> Vec<WordEntry> {
             if e.left_id != e.right_id {
                 warn!("left id and right id are not same: {e:?}");
             }
-            WordEntry {
-                word_id: crate::viterbi::WordId::new(crate::viterbi::LexType::Unknown, i as u32),
-                left_id: e.left_id as u16,
-                right_id: e.right_id as u16,
-                word_cost: e.word_cost as i16,
-            }
+            WordEntry::new(
+                crate::viterbi::WordId::new(crate::viterbi::LexType::Unknown, i as u32),
+                e.word_cost as i16,
+                e.left_id as u16,
+                e.right_id as u16,
+            )
         })
         .collect()
 }

--- a/lindera-dictionary/src/mode.rs
+++ b/lindera-dictionary/src/mode.rs
@@ -31,7 +31,7 @@ impl Penalty {
         if num_chars <= self.kanji_penalty_length_threshold {
             return 0;
         }
-        if edge.kanji_only {
+        if edge.kanji_only() {
             ((num_chars - self.kanji_penalty_length_threshold) as i32)
                 * self.kanji_penalty_length_penalty
         } else if num_chars > self.other_penalty_length_threshold {

--- a/lindera-dictionary/src/nbest.rs
+++ b/lindera-dictionary/src/nbest.rs
@@ -80,7 +80,7 @@ impl<'a> NBestGenerator<'a> {
         let elem = QueueElement {
             byte_pos: text_len as u32,
             edge_index: eos_index,
-            fx: eos_edge.path_cost as i64,
+            fx: eos_edge.path_cost() as i64,
             gx: 0,
             prev: None,
         };
@@ -104,7 +104,7 @@ impl<'a> NBestGenerator<'a> {
             let edge = &edges[edge_index];
 
             // Check if we reached BOS (left_index == u16::MAX means no predecessor = BOS)
-            if edge.left_index == u16::MAX {
+            if edge.left_index() == u16::MAX {
                 return Some((self.reconstruct_path(&current), current.fx));
             }
 
@@ -115,12 +115,12 @@ impl<'a> NBestGenerator<'a> {
             // Expand: for each predecessor path of this edge
             let paths = self.lattice.paths_at(byte_pos);
             for path_entry in paths {
-                if path_entry.edge_index != edge_index as u16 {
+                if path_entry.edge_index() != edge_index as u16 {
                     continue; // Not a path to this edge
                 }
 
-                let left_pos = path_entry.left_pos as usize;
-                let left_index = path_entry.left_index as usize;
+                let left_pos = path_entry.left_pos() as usize;
+                let left_index = path_entry.left_index() as usize;
 
                 let left_edges = self.lattice.edges_at(left_pos);
                 if left_index >= left_edges.len() {
@@ -132,11 +132,11 @@ impl<'a> NBestGenerator<'a> {
                 // path_entry.cost = left_edge.path_cost + conn_cost + penalty
                 // conn_and_penalty = path_entry.cost - left_edge.path_cost
                 // new_gx = current.gx + conn_and_penalty + edge.word_cost
-                let conn_and_penalty = path_entry.cost as i64 - left_edge.path_cost as i64;
-                let new_gx = current.gx + conn_and_penalty + edge.word_entry.word_cost as i64;
+                let conn_and_penalty = path_entry.cost() as i64 - left_edge.path_cost() as i64;
+                let new_gx = current.gx + conn_and_penalty + edge.word_entry().word_cost() as i64;
 
                 // f(x) = h(x) + g(x), where h(x) = left_edge.path_cost
-                let new_fx = left_edge.path_cost as i64 + new_gx;
+                let new_fx = left_edge.path_cost() as i64 + new_gx;
 
                 let new_elem = QueueElement {
                     byte_pos: left_pos as u32,
@@ -164,8 +164,8 @@ impl<'a> NBestGenerator<'a> {
             let edge = &edges[elem.edge_index as usize];
 
             // Skip EOS edge (start_index == stop_index)
-            if edge.start_index != edge.stop_index {
-                path.push((edge.start_index as usize, edge.word_entry.word_id));
+            if edge.start_index() != edge.stop_index() {
+                path.push((edge.start_index() as usize, edge.word_entry().word_id()));
             }
 
             maybe_idx = elem.prev;

--- a/lindera-dictionary/src/trainer/model.rs
+++ b/lindera-dictionary/src/trainer/model.rs
@@ -173,12 +173,7 @@ impl Model {
                 // Create word ID for user dictionary entry
                 let word_id = WordId::new(LexType::User, self.user_entries.len() as u32);
 
-                let entry = WordEntry {
-                    word_id,
-                    word_cost: cost,
-                    left_id: left_id as u16,
-                    right_id: right_id as u16,
-                };
+                let entry = WordEntry::new(word_id, cost, left_id as u16, right_id as u16);
 
                 // Extract features and create feature set for this user entry
                 let first_char = surface.chars().next().unwrap_or('\0');
@@ -701,7 +696,7 @@ impl Model {
             // Try to find in user_entries first
             if idx < self.user_entries.len() {
                 let (_, entry, _) = &self.user_entries[idx];
-                return (entry.left_id as u32, entry.right_id as u32);
+                return (entry.left_id(), entry.right_id());
             }
         }
 
@@ -719,7 +714,7 @@ impl Model {
 
         // Ultimate fallback: use first user_entry's IDs or default to 0
         if let Some((_, entry, _)) = self.user_entries.first() {
-            (entry.left_id as u32, entry.right_id as u32)
+            (entry.left_id(), entry.right_id())
         } else {
             (0, 0)
         }
@@ -732,7 +727,7 @@ impl Model {
 
         // Get maximum ID from all user_entries
         for (_, entry, _) in &self.user_entries {
-            max_id = max_id.max(entry.left_id as u32).max(entry.right_id as u32);
+            max_id = max_id.max(entry.left_id()).max(entry.right_id());
         }
 
         max_id

--- a/lindera-dictionary/src/viterbi.rs
+++ b/lindera-dictionary/src/viterbi.rs
@@ -49,9 +49,12 @@ pub enum LexType {
 )]
 
 pub struct WordId {
-    pub id: u32,
-    pub is_system: bool,
-    pub lex_type: LexType,
+    /// Numeric identifier of the word within its lexicon.
+    id: u32,
+    /// Whether the word originates from the system dictionary.
+    is_system: bool,
+    /// Lexicon type the word belongs to.
+    lex_type: LexType,
 }
 
 impl WordId {
@@ -64,14 +67,30 @@ impl WordId {
         }
     }
 
+    /// Returns the numeric identifier of the word within its lexicon.
+    ///
+    /// # 戻り値
+    ///
+    /// The lexicon-local word id.
+    #[inline]
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// Returns `true` when the word is an unknown-word entry.
+    #[inline]
     pub fn is_unknown(&self) -> bool {
         matches!(self.lex_type, LexType::Unknown)
     }
 
+    /// Returns `true` when the word originates from the system dictionary.
+    #[inline]
     pub fn is_system(&self) -> bool {
         self.is_system
     }
 
+    /// Returns the lexicon type of the word.
+    #[inline]
     pub fn lex_type(&self) -> LexType {
         self.lex_type
     }
@@ -102,24 +121,64 @@ impl Default for WordId {
 )]
 
 pub struct WordEntry {
-    pub word_id: WordId,
-    pub word_cost: i16,
-    pub left_id: u16,
-    pub right_id: u16,
+    /// Word id identifying this entry in the dictionary.
+    word_id: WordId,
+    /// Emission (word) cost of the entry.
+    word_cost: i16,
+    /// Left context id used by the connection matrix.
+    left_id: u16,
+    /// Right context id used by the connection matrix.
+    right_id: u16,
 }
 
 impl WordEntry {
-    pub const SERIALIZED_LEN: usize = 10;
+    /// Length in bytes of the serialized representation.
+    pub(crate) const SERIALIZED_LEN: usize = 10;
 
+    /// Creates a new word entry from its raw components.
+    ///
+    /// # 引数
+    ///
+    /// * `word_id` - The word id identifying the entry.
+    /// * `word_cost` - The emission cost of the word.
+    /// * `left_id` - The left context id.
+    /// * `right_id` - The right context id.
+    #[inline]
+    pub fn new(word_id: WordId, word_cost: i16, left_id: u16, right_id: u16) -> Self {
+        WordEntry {
+            word_id,
+            word_cost,
+            left_id,
+            right_id,
+        }
+    }
+
+    /// Returns the word id of this entry.
+    #[inline]
+    pub fn word_id(&self) -> WordId {
+        self.word_id
+    }
+
+    /// Returns the emission (word) cost of this entry.
+    #[inline]
+    pub fn word_cost(&self) -> i16 {
+        self.word_cost
+    }
+
+    /// Returns the left context id, widened to `u32`.
+    #[inline]
     pub fn left_id(&self) -> u32 {
         self.left_id as u32
     }
 
+    /// Returns the right context id, widened to `u32`.
+    #[inline]
     pub fn right_id(&self) -> u32 {
         self.right_id as u32
     }
 
-    pub fn serialize<W: io::Write>(&self, wtr: &mut W) -> io::Result<()> {
+    /// Serializes this entry into `wtr` in little-endian byte order.
+    pub(crate) fn serialize<W: io::Write>(&self, wtr: &mut W) -> io::Result<()> {
         wtr.write_u32::<LittleEndian>(self.word_id.id)?;
         wtr.write_i16::<LittleEndian>(self.word_cost)?;
         wtr.write_u16::<LittleEndian>(self.left_id)?;
@@ -127,7 +186,8 @@ impl WordEntry {
         Ok(())
     }
 
-    pub fn deserialize(data: &[u8], is_system_entry: bool) -> WordEntry {
+    /// Deserializes a word entry from `data`.
+    pub(crate) fn deserialize(data: &[u8], is_system_entry: bool) -> WordEntry {
         let word_id = WordId::new(
             if is_system_entry {
                 LexType::System
@@ -148,32 +208,65 @@ impl WordEntry {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default)]
-pub enum EdgeType {
-    #[default]
-    KNOWN,
-    UNKNOWN,
-    USER,
-    INSERTED,
-}
-
 #[derive(Default, Clone, Debug)]
 pub struct Edge {
-    pub edge_type: EdgeType,
-    pub word_entry: WordEntry,
+    /// Word entry backing this edge.
+    word_entry: WordEntry,
 
-    pub path_cost: i32,
-    pub left_index: u16, // Index in the previous position's vector
+    /// Best forward path cost reaching this edge.
+    path_cost: i32,
+    /// Index of the chosen left edge in the previous position's vector.
+    left_index: u16,
 
-    pub start_index: u32,
-    pub stop_index: u32,
+    /// Start byte position of the edge.
+    start_index: u32,
+    /// Stop byte position of the edge.
+    stop_index: u32,
 
-    pub kanji_only: bool,
+    /// Whether the edge surface consists solely of kanji.
+    kanji_only: bool,
 }
 
 impl Edge {
+    /// Returns the number of characters spanned by this edge.
     pub fn num_chars(&self) -> usize {
         (self.stop_index - self.start_index) as usize / 3
+    }
+
+    /// Returns the word entry backing this edge.
+    #[inline]
+    pub(crate) fn word_entry(&self) -> &WordEntry {
+        &self.word_entry
+    }
+
+    /// Returns the best forward path cost reaching this edge.
+    #[inline]
+    pub(crate) fn path_cost(&self) -> i32 {
+        self.path_cost
+    }
+
+    /// Returns the index of the chosen left edge in the previous position.
+    #[inline]
+    pub(crate) fn left_index(&self) -> u16 {
+        self.left_index
+    }
+
+    /// Returns the start byte position of this edge.
+    #[inline]
+    pub(crate) fn start_index(&self) -> u32 {
+        self.start_index
+    }
+
+    /// Returns the stop byte position of this edge.
+    #[inline]
+    pub(crate) fn stop_index(&self) -> u32 {
+        self.stop_index
+    }
+
+    /// Returns whether the edge surface consists solely of kanji.
+    #[inline]
+    pub(crate) fn kanji_only(&self) -> bool {
+        self.kanji_only
     }
 }
 
@@ -183,13 +276,39 @@ impl Edge {
 #[derive(Clone, Debug)]
 pub struct PathEntry {
     /// Index of this edge in ends_at[stop_index]
-    pub edge_index: u16,
+    edge_index: u16,
     /// Byte position where the left edge ends (= this edge's start_index)
-    pub left_pos: u32,
+    left_pos: u32,
     /// Index of the left edge in ends_at[left_pos]
-    pub left_index: u16,
+    left_index: u16,
     /// Total forward cost: left_edge.path_cost + conn_cost + penalty_cost
-    pub cost: i32,
+    cost: i32,
+}
+
+impl PathEntry {
+    /// Returns the index of this edge in `ends_at[stop_index]`.
+    #[inline]
+    pub(crate) fn edge_index(&self) -> u16 {
+        self.edge_index
+    }
+
+    /// Returns the byte position where the left edge ends.
+    #[inline]
+    pub(crate) fn left_pos(&self) -> u32 {
+        self.left_pos
+    }
+
+    /// Returns the index of the left edge in `ends_at[left_pos]`.
+    #[inline]
+    pub(crate) fn left_index(&self) -> u16 {
+        self.left_index
+    }
+
+    /// Returns the total forward cost of this transition.
+    #[inline]
+    pub(crate) fn cost(&self) -> i32 {
+        self.cost
+    }
 }
 
 #[derive(Clone, Default)]
@@ -226,15 +345,8 @@ pub fn is_kanji(c: char) -> bool {
 impl Lattice {
     /// Helper method to create an edge efficiently
     #[inline]
-    fn create_edge(
-        edge_type: EdgeType,
-        word_entry: WordEntry,
-        start: usize,
-        stop: usize,
-        kanji_only: bool,
-    ) -> Edge {
+    fn create_edge(word_entry: WordEntry, start: usize, stop: usize, kanji_only: bool) -> Edge {
         Edge {
-            edge_type,
             word_entry,
             left_index: u16::MAX,
             start_index: start as u32,
@@ -450,11 +562,8 @@ impl Lattice {
                     let prefix_len = end - start;
                     let kanji_only = self.is_kanji_all(char_idx, prefix_len);
                     let edge = Self::create_edge(
-                        EdgeType::KNOWN,
                         word_entry, // WordEntry is Copy
-                        start,
-                        end,
-                        kanji_only,
+                        start, end, kanji_only,
                     );
                     self.add_edge_in_lattice(edge, cost_matrix, search_mode);
                     found = true;
@@ -566,13 +675,7 @@ impl Lattice {
 
             for &word_id in unknown_dictionary.lookup_word_ids(category) {
                 let word_entry = unknown_dictionary.word_entry(word_id);
-                let edge = Self::create_edge(
-                    EdgeType::UNKNOWN,
-                    word_entry,
-                    start,
-                    start + byte_len,
-                    kanji_only,
-                );
+                let edge = Self::create_edge(word_entry, start, start + byte_len, kanji_only);
                 self.add_edge_in_lattice(edge, cost_matrix, search_mode);
             }
             return Some(start + byte_len);
@@ -824,13 +927,7 @@ impl Lattice {
 
             for &word_id in unknown_dictionary.lookup_word_ids(category) {
                 let word_entry = unknown_dictionary.word_entry(word_id);
-                let edge = Self::create_edge(
-                    EdgeType::UNKNOWN,
-                    word_entry,
-                    start,
-                    start + byte_len,
-                    kanji_only,
-                );
+                let edge = Self::create_edge(word_entry, start, start + byte_len, kanji_only);
                 self.add_edge_in_lattice_nbest(edge, cost_matrix, search_mode);
             }
             return Some(start + byte_len);
@@ -990,8 +1087,7 @@ impl Lattice {
 
                     let prefix_len = end - start;
                     let kanji_only = self.is_kanji_all(char_idx, prefix_len);
-                    let edge =
-                        Self::create_edge(EdgeType::KNOWN, word_entry, start, end, kanji_only);
+                    let edge = Self::create_edge(word_entry, start, end, kanji_only);
                     self.add_edge_in_lattice_nbest(edge, cost_matrix, search_mode);
                     found = true;
 
@@ -1129,16 +1225,8 @@ mod tests {
     #[test]
     fn test_word_entry() {
         let mut buffer = Vec::new();
-        let word_entry = WordEntry {
-            word_id: WordId {
-                id: 1u32,
-                is_system: true,
-                lex_type: LexType::System,
-            },
-            word_cost: -17i16,
-            left_id: 1411u16,
-            right_id: 1412u16,
-        };
+        let word_entry =
+            WordEntry::new(WordId::new(LexType::System, 1u32), -17i16, 1411u16, 1412u16);
         word_entry.serialize(&mut buffer).unwrap();
         assert_eq!(WordEntry::SERIALIZED_LEN, buffer.len());
         let word_entry2 = WordEntry::deserialize(&buffer[..], true);

--- a/lindera/src/token.rs
+++ b/lindera/src/token.rs
@@ -139,12 +139,14 @@ impl<'a> Token<'a> {
         if self.details.is_none() {
             let tmp = if self.word_id.is_unknown() {
                 self.dictionary
-                    .unknown_word_details(self.word_id.id as usize)
+                    .unknown_word_details(self.word_id.id() as usize)
             } else if self.word_id.is_system() {
-                self.dictionary.word_details(self.word_id.id as usize)
+                self.dictionary.word_details(self.word_id.id() as usize)
             } else {
                 match self.user_dictionary {
-                    Some(user_dictionary) => user_dictionary.word_details(self.word_id.id as usize),
+                    Some(user_dictionary) => {
+                        user_dictionary.word_details(self.word_id.id() as usize)
+                    }
                     None => UNK.to_vec(),
                 }
             };
@@ -280,7 +282,7 @@ impl<'a> Token<'a> {
         let surface = self.surface.to_string();
         let byte_start = self.byte_start;
         let byte_end = self.byte_end;
-        let word_id = self.word_id.id;
+        let word_id = self.word_id.id();
 
         // Get details (requires mutable borrow)
         let details = self.details();

--- a/lindera/src/token_filter/japanese_base_form.rs
+++ b/lindera/src/token_filter/japanese_base_form.rs
@@ -82,11 +82,7 @@ mod tests {
                 byte_end: 12,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 321702,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 321702),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -107,11 +103,7 @@ mod tests {
                 byte_end: 15,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 53041,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 53041),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -132,11 +124,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 3222,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 3222),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -157,11 +145,7 @@ mod tests {
                 byte_end: 27,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 68730,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 68730),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/japanese_compound_word.rs
+++ b/lindera/src/token_filter/japanese_compound_word.rs
@@ -278,11 +278,7 @@ mod tests {
                 byte_end: 3,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 391174,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 391174),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -303,11 +299,7 @@ mod tests {
                 byte_end: 6,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 391171,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 391171),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -328,11 +320,7 @@ mod tests {
                 byte_end: 9,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 391171,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 391171),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -353,11 +341,7 @@ mod tests {
                 byte_end: 12,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 137904,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 137904),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -378,11 +362,7 @@ mod tests {
                 byte_end: 15,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 287427,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 287427),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -403,11 +383,7 @@ mod tests {
                 byte_end: 18,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 80582,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 80582),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -428,11 +404,7 @@ mod tests {
                 byte_end: 24,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 228047,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 228047),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/japanese_kana.rs
+++ b/lindera/src/token_filter/japanese_kana.rs
@@ -226,11 +226,7 @@ mod tests {
                 byte_end: 12,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 321702,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 321702),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -251,11 +247,7 @@ mod tests {
                 byte_end: 18,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 374175,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 374175),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -276,11 +268,7 @@ mod tests {
                 byte_end: 36,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 4294967295,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 4294967295),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![Cow::Borrowed("UNK")]),
@@ -325,11 +313,7 @@ mod tests {
                 byte_end: 6,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 171030,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 171030),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -350,11 +334,7 @@ mod tests {
                 byte_end: 9,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 298064,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 298064),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -375,11 +355,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 28502,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 28502),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -400,11 +376,7 @@ mod tests {
                 byte_end: 24,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 202045,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 202045),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -460,11 +432,7 @@ mod tests {
                 byte_end: 12,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 321702,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 321702),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -485,11 +453,7 @@ mod tests {
                 byte_end: 18,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 374175,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 374175),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -510,11 +474,7 @@ mod tests {
                 byte_end: 36,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 4294967295,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 4294967295),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![Cow::Borrowed("UNK")]),
@@ -559,11 +519,7 @@ mod tests {
                 byte_end: 6,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 171030,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 171030),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -584,11 +540,7 @@ mod tests {
                 byte_end: 9,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 298064,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 298064),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -609,11 +561,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 28502,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 28502),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -634,11 +582,7 @@ mod tests {
                 byte_end: 24,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 202045,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 202045),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -694,11 +638,7 @@ mod tests {
                 byte_end: 6,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 250023,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 250023),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -719,11 +659,7 @@ mod tests {
                 byte_end: 9,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 364736,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 364736),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -744,11 +680,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 927,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 927),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -769,11 +701,7 @@ mod tests {
                 byte_end: 24,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 202045,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 202045),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -829,11 +757,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 151151,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 151151),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -854,11 +778,7 @@ mod tests {
                 byte_end: 18,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 166998,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 166998),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -879,11 +799,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 383791,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 383791),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/japanese_katakana_stem.rs
+++ b/lindera/src/token_filter/japanese_katakana_stem.rs
@@ -216,11 +216,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 94843,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 94843),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -241,11 +237,7 @@ mod tests {
                 byte_end: 21,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 100137,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 100137),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/japanese_keep_tags.rs
+++ b/lindera/src/token_filter/japanese_keep_tags.rs
@@ -260,11 +260,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 36165,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 36165),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -285,11 +281,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -310,11 +302,7 @@ mod tests {
                 byte_end: 18,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -335,11 +323,7 @@ mod tests {
                 byte_end: 21,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -360,11 +344,7 @@ mod tests {
                 byte_end: 27,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -385,11 +365,7 @@ mod tests {
                 byte_end: 30,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 55831,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 55831),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -410,11 +386,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 8029,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 8029),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/japanese_number.rs
+++ b/lindera/src/token_filter/japanese_number.rs
@@ -919,11 +919,7 @@ mod tests {
                 byte_end: 3,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 102657,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 102657),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -952,11 +948,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 102657,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 102657),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -987,11 +979,7 @@ mod tests {
                 byte_end: 129,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 102657,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 102657),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -1021,11 +1009,7 @@ mod tests {
                     byte_end: 6,
                     position: 0,
                     position_length: 1,
-                    word_id: WordId {
-                        id: 368893,
-                        is_system: true,
-                        lex_type: LexType::System,
-                    },
+                    word_id: WordId::new(LexType::System, 368893),
                     dictionary: &dictionary,
                     user_dictionary: None,
                     details: Some(vec![
@@ -1046,11 +1030,7 @@ mod tests {
                     byte_end: 12,
                     position: 0,
                     position_length: 1,
-                    word_id: WordId {
-                        id: 103913,
-                        is_system: true,
-                        lex_type: LexType::System,
-                    },
+                    word_id: WordId::new(LexType::System, 103913),
                     dictionary: &dictionary,
                     user_dictionary: None,
                     details: Some(vec![
@@ -1099,11 +1079,7 @@ mod tests {
                 byte_end: 3,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 102657,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 102657),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -1132,11 +1108,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 102657,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 102657),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -1167,11 +1139,7 @@ mod tests {
                 byte_end: 129,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 102657,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 102657),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -1201,11 +1169,7 @@ mod tests {
                     byte_end: 6,
                     position: 0,
                     position_length: 1,
-                    word_id: WordId {
-                        id: 368893,
-                        is_system: true,
-                        lex_type: LexType::System,
-                    },
+                    word_id: WordId::new(LexType::System, 368893),
                     dictionary: &dictionary,
                     user_dictionary: None,
                     details: Some(vec![
@@ -1226,11 +1190,7 @@ mod tests {
                     byte_end: 12,
                     position: 0,
                     position_length: 1,
-                    word_id: WordId {
-                        id: 103913,
-                        is_system: true,
-                        lex_type: LexType::System,
-                    },
+                    word_id: WordId::new(LexType::System, 103913),
                     dictionary: &dictionary,
                     user_dictionary: None,
                     details: Some(vec![

--- a/lindera/src/token_filter/japanese_reading_form.rs
+++ b/lindera/src/token_filter/japanese_reading_form.rs
@@ -112,11 +112,7 @@ mod tests {
                 byte_end: 12,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 321702,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 321702),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -137,11 +133,7 @@ mod tests {
                 byte_end: 18,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 374175,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 374175),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -162,11 +154,7 @@ mod tests {
                 byte_end: 36,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 4294967295,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 4294967295),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![Cow::Borrowed("UNK")]),

--- a/lindera/src/token_filter/japanese_stop_tags.rs
+++ b/lindera/src/token_filter/japanese_stop_tags.rs
@@ -218,11 +218,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 36165,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 36165),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -243,11 +239,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -268,11 +260,7 @@ mod tests {
                 byte_end: 18,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -293,11 +281,7 @@ mod tests {
                 byte_end: 21,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -318,11 +302,7 @@ mod tests {
                 byte_end: 27,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -343,11 +323,7 @@ mod tests {
                 byte_end: 30,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 55831,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 55831),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -368,11 +344,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 8029,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 8029),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/keep_words.rs
+++ b/lindera/src/token_filter/keep_words.rs
@@ -147,11 +147,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 36165,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 36165),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -172,11 +168,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -197,11 +189,7 @@ mod tests {
                 byte_end: 18,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -222,11 +210,7 @@ mod tests {
                 byte_end: 21,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -247,11 +231,7 @@ mod tests {
                 byte_end: 27,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -272,11 +252,7 @@ mod tests {
                 byte_end: 30,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 55831,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 55831),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -297,11 +273,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 8029,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 8029),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/korean_keep_tags.rs
+++ b/lindera/src/token_filter/korean_keep_tags.rs
@@ -133,11 +133,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 770060,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 770060),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -157,11 +153,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 576336,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 576336),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -181,11 +173,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 787807,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 787807),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -205,11 +193,7 @@ mod tests {
                 byte_end: 27,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 383955,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 383955),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -229,11 +213,7 @@ mod tests {
                 byte_end: 30,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 574939,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 574939),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -253,11 +233,7 @@ mod tests {
                 byte_end: 33,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 774117,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 774117),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -277,11 +253,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 444151,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 444151),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -301,11 +273,7 @@ mod tests {
                 byte_end: 39,
                 position: 7,
                 position_length: 1,
-                word_id: WordId {
-                    id: 602850,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 602850),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -325,11 +293,7 @@ mod tests {
                 byte_end: 48,
                 position: 8,
                 position_length: 1,
-                word_id: WordId {
-                    id: 458024,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 458024),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/korean_reading_form.rs
+++ b/lindera/src/token_filter/korean_reading_form.rs
@@ -77,11 +77,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 770060,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 770060),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -101,11 +97,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 576336,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 576336),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -125,11 +117,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 787807,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 787807),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -149,11 +137,7 @@ mod tests {
                 byte_end: 27,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 383955,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 383955),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -173,11 +157,7 @@ mod tests {
                 byte_end: 30,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 574939,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 574939),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -197,11 +177,7 @@ mod tests {
                 byte_end: 33,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 774117,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 774117),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -221,11 +197,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 444151,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 444151),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -245,11 +217,7 @@ mod tests {
                 byte_end: 39,
                 position: 7,
                 position_length: 1,
-                word_id: WordId {
-                    id: 602850,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 602850),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -269,11 +237,7 @@ mod tests {
                 byte_end: 48,
                 position: 8,
                 position_length: 1,
-                word_id: WordId {
-                    id: 458024,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 458024),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/korean_stop_tags.rs
+++ b/lindera/src/token_filter/korean_stop_tags.rs
@@ -193,11 +193,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 770060,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 770060),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -217,11 +213,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 576336,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 576336),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -241,11 +233,7 @@ mod tests {
                 byte_end: 21,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 787807,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 787807),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -265,11 +253,7 @@ mod tests {
                 byte_end: 27,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 383955,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 383955),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -289,11 +273,7 @@ mod tests {
                 byte_end: 30,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 574939,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 574939),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -313,11 +293,7 @@ mod tests {
                 byte_end: 33,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 774117,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 774117),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -337,11 +313,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 444151,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 444151),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -361,11 +333,7 @@ mod tests {
                 byte_end: 39,
                 position: 7,
                 position_length: 1,
-                word_id: WordId {
-                    id: 602850,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 602850),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -385,11 +353,7 @@ mod tests {
                 byte_end: 48,
                 position: 8,
                 position_length: 1,
-                word_id: WordId {
-                    id: 458024,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 458024),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/length.rs
+++ b/lindera/src/token_filter/length.rs
@@ -151,11 +151,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 36165,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 36165),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -176,11 +172,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -201,11 +193,7 @@ mod tests {
                 byte_end: 18,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -226,11 +214,7 @@ mod tests {
                 byte_end: 21,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -251,11 +235,7 @@ mod tests {
                 byte_end: 27,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -276,11 +256,7 @@ mod tests {
                 byte_end: 30,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 55831,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 55831),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -301,11 +277,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 8029,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 8029),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/lowercase.rs
+++ b/lindera/src/token_filter/lowercase.rs
@@ -68,11 +68,7 @@ mod tests {
             byte_end: 4,
             position: 0,
             position_length: 1,
-            word_id: WordId {
-                id: 4294967295,
-                is_system: true,
-                lex_type: LexType::System,
-            },
+            word_id: WordId::new(LexType::System, 4294967295),
             dictionary: &dictionary,
             user_dictionary: None,
             details: Some(vec![Cow::Borrowed("UNK")]),

--- a/lindera/src/token_filter/mapping.rs
+++ b/lindera/src/token_filter/mapping.rs
@@ -173,11 +173,7 @@ mod tests {
                 byte_end: 6,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 312630,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 312630),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -198,11 +194,7 @@ mod tests {
                 byte_end: 9,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 383791,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 383791),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/remove_diacritical_mark.rs
+++ b/lindera/src/token_filter/remove_diacritical_mark.rs
@@ -159,11 +159,7 @@ mod tests {
                 byte_end: 4,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 4294967295,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 4294967295),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![Cow::Borrowed("UNK")]),
@@ -181,11 +177,7 @@ mod tests {
                 byte_end: 12,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 84915,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 84915),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -235,11 +227,7 @@ mod tests {
                 byte_end: 4,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 4294967295,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 4294967295),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![Cow::Borrowed("UNK")]),
@@ -257,11 +245,7 @@ mod tests {
                 byte_end: 12,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 84915,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 84915),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/stop_words.rs
+++ b/lindera/src/token_filter/stop_words.rs
@@ -120,11 +120,7 @@ mod tests {
                 byte_end: 9,
                 position: 0,
                 position_length: 1,
-                word_id: WordId {
-                    id: 36165,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 36165),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -145,11 +141,7 @@ mod tests {
                 byte_end: 12,
                 position: 1,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -170,11 +162,7 @@ mod tests {
                 byte_end: 18,
                 position: 2,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -195,11 +183,7 @@ mod tests {
                 byte_end: 21,
                 position: 3,
                 position_length: 1,
-                word_id: WordId {
-                    id: 73246,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 73246),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -220,11 +204,7 @@ mod tests {
                 byte_end: 27,
                 position: 4,
                 position_length: 1,
-                word_id: WordId {
-                    id: 74990,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 74990),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -245,11 +225,7 @@ mod tests {
                 byte_end: 30,
                 position: 5,
                 position_length: 1,
-                word_id: WordId {
-                    id: 55831,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 55831),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![
@@ -270,11 +246,7 @@ mod tests {
                 byte_end: 36,
                 position: 6,
                 position_length: 1,
-                word_id: WordId {
-                    id: 8029,
-                    is_system: true,
-                    lex_type: LexType::System,
-                },
+                word_id: WordId::new(LexType::System, 8029),
                 dictionary: &dictionary,
                 user_dictionary: None,
                 details: Some(vec![

--- a/lindera/src/token_filter/uppercase.rs
+++ b/lindera/src/token_filter/uppercase.rs
@@ -68,11 +68,7 @@ mod tests {
             byte_end: 4,
             position: 0,
             position_length: 1,
-            word_id: WordId {
-                id: 4294967295,
-                is_system: true,
-                lex_type: LexType::System,
-            },
+            word_id: WordId::new(LexType::System, 4294967295),
             dictionary: &dictionary,
             user_dictionary: None,
             details: Some(vec![Cow::Borrowed("UNK")]),


### PR DESCRIPTION
# Encapsulate viterbi internal structs behind accessors (#709)

Part of #708 (Phase 6 / v4.0.0). Refs #709.

## Summary

Make the fields of the viterbi internal structs private and expose `#[inline]` accessors, so
consumers no longer depend on implementation details. This is a **breaking** change to the public API
of `lindera-dictionary::viterbi` (and therefore deferred to v4.0.0).

## What changed

- **`WordId`**: fields (`id`, `is_system`, `lex_type`) are now private. Added `#[inline] id()`; kept
  `new()` / `is_unknown()` / `is_system()` / `lex_type()` (now `#[inline]`).
- **`WordEntry`**: fields private. Added `WordEntry::new()` as the sole constructor, plus `#[inline]`
  `word_id()` / `word_cost()` accessors (`left_id()` / `right_id()` kept). `SERIALIZED_LEN`,
  `serialize`, `deserialize` demoted to `pub(crate)`.
- **`Edge`** / **`PathEntry`**: fields private with `#[inline] pub(crate)` accessors.
- **`Lattice`**: already had private fields — unchanged.
- **Dead-code removal**: the `Edge::edge_type` field and the `EdgeType` enum were write-only (set in
  `create_edge`, never read anywhere). They had been masked by the `pub` field; encapsulation
  surfaced them as dead code, so they are removed (`create_edge` and its 4 call sites updated).
- **Call sites** updated across `lindera-dictionary` (`nbest`, `mode`, `builder/*`,
  `dictionary/*`, `trainer/model`), `lindera` (`token`), and `lindera-binding-core` (`token`).
- **Tests**: the ~117 test-only `WordId { .. }` struct literals (all `LexType::System`) were
  converted to `WordId::new(LexType::System, id)`.

Net: 28 files changed, ~+316 / -699 lines (the deletions are mostly the collapsed test literals and
the removed `EdgeType` plumbing).

## Verification

- `cargo build` — `lindera-dictionary --features train`, `lindera`, `lindera-binding-core`: OK
- `cargo test -p lindera-dictionary --features train --lib`: 52 passed
- `cargo test -p lindera-binding-core`: 4 passed
- `cargo test -p lindera --features embed-ipadic,embed-ko-dic,embed-jieba,train --test golden_tokenization`:
  **8/8 passed, snapshots unchanged** (incl. N-best and user dictionary) → behavior is invariant
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets -- -D warnings` (lindera-dictionary/lindera/lindera-binding-core): clean
- Production-LTO benchmark (`[profile.bench] lto = true`, matching `[profile.release]`),
  `bench_ipadic` tokenize benches, same machine, baseline = `main`:
  - The stable ms-scale benches show **no regression**: `bench-tokenize-long-text-ipadic` +0.3%,
    `bench-tokenize-details-long-text-ipadic` −1.6%.
  - The µs-scale micro-benches could not be measured reliably on this (shared, loaded) machine:
    re-running the **same** branch binary against the same baseline produced wildly different
    deltas (e.g. `bench-tokenize-ipadic`: +3.0% → −21% → −27% across three consecutive runs; the
    absolute time drifted 16.7→13.2→12.2 µs purely with background load). Machine-state noise
    (±25%) dwarfs any code effect at this scale.
  - Assessment: **no evidence of a real regression.** The change is `#[inline]` accessors that the
    compiler reduces to direct field access under LTO, plus removal of a write-only field (`Edge`
    shrinks). The definitive ±3% gate should be confirmed on a quiesced machine / CI bench per
    `BENCHMARKING.md`.
