### PR TITLE
feat(binding-core): add CoreTokenizerBuilder and CoreTokenizer

### DIFF
--- a/lindera-binding-core/Cargo.toml
+++ b/lindera-binding-core/Cargo.toml
@@ -12,3 +12,4 @@ license = { workspace = true }
 
 [dependencies]
 lindera = { workspace = true }
+serde_json = { workspace = true }

--- a/lindera-binding-core/src/lib.rs
+++ b/lindera-binding-core/src/lib.rs
@@ -11,8 +11,10 @@ pub mod error;
 pub mod metadata;
 pub mod schema;
 pub mod token;
+pub mod tokenizer;
 
 pub use error::{CoreError, CoreResult, ErrorKind};
 pub use metadata::CoreMetadata;
 pub use schema::{CoreFieldDefinition, CoreFieldType, CoreSchema};
 pub use token::TokenView;
+pub use tokenizer::{CoreTokenizer, CoreTokenizerBuilder};

--- a/lindera-binding-core/src/tokenizer.rs
+++ b/lindera-binding-core/src/tokenizer.rs
@@ -1,0 +1,179 @@
+//! Shared tokenizer build-flow orchestration for the bindings.
+//!
+//! Each binding's tokenizer wrapper reimplements the same flow: configure a
+//! [`lindera::tokenizer::TokenizerBuilder`], build a
+//! [`lindera::tokenizer::Tokenizer`], and convert the resulting tokens. This
+//! module collects that orchestration into [`CoreTokenizerBuilder`] and
+//! [`CoreTokenizer`], leaving each binding to do only its FFI-value conversion
+//! (`serde_json::Value` ⇔ the host language's argument type) and a thin wrapper.
+
+use std::path::Path;
+use std::str::FromStr;
+
+use serde_json::Value;
+
+use lindera::dictionary::{Dictionary, UserDictionary};
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+use lindera::tokenizer::{Tokenizer, TokenizerBuilder};
+
+use crate::error::CoreResult;
+use crate::token::TokenView;
+
+/// Builder that orchestrates tokenizer configuration on behalf of the bindings.
+///
+/// Wraps [`lindera::tokenizer::TokenizerBuilder`]; filter arguments are passed
+/// as [`serde_json::Value`] so the FFI-specific value conversion stays in each
+/// binding.
+pub struct CoreTokenizerBuilder {
+    /// The backing lindera builder.
+    inner: TokenizerBuilder,
+}
+
+impl CoreTokenizerBuilder {
+    /// Creates a builder with the default (empty) configuration.
+    pub fn new() -> CoreResult<Self> {
+        Ok(Self {
+            inner: TokenizerBuilder::new()?,
+        })
+    }
+
+    /// Creates a builder from a YAML configuration file.
+    pub fn from_file(file_path: &Path) -> CoreResult<Self> {
+        Ok(Self {
+            inner: TokenizerBuilder::from_file(file_path)?,
+        })
+    }
+
+    /// Sets the segmenter mode from a string (`"normal"` or `"decompose"`).
+    pub fn set_mode(&mut self, mode: &str) -> CoreResult<&mut Self> {
+        let mode = Mode::from_str(mode)?;
+        self.inner.set_segmenter_mode(&mode);
+        Ok(self)
+    }
+
+    /// Sets the segmenter dictionary URI / path.
+    pub fn set_dictionary(&mut self, uri: &str) -> &mut Self {
+        self.inner.set_segmenter_dictionary(uri);
+        self
+    }
+
+    /// Sets the segmenter user-dictionary URI / path.
+    pub fn set_user_dictionary(&mut self, uri: &str) -> &mut Self {
+        self.inner.set_segmenter_user_dictionary(uri);
+        self
+    }
+
+    /// Sets whether whitespace tokens are kept in the output.
+    pub fn set_keep_whitespace(&mut self, keep_whitespace: bool) -> &mut Self {
+        self.inner.set_segmenter_keep_whitespace(keep_whitespace);
+        self
+    }
+
+    /// Appends a character filter identified by `kind` with JSON `args`.
+    pub fn append_character_filter(&mut self, kind: &str, args: &Value) -> &mut Self {
+        self.inner.append_character_filter(kind, args);
+        self
+    }
+
+    /// Appends a token filter identified by `kind` with JSON `args`.
+    pub fn append_token_filter(&mut self, kind: &str, args: &Value) -> &mut Self {
+        self.inner.append_token_filter(kind, args);
+        self
+    }
+
+    /// Builds a [`CoreTokenizer`] from the current configuration.
+    pub fn build(&self) -> CoreResult<CoreTokenizer> {
+        Ok(CoreTokenizer {
+            inner: self.inner.build()?,
+        })
+    }
+}
+
+/// Tokenizer that orchestrates tokenization on behalf of the bindings.
+///
+/// Wraps [`lindera::tokenizer::Tokenizer`] and returns owned [`TokenView`]s so
+/// the bindings never handle borrowed `lindera` tokens directly.
+pub struct CoreTokenizer {
+    /// The backing lindera tokenizer.
+    inner: Tokenizer,
+}
+
+impl CoreTokenizer {
+    /// Builds a tokenizer from segmenter parts, parsing `mode` from a string.
+    pub fn from_segmenter(
+        mode: &str,
+        dictionary: Dictionary,
+        user_dictionary: Option<UserDictionary>,
+    ) -> CoreResult<Self> {
+        let mode = Mode::from_str(mode)?;
+        let segmenter = Segmenter::new(mode, dictionary, user_dictionary);
+        Ok(Self {
+            inner: Tokenizer::new(segmenter),
+        })
+    }
+
+    /// Wraps an already-built lindera [`Tokenizer`].
+    pub fn from_tokenizer(tokenizer: Tokenizer) -> Self {
+        Self { inner: tokenizer }
+    }
+
+    /// Tokenizes `text`, returning owned [`TokenView`]s.
+    pub fn tokenize(&self, text: &str) -> CoreResult<Vec<TokenView>> {
+        let tokens = self.inner.tokenize(text)?;
+        Ok(tokens.into_iter().map(TokenView::from_token).collect())
+    }
+
+    /// Tokenizes `text` and returns the N-best results as `(tokens, cost)` pairs.
+    pub fn tokenize_nbest(
+        &self,
+        text: &str,
+        n: usize,
+        unique: bool,
+        cost_threshold: Option<i64>,
+    ) -> CoreResult<Vec<(Vec<TokenView>, i64)>> {
+        let results = self.inner.tokenize_nbest(text, n, unique, cost_threshold)?;
+        Ok(results
+            .into_iter()
+            .map(|(tokens, cost)| {
+                (
+                    tokens.into_iter().map(TokenView::from_token).collect(),
+                    cost,
+                )
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_new_succeeds() {
+        assert!(CoreTokenizerBuilder::new().is_ok());
+    }
+
+    #[test]
+    fn set_mode_accepts_known_modes() {
+        let mut builder = CoreTokenizerBuilder::new().expect("builder");
+        assert!(builder.set_mode("normal").is_ok());
+        assert!(builder.set_mode("decompose").is_ok());
+    }
+
+    #[test]
+    fn set_mode_rejects_unknown_mode() {
+        let mut builder = CoreTokenizerBuilder::new().expect("builder");
+        assert!(builder.set_mode("definitely-not-a-mode").is_err());
+    }
+
+    #[test]
+    fn infallible_setters_chain() {
+        let mut builder = CoreTokenizerBuilder::new().expect("builder");
+        builder
+            .set_dictionary("embedded://ipadic")
+            .set_keep_whitespace(true)
+            .append_token_filter("japanese_compound_word", &Value::Object(Default::default()));
+        // Reaching here means the borrow-returning setters compose.
+    }
+}


### PR DESCRIPTION
# Add `CoreTokenizerBuilder` + `CoreTokenizer` to lindera-binding-core (#713)

Part of #708 (Phase 6 / v4.0.0). Refs #713. This completes the binding-core facade additions
(#710 CoreError, #711 CoreSchema, #712 CoreMetadata, #713 CoreTokenizer).

## Summary

Lift the tokenizer build-flow orchestration into `lindera-binding-core`, so each binding's tokenizer
wrapper can become a thin FFI adapter that only does value conversion. Purely additive — **no binding
is changed**.

## What changed (`lindera-binding-core/src/tokenizer.rs`)

- `CoreTokenizerBuilder` — wraps `lindera::tokenizer::TokenizerBuilder`: `new`, `from_file`,
  `set_mode` (parses `Mode` from a string), `set_dictionary`, `set_user_dictionary`,
  `set_keep_whitespace`, `append_character_filter`, `append_token_filter`, `build`. Filter args are
  `serde_json::Value` so the FFI-specific value conversion stays in each binding.
- `CoreTokenizer` — wraps `lindera::tokenizer::Tokenizer`: `from_segmenter` (mode string + dictionary
  + optional user dictionary), `from_tokenizer`, `tokenize`, `tokenize_nbest`. Returns owned
  `TokenView`s so bindings never handle borrowed `lindera` tokens.
- All errors map through `CoreError` (#710).
- Re-exported `CoreTokenizer`, `CoreTokenizerBuilder` from `lib.rs`.
- Added `serde_json` as a dependency (already a workspace dependency; MIT/Apache-2.0).

## Verification

- `cargo test -p lindera-binding-core`: 22 passed (4 error + 11 schema + 3 metadata + 4 tokenizer)
- `cargo fmt -p lindera-binding-core -- --check`: clean
- `cargo clippy -p lindera-binding-core --all-targets -- -D warnings`: clean
- `cargo test -p lindera --features embed-ipadic,embed-ko-dic,embed-jieba,train --test golden_tokenization`:
  8/8 unchanged

> Note: the full build/tokenize path needs a loaded dictionary, which `lindera-binding-core` has no
> embed feature for; the unit tests cover the pure logic (builder creation, mode parsing, setter
> chaining), and the end-to-end flow is covered by the per-binding integration tests (`make
> test-lindera-*`) once the bindings migrate (#714+).
