### PR TITLE
feat(python): migrate lindera-python to the lindera-binding-core facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ name = "lindera-binding-core"
 version = "3.0.7"
 dependencies = [
  "lindera",
+ "serde_json",
 ]
 
 [[package]]

--- a/lindera-python/src/error.rs
+++ b/lindera-python/src/error.rs
@@ -4,8 +4,10 @@
 
 use std::fmt;
 
-use pyo3::exceptions::PyException;
+use pyo3::exceptions::{PyException, PyIOError, PyValueError};
 use pyo3::prelude::*;
+
+use lindera_binding_core::{CoreError, ErrorKind};
 
 /// Error type for Lindera operations.
 ///
@@ -49,6 +51,28 @@ impl std::error::Error for PyLinderaError {}
 impl From<PyLinderaError> for PyErr {
     fn from(err: PyLinderaError) -> PyErr {
         PyException::new_err(err.message)
+    }
+}
+
+/// Maps a [`CoreError`] onto the matching Python exception.
+///
+/// I/O failures become `IOError`; everything else becomes `ValueError`,
+/// preserving the exception types the bindings raised before the migration.
+/// (A `From<CoreError> for PyErr` impl is not possible here because of the
+/// orphan rule, so binding methods use this with `map_err`.)
+///
+/// # 引数
+///
+/// * `err` - The core error to convert.
+///
+/// # 戻り値
+///
+/// The equivalent Python exception.
+pub fn to_py_error(err: CoreError) -> PyErr {
+    let message = err.message().to_string();
+    match err.kind() {
+        ErrorKind::Io => PyIOError::new_err(message),
+        _ => PyValueError::new_err(message),
     }
 }
 

--- a/lindera-python/src/metadata.rs
+++ b/lindera-python/src/metadata.rs
@@ -1,7 +1,9 @@
 //! Dictionary metadata configuration.
 //!
 //! This module provides structures for configuring dictionary metadata, including
-//! character encodings and schema definitions.
+//! character encodings and schema definitions. The defaults and schema wiring are
+//! delegated to [`lindera_binding_core::CoreMetadata`]; this module only adds the
+//! PyO3 wrappers.
 //!
 //! # Examples
 //!
@@ -24,12 +26,14 @@ use std::collections::HashMap;
 use pyo3::prelude::*;
 
 use lindera::dictionary::Metadata;
+use lindera_binding_core::CoreMetadata;
 
 use crate::schema::PySchema;
 
 /// Dictionary metadata configuration.
 ///
-/// Contains all configuration parameters for building and using dictionaries.
+/// A thin PyO3 wrapper over [`lindera_binding_core::CoreMetadata`], which owns
+/// the default values and the schema wiring.
 ///
 /// # Fields
 ///
@@ -47,17 +51,8 @@ use crate::schema::PySchema;
 #[pyclass(name = "Metadata", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PyMetadata {
-    name: String,
-    encoding: String,
-    default_word_cost: i16,
-    default_left_context_id: u16,
-    default_right_context_id: u16,
-    default_field_value: String,
-    flexible_csv: bool,
-    skip_invalid_cost_or_id: bool,
-    normalize_details: bool,
-    dictionary_schema: PySchema,
-    user_dictionary_schema: PySchema,
+    /// The backing binding-core metadata.
+    pub inner: CoreMetadata,
 }
 
 #[pymethods]
@@ -79,31 +74,27 @@ impl PyMetadata {
         user_dictionary_schema: Option<PySchema>,
     ) -> Self {
         PyMetadata {
-            name: name.unwrap_or_else(|| "default".to_string()),
-            encoding: encoding.unwrap_or_else(|| "UTF-8".to_string()),
-            default_word_cost: default_word_cost.unwrap_or(-10000),
-            default_left_context_id: default_left_context_id.unwrap_or(1288),
-            default_right_context_id: default_right_context_id.unwrap_or(1288),
-            default_field_value: default_field_value.unwrap_or_else(|| "*".to_string()),
-            flexible_csv: flexible_csv.unwrap_or(false),
-            skip_invalid_cost_or_id: skip_invalid_cost_or_id.unwrap_or(false),
-            normalize_details: normalize_details.unwrap_or(false),
-            dictionary_schema: dictionary_schema.unwrap_or_else(PySchema::create_default),
-            user_dictionary_schema: user_dictionary_schema.unwrap_or_else(|| {
-                PySchema::new(vec![
-                    "surface".to_string(),
-                    "reading".to_string(),
-                    "pronunciation".to_string(),
-                ])
-            }),
+            inner: CoreMetadata::new(
+                name,
+                encoding,
+                default_word_cost,
+                default_left_context_id,
+                default_right_context_id,
+                default_field_value,
+                flexible_csv,
+                skip_invalid_cost_or_id,
+                normalize_details,
+                dictionary_schema.map(Into::into),
+                user_dictionary_schema.map(Into::into),
+            ),
         }
     }
 
     #[staticmethod]
     pub fn create_default() -> Self {
-        PyMetadata::new(
-            None, None, None, None, None, None, None, None, None, None, None,
-        )
+        PyMetadata {
+            inner: CoreMetadata::create_default(),
+        }
     }
 
     #[staticmethod]
@@ -123,150 +114,153 @@ impl PyMetadata {
 
     #[getter]
     pub fn name(&self) -> &str {
-        &self.name
+        &self.inner.name
     }
 
     #[setter]
     pub fn set_name(&mut self, name: String) {
-        self.name = name;
+        self.inner.name = name;
     }
 
     #[getter]
     pub fn encoding(&self) -> &str {
-        &self.encoding
+        &self.inner.encoding
     }
 
     #[setter]
     pub fn set_encoding(&mut self, encoding: String) {
-        self.encoding = encoding;
+        self.inner.encoding = encoding;
     }
 
     #[getter]
     pub fn default_word_cost(&self) -> i16 {
-        self.default_word_cost
+        self.inner.default_word_cost
     }
 
     #[setter]
     pub fn set_default_word_cost(&mut self, cost: i16) {
-        self.default_word_cost = cost;
+        self.inner.default_word_cost = cost;
     }
 
     #[getter]
     pub fn default_left_context_id(&self) -> u16 {
-        self.default_left_context_id
+        self.inner.default_left_context_id
     }
 
     #[setter]
     pub fn set_default_left_context_id(&mut self, id: u16) {
-        self.default_left_context_id = id;
+        self.inner.default_left_context_id = id;
     }
 
     #[getter]
     pub fn default_right_context_id(&self) -> u16 {
-        self.default_right_context_id
+        self.inner.default_right_context_id
     }
 
     #[setter]
     pub fn set_default_right_context_id(&mut self, id: u16) {
-        self.default_right_context_id = id;
+        self.inner.default_right_context_id = id;
     }
 
     #[getter]
     pub fn default_field_value(&self) -> &str {
-        &self.default_field_value
+        &self.inner.default_field_value
     }
 
     #[setter]
     pub fn set_default_field_value(&mut self, value: String) {
-        self.default_field_value = value;
+        self.inner.default_field_value = value;
     }
 
     #[getter]
     pub fn flexible_csv(&self) -> bool {
-        self.flexible_csv
+        self.inner.flexible_csv
     }
 
     #[setter]
     pub fn set_flexible_csv(&mut self, value: bool) {
-        self.flexible_csv = value;
+        self.inner.flexible_csv = value;
     }
 
     #[getter]
     pub fn skip_invalid_cost_or_id(&self) -> bool {
-        self.skip_invalid_cost_or_id
+        self.inner.skip_invalid_cost_or_id
     }
 
     #[setter]
     pub fn set_skip_invalid_cost_or_id(&mut self, value: bool) {
-        self.skip_invalid_cost_or_id = value;
+        self.inner.skip_invalid_cost_or_id = value;
     }
 
     #[getter]
     pub fn normalize_details(&self) -> bool {
-        self.normalize_details
+        self.inner.normalize_details
     }
 
     #[setter]
     pub fn set_normalize_details(&mut self, value: bool) {
-        self.normalize_details = value;
+        self.inner.normalize_details = value;
     }
 
     #[getter]
     pub fn dictionary_schema(&self) -> PySchema {
-        self.dictionary_schema.clone()
+        PySchema::from(self.inner.dictionary_schema.clone())
     }
 
     #[setter]
     pub fn set_dictionary_schema(&mut self, schema: PySchema) {
-        self.dictionary_schema = schema;
+        self.inner.dictionary_schema = schema.into();
     }
 
     #[getter]
     pub fn user_dictionary_schema(&self) -> PySchema {
-        self.user_dictionary_schema.clone()
+        PySchema::from(self.inner.user_dictionary_schema.clone())
     }
 
     #[setter]
     pub fn set_user_dictionary_schema(&mut self, schema: PySchema) {
-        self.user_dictionary_schema = schema;
+        self.inner.user_dictionary_schema = schema.into();
     }
 
     pub fn to_dict(&self) -> HashMap<String, String> {
         let mut dict = HashMap::new();
-        dict.insert("name".to_string(), self.name.clone());
-        dict.insert("encoding".to_string(), self.encoding.clone());
+        dict.insert("name".to_string(), self.inner.name.clone());
+        dict.insert("encoding".to_string(), self.inner.encoding.clone());
         dict.insert(
             "default_word_cost".to_string(),
-            self.default_word_cost.to_string(),
+            self.inner.default_word_cost.to_string(),
         );
         dict.insert(
             "default_left_context_id".to_string(),
-            self.default_left_context_id.to_string(),
+            self.inner.default_left_context_id.to_string(),
         );
         dict.insert(
             "default_right_context_id".to_string(),
-            self.default_right_context_id.to_string(),
+            self.inner.default_right_context_id.to_string(),
         );
         dict.insert(
             "default_field_value".to_string(),
-            self.default_field_value.clone(),
+            self.inner.default_field_value.clone(),
         );
-        dict.insert("flexible_csv".to_string(), self.flexible_csv.to_string());
+        dict.insert(
+            "flexible_csv".to_string(),
+            self.inner.flexible_csv.to_string(),
+        );
         dict.insert(
             "skip_invalid_cost_or_id".to_string(),
-            self.skip_invalid_cost_or_id.to_string(),
+            self.inner.skip_invalid_cost_or_id.to_string(),
         );
         dict.insert(
             "normalize_details".to_string(),
-            self.normalize_details.to_string(),
+            self.inner.normalize_details.to_string(),
         );
         dict.insert(
             "dictionary_schema_fields".to_string(),
-            self.dictionary_schema.fields.join(","),
+            self.inner.dictionary_schema.fields().join(","),
         );
         dict.insert(
             "user_dictionary_schema_fields".to_string(),
-            self.user_dictionary_schema.fields.join(","),
+            self.inner.user_dictionary_schema.fields().join(","),
         );
         dict
     }
@@ -274,52 +268,30 @@ impl PyMetadata {
     fn __str__(&self) -> String {
         format!(
             "Metadata(name='{}', encoding='{}')",
-            self.name, self.encoding,
+            self.inner.name, self.inner.encoding,
         )
     }
 
     fn __repr__(&self) -> String {
         format!(
             "Metadata(name='{}', encoding='{}', schema_fields={})",
-            self.name,
-            self.encoding,
-            self.dictionary_schema.field_count()
+            self.inner.name,
+            self.inner.encoding,
+            self.inner.dictionary_schema.field_count()
         )
     }
 }
 
 impl From<PyMetadata> for Metadata {
     fn from(metadata: PyMetadata) -> Self {
-        Metadata::new(
-            metadata.name,
-            metadata.encoding,
-            metadata.default_word_cost,
-            metadata.default_left_context_id,
-            metadata.default_right_context_id,
-            metadata.default_field_value,
-            metadata.flexible_csv,
-            metadata.skip_invalid_cost_or_id,
-            metadata.normalize_details,
-            metadata.dictionary_schema.into(),
-            metadata.user_dictionary_schema.into(),
-        )
+        metadata.inner.into()
     }
 }
 
 impl From<Metadata> for PyMetadata {
     fn from(metadata: Metadata) -> Self {
         PyMetadata {
-            name: metadata.name,
-            encoding: metadata.encoding,
-            default_word_cost: metadata.default_word_cost,
-            default_left_context_id: metadata.default_left_context_id,
-            default_right_context_id: metadata.default_right_context_id,
-            default_field_value: metadata.default_field_value,
-            flexible_csv: metadata.flexible_csv,
-            skip_invalid_cost_or_id: metadata.skip_invalid_cost_or_id,
-            normalize_details: metadata.normalize_details,
-            dictionary_schema: metadata.dictionary_schema.into(),
-            user_dictionary_schema: metadata.user_dictionary_schema.into(),
+            inner: CoreMetadata::from(metadata),
         }
     }
 }
@@ -388,33 +360,33 @@ mod tests {
             userdic_schema,
         );
         let py_meta: PyMetadata = meta.into();
-        assert_eq!(py_meta.name, "my_dict");
-        assert_eq!(py_meta.encoding, "UTF-8");
-        assert_eq!(py_meta.default_word_cost, -10000);
-        assert_eq!(py_meta.default_left_context_id, 1288);
-        assert_eq!(py_meta.default_right_context_id, 1288);
-        assert_eq!(py_meta.default_field_value, "*");
-        assert!(!py_meta.flexible_csv);
-        assert!(!py_meta.skip_invalid_cost_or_id);
-        assert!(!py_meta.normalize_details);
-        assert_eq!(py_meta.dictionary_schema.fields.len(), 4);
-        assert_eq!(py_meta.user_dictionary_schema.fields.len(), 2);
+        assert_eq!(py_meta.name(), "my_dict");
+        assert_eq!(py_meta.encoding(), "UTF-8");
+        assert_eq!(py_meta.default_word_cost(), -10000);
+        assert_eq!(py_meta.default_left_context_id(), 1288);
+        assert_eq!(py_meta.default_right_context_id(), 1288);
+        assert_eq!(py_meta.default_field_value(), "*");
+        assert!(!py_meta.flexible_csv());
+        assert!(!py_meta.skip_invalid_cost_or_id());
+        assert!(!py_meta.normalize_details());
+        assert_eq!(py_meta.dictionary_schema().fields().len(), 4);
+        assert_eq!(py_meta.user_dictionary_schema().fields().len(), 2);
     }
 
     #[test]
     fn test_pymetadata_default_values() {
         let py_meta = PyMetadata::create_default();
-        assert_eq!(py_meta.name, "default");
-        assert_eq!(py_meta.encoding, "UTF-8");
-        assert_eq!(py_meta.default_word_cost, -10000);
-        assert_eq!(py_meta.default_left_context_id, 1288);
-        assert_eq!(py_meta.default_right_context_id, 1288);
-        assert_eq!(py_meta.default_field_value, "*");
-        assert!(!py_meta.flexible_csv);
-        assert!(!py_meta.skip_invalid_cost_or_id);
-        assert!(!py_meta.normalize_details);
-        assert_eq!(py_meta.dictionary_schema.field_count(), 13);
-        assert_eq!(py_meta.user_dictionary_schema.fields.len(), 3);
+        assert_eq!(py_meta.name(), "default");
+        assert_eq!(py_meta.encoding(), "UTF-8");
+        assert_eq!(py_meta.default_word_cost(), -10000);
+        assert_eq!(py_meta.default_left_context_id(), 1288);
+        assert_eq!(py_meta.default_right_context_id(), 1288);
+        assert_eq!(py_meta.default_field_value(), "*");
+        assert!(!py_meta.flexible_csv());
+        assert!(!py_meta.skip_invalid_cost_or_id());
+        assert!(!py_meta.normalize_details());
+        assert_eq!(py_meta.dictionary_schema().field_count(), 13);
+        assert_eq!(py_meta.user_dictionary_schema().fields().len(), 3);
     }
 
     #[test]
@@ -434,14 +406,14 @@ mod tests {
         );
         let meta: Metadata = py_meta.into();
         let roundtripped: PyMetadata = meta.into();
-        assert_eq!(roundtripped.name, "roundtrip");
-        assert_eq!(roundtripped.encoding, "UTF-8");
-        assert_eq!(roundtripped.default_word_cost, -8000);
-        assert_eq!(roundtripped.default_left_context_id, 500);
-        assert_eq!(roundtripped.default_right_context_id, 600);
-        assert_eq!(roundtripped.default_field_value, "?");
-        assert!(roundtripped.flexible_csv);
-        assert!(!roundtripped.skip_invalid_cost_or_id);
-        assert!(roundtripped.normalize_details);
+        assert_eq!(roundtripped.name(), "roundtrip");
+        assert_eq!(roundtripped.encoding(), "UTF-8");
+        assert_eq!(roundtripped.default_word_cost(), -8000);
+        assert_eq!(roundtripped.default_left_context_id(), 500);
+        assert_eq!(roundtripped.default_right_context_id(), 600);
+        assert_eq!(roundtripped.default_field_value(), "?");
+        assert!(roundtripped.flexible_csv());
+        assert!(!roundtripped.skip_invalid_cost_or_id());
+        assert!(roundtripped.normalize_details());
     }
 }

--- a/lindera-python/src/schema.rs
+++ b/lindera-python/src/schema.rs
@@ -1,7 +1,8 @@
 //! Dictionary schema definitions.
 //!
 //! This module provides schema structures that define the format and fields
-//! of dictionary entries.
+//! of dictionary entries. The field-management logic is delegated to
+//! [`lindera_binding_core::CoreSchema`]; this module only adds the PyO3 wrappers.
 //!
 //! # Examples
 //!
@@ -23,11 +24,12 @@
 //! field = schema.get_field_by_name("part_of_speech")
 //! ```
 
-use std::collections::HashMap;
-
 use pyo3::prelude::*;
 
 use lindera::dictionary::{FieldDefinition, FieldType, Schema};
+use lindera_binding_core::{CoreFieldDefinition, CoreFieldType, CoreSchema};
+
+use crate::error::to_py_error;
 
 /// Field type in dictionary schema.
 ///
@@ -64,27 +66,39 @@ impl PyFieldType {
     }
 }
 
+impl From<CoreFieldType> for PyFieldType {
+    fn from(field_type: CoreFieldType) -> Self {
+        match field_type {
+            CoreFieldType::Surface => PyFieldType::Surface,
+            CoreFieldType::LeftContextId => PyFieldType::LeftContextId,
+            CoreFieldType::RightContextId => PyFieldType::RightContextId,
+            CoreFieldType::Cost => PyFieldType::Cost,
+            CoreFieldType::Custom => PyFieldType::Custom,
+        }
+    }
+}
+
+impl From<PyFieldType> for CoreFieldType {
+    fn from(field_type: PyFieldType) -> Self {
+        match field_type {
+            PyFieldType::Surface => CoreFieldType::Surface,
+            PyFieldType::LeftContextId => CoreFieldType::LeftContextId,
+            PyFieldType::RightContextId => CoreFieldType::RightContextId,
+            PyFieldType::Cost => CoreFieldType::Cost,
+            PyFieldType::Custom => CoreFieldType::Custom,
+        }
+    }
+}
+
 impl From<FieldType> for PyFieldType {
     fn from(field_type: FieldType) -> Self {
-        match field_type {
-            FieldType::Surface => PyFieldType::Surface,
-            FieldType::LeftContextId => PyFieldType::LeftContextId,
-            FieldType::RightContextId => PyFieldType::RightContextId,
-            FieldType::Cost => PyFieldType::Cost,
-            FieldType::Custom => PyFieldType::Custom,
-        }
+        PyFieldType::from(CoreFieldType::from(field_type))
     }
 }
 
 impl From<PyFieldType> for FieldType {
     fn from(field_type: PyFieldType) -> Self {
-        match field_type {
-            PyFieldType::Surface => FieldType::Surface,
-            PyFieldType::LeftContextId => FieldType::LeftContextId,
-            PyFieldType::RightContextId => FieldType::RightContextId,
-            PyFieldType::Cost => FieldType::Cost,
-            PyFieldType::Custom => FieldType::Custom,
-        }
+        FieldType::from(CoreFieldType::from(field_type))
     }
 }
 
@@ -133,8 +147,8 @@ impl PyFieldDefinition {
     }
 }
 
-impl From<FieldDefinition> for PyFieldDefinition {
-    fn from(field_def: FieldDefinition) -> Self {
+impl From<CoreFieldDefinition> for PyFieldDefinition {
+    fn from(field_def: CoreFieldDefinition) -> Self {
         PyFieldDefinition {
             index: field_def.index,
             name: field_def.name,
@@ -144,9 +158,9 @@ impl From<FieldDefinition> for PyFieldDefinition {
     }
 }
 
-impl From<PyFieldDefinition> for FieldDefinition {
+impl From<PyFieldDefinition> for CoreFieldDefinition {
     fn from(field_def: PyFieldDefinition) -> Self {
-        FieldDefinition {
+        CoreFieldDefinition {
             index: field_def.index,
             name: field_def.name,
             field_type: field_def.field_type.into(),
@@ -155,9 +169,22 @@ impl From<PyFieldDefinition> for FieldDefinition {
     }
 }
 
+impl From<FieldDefinition> for PyFieldDefinition {
+    fn from(field_def: FieldDefinition) -> Self {
+        PyFieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
+impl From<PyFieldDefinition> for FieldDefinition {
+    fn from(field_def: PyFieldDefinition) -> Self {
+        FieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
 /// Dictionary schema definition.
 ///
-/// Defines the structure and fields of dictionary entries.
+/// A thin PyO3 wrapper over [`lindera_binding_core::CoreSchema`], which owns the
+/// field storage, the name-to-index map, and the field lookups.
 ///
 /// # Examples
 ///
@@ -172,115 +199,97 @@ impl From<PyFieldDefinition> for FieldDefinition {
 #[pyclass(name = "Schema", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct PySchema {
-    #[pyo3(get)]
-    pub fields: Vec<String>,
-    field_index_map: Option<HashMap<String, usize>>,
+    /// The backing binding-core schema.
+    pub inner: CoreSchema,
 }
 
 #[pymethods]
 impl PySchema {
     #[new]
     pub fn new(fields: Vec<String>) -> Self {
-        let mut schema = Self {
-            fields,
-            field_index_map: None,
-        };
-        schema.build_index_map();
-        schema
+        Self {
+            inner: CoreSchema::new(fields),
+        }
     }
 
     #[staticmethod]
     pub fn create_default() -> Self {
-        Self::new(lindera_binding_core::schema::default_dictionary_fields())
+        Self {
+            inner: CoreSchema::create_default(),
+        }
+    }
+
+    #[getter]
+    pub fn fields(&self) -> Vec<String> {
+        self.inner.fields().to_vec()
     }
 
     pub fn get_field_index(&self, field_name: &str) -> Option<usize> {
-        self.field_index_map
-            .as_ref()
-            .and_then(|map| map.get(field_name))
-            .copied()
+        self.inner.get_field_index(field_name)
     }
 
     pub fn field_count(&self) -> usize {
-        self.get_all_fields().len()
+        self.inner.field_count()
     }
 
     pub fn get_field_name(&self, index: usize) -> Option<&str> {
-        self.fields.get(index).map(|s| s.as_str())
+        self.inner.get_field_name(index)
     }
 
     pub fn get_custom_fields(&self) -> Vec<String> {
-        if self.fields.len() > 4 {
-            self.fields[4..].to_vec()
-        } else {
-            Vec::new()
-        }
+        self.inner.get_custom_fields().to_vec()
     }
 
     pub fn get_all_fields(&self) -> Vec<String> {
-        self.fields.clone()
+        self.inner.fields().to_vec()
     }
 
     pub fn get_field_by_name(&self, name: &str) -> Option<PyFieldDefinition> {
-        self.get_field_index(name).map(|index| {
-            let field_type = if index < 4 {
-                match index {
-                    0 => PyFieldType::Surface,
-                    1 => PyFieldType::LeftContextId,
-                    2 => PyFieldType::RightContextId,
-                    3 => PyFieldType::Cost,
-                    _ => unreachable!(),
-                }
-            } else {
-                PyFieldType::Custom
-            };
-
-            PyFieldDefinition {
-                index,
-                name: name.to_string(),
-                field_type,
-                description: None,
-            }
-        })
+        self.inner
+            .get_field_by_name(name)
+            .map(PyFieldDefinition::from)
     }
 
     pub fn validate_record(&self, record: Vec<String>) -> PyResult<()> {
-        lindera_binding_core::schema::validate_record(&self.fields, &record)
-            .map_err(PyErr::new::<pyo3::exceptions::PyValueError, _>)
+        self.inner.validate_record(&record).map_err(to_py_error)
     }
 
     fn __str__(&self) -> String {
-        format!("Schema(fields={})", self.fields.len())
+        format!("Schema(fields={})", self.inner.field_count())
     }
 
     fn __repr__(&self) -> String {
-        format!("Schema(fields={:?})", self.fields)
+        format!("Schema(fields={:?})", self.inner.fields())
     }
 
     fn __len__(&self) -> usize {
-        self.fields.len()
+        self.inner.field_count()
     }
 }
 
-impl PySchema {
-    fn build_index_map(&mut self) {
-        let mut map = HashMap::new();
-        for (i, field) in self.fields.iter().enumerate() {
-            map.insert(field.clone(), i);
-        }
-        self.field_index_map = Some(map);
+impl From<CoreSchema> for PySchema {
+    fn from(schema: CoreSchema) -> Self {
+        PySchema { inner: schema }
+    }
+}
+
+impl From<PySchema> for CoreSchema {
+    fn from(schema: PySchema) -> Self {
+        schema.inner
     }
 }
 
 impl From<PySchema> for Schema {
     fn from(schema: PySchema) -> Self {
-        Schema::new(schema.fields)
+        schema.inner.into()
     }
 }
 
 impl From<Schema> for PySchema {
     fn from(schema: Schema) -> Self {
-        PySchema::new(schema.get_all_fields().to_vec())
+        PySchema {
+            inner: CoreSchema::from(schema),
+        }
     }
 }
 
@@ -300,38 +309,17 @@ mod tests {
     use lindera::dictionary::{FieldDefinition, FieldType, Schema};
 
     #[test]
-    fn test_pyfieldtype_surface_to_fieldtype() {
-        let py_ft = PyFieldType::Surface;
-        let ft: FieldType = py_ft.into();
-        assert!(matches!(ft, FieldType::Surface));
-    }
-
-    #[test]
-    fn test_pyfieldtype_left_context_id_to_fieldtype() {
-        let py_ft = PyFieldType::LeftContextId;
-        let ft: FieldType = py_ft.into();
-        assert!(matches!(ft, FieldType::LeftContextId));
-    }
-
-    #[test]
-    fn test_pyfieldtype_right_context_id_to_fieldtype() {
-        let py_ft = PyFieldType::RightContextId;
-        let ft: FieldType = py_ft.into();
-        assert!(matches!(ft, FieldType::RightContextId));
-    }
-
-    #[test]
-    fn test_pyfieldtype_cost_to_fieldtype() {
-        let py_ft = PyFieldType::Cost;
-        let ft: FieldType = py_ft.into();
-        assert!(matches!(ft, FieldType::Cost));
-    }
-
-    #[test]
-    fn test_pyfieldtype_custom_to_fieldtype() {
-        let py_ft = PyFieldType::Custom;
-        let ft: FieldType = py_ft.into();
-        assert!(matches!(ft, FieldType::Custom));
+    fn test_pyfieldtype_to_fieldtype_all_variants() {
+        for (py, ft) in [
+            (PyFieldType::Surface, FieldType::Surface),
+            (PyFieldType::LeftContextId, FieldType::LeftContextId),
+            (PyFieldType::RightContextId, FieldType::RightContextId),
+            (PyFieldType::Cost, FieldType::Cost),
+            (PyFieldType::Custom, FieldType::Custom),
+        ] {
+            let converted: FieldType = py.into();
+            assert_eq!(converted, ft);
+        }
     }
 
     #[test]
@@ -339,18 +327,6 @@ mod tests {
         assert!(matches!(
             PyFieldType::from(FieldType::Surface),
             PyFieldType::Surface
-        ));
-        assert!(matches!(
-            PyFieldType::from(FieldType::LeftContextId),
-            PyFieldType::LeftContextId
-        ));
-        assert!(matches!(
-            PyFieldType::from(FieldType::RightContextId),
-            PyFieldType::RightContextId
-        ));
-        assert!(matches!(
-            PyFieldType::from(FieldType::Cost),
-            PyFieldType::Cost
         ));
         assert!(matches!(
             PyFieldType::from(FieldType::Custom),
@@ -413,43 +389,27 @@ mod tests {
             "cost".to_string(),
         ]);
         let py_schema: PySchema = schema.into();
-        assert_eq!(py_schema.fields.len(), 4);
-        assert_eq!(py_schema.fields[0], "surface");
+        assert_eq!(py_schema.fields().len(), 4);
+        assert_eq!(py_schema.fields()[0], "surface");
     }
 
     #[test]
-    fn test_pyschema_new_builds_index_map() {
+    fn test_pyschema_index_and_name_lookups() {
         let schema = PySchema::new(vec![
             "surface".to_string(),
             "pos".to_string(),
             "reading".to_string(),
         ]);
         assert_eq!(schema.get_field_index("surface"), Some(0));
-        assert_eq!(schema.get_field_index("pos"), Some(1));
         assert_eq!(schema.get_field_index("reading"), Some(2));
-    }
-
-    #[test]
-    fn test_pyschema_get_field_index_existing() {
-        let schema = PySchema::new(vec!["surface".to_string(), "cost".to_string()]);
-        assert_eq!(schema.get_field_index("surface"), Some(0));
-        assert_eq!(schema.get_field_index("cost"), Some(1));
-    }
-
-    #[test]
-    fn test_pyschema_get_field_index_nonexistent() {
-        let schema = PySchema::new(vec!["surface".to_string()]);
         assert_eq!(schema.get_field_index("nonexistent"), None);
-    }
-
-    #[test]
-    fn test_pyschema_field_count() {
-        let schema = PySchema::new(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        assert_eq!(schema.get_field_name(1), Some("pos"));
+        assert_eq!(schema.get_field_name(9), None);
         assert_eq!(schema.field_count(), 3);
     }
 
     #[test]
-    fn test_pyschema_get_custom_fields() {
+    fn test_pyschema_custom_fields() {
         let schema = PySchema::new(vec![
             "surface".to_string(),
             "left_context_id".to_string(),
@@ -459,77 +419,42 @@ mod tests {
             "reading".to_string(),
         ]);
         let custom = schema.get_custom_fields();
-        assert_eq!(custom.len(), 2);
-        assert_eq!(custom[0], "major_pos");
-        assert_eq!(custom[1], "reading");
+        assert_eq!(custom, ["major_pos", "reading"]);
     }
 
     #[test]
-    fn test_pyschema_get_custom_fields_no_custom() {
-        let schema = PySchema::new(vec![
-            "surface".to_string(),
-            "left_context_id".to_string(),
-            "right_context_id".to_string(),
-            "cost".to_string(),
-        ]);
-        let custom = schema.get_custom_fields();
-        assert!(custom.is_empty());
-    }
-
-    #[test]
-    fn test_pyschema_get_custom_fields_fewer_than_four() {
-        let schema = PySchema::new(vec!["surface".to_string(), "cost".to_string()]);
-        let custom = schema.get_custom_fields();
-        assert!(custom.is_empty());
-    }
-
-    #[test]
-    fn test_pyschema_create_default_has_13_fields() {
+    fn test_pyschema_create_default() {
         let schema = PySchema::create_default();
         assert_eq!(schema.field_count(), 13);
-        assert_eq!(schema.fields[0], "surface");
-        assert_eq!(schema.fields[12], "pronunciation");
-    }
-
-    #[test]
-    fn test_pyschema_create_default_index_map() {
-        let schema = PySchema::create_default();
-        assert_eq!(schema.get_field_index("surface"), Some(0));
+        assert_eq!(schema.fields()[0], "surface");
+        assert_eq!(schema.fields()[5], "middle_pos");
+        assert_eq!(schema.fields()[12], "pronunciation");
         assert_eq!(schema.get_field_index("cost"), Some(3));
-        assert_eq!(schema.get_field_index("pronunciation"), Some(12));
-        assert_eq!(schema.get_field_index("nonexistent"), None);
     }
 
     #[test]
-    fn test_pyschema_get_field_name() {
-        let schema = PySchema::new(vec!["surface".to_string(), "pos".to_string()]);
-        assert_eq!(schema.get_field_name(0), Some("surface"));
-        assert_eq!(schema.get_field_name(1), Some("pos"));
-        assert_eq!(schema.get_field_name(2), None);
-    }
-
-    #[test]
-    fn test_pyschema_get_field_by_name_system_field() {
+    fn test_pyschema_get_field_by_name() {
         let schema = PySchema::create_default();
-        let field = schema.get_field_by_name("surface").unwrap();
-        assert_eq!(field.index, 0);
-        assert_eq!(field.name, "surface");
-        assert!(matches!(field.field_type, PyFieldType::Surface));
-    }
+        let surface = schema.get_field_by_name("surface").unwrap();
+        assert_eq!(surface.index, 0);
+        assert!(matches!(surface.field_type, PyFieldType::Surface));
 
-    #[test]
-    fn test_pyschema_get_field_by_name_custom_field() {
-        let schema = PySchema::create_default();
-        let field = schema.get_field_by_name("major_pos").unwrap();
-        assert_eq!(field.index, 4);
-        assert_eq!(field.name, "major_pos");
-        assert!(matches!(field.field_type, PyFieldType::Custom));
-    }
+        let custom = schema.get_field_by_name("major_pos").unwrap();
+        assert_eq!(custom.index, 4);
+        assert!(matches!(custom.field_type, PyFieldType::Custom));
 
-    #[test]
-    fn test_pyschema_get_field_by_name_nonexistent() {
-        let schema = PySchema::create_default();
         assert!(schema.get_field_by_name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_pyschema_validate_record() {
+        let schema = PySchema::new(vec!["surface".to_string(), "reading".to_string()]);
+        assert!(
+            schema
+                .validate_record(vec!["x".to_string(), "y".to_string()])
+                .is_ok()
+        );
+        assert!(schema.validate_record(vec!["x".to_string()]).is_err());
     }
 
     #[test]
@@ -544,6 +469,6 @@ mod tests {
         let py_schema = PySchema::new(fields.clone());
         let schema: Schema = py_schema.into();
         let roundtripped: PySchema = schema.into();
-        assert_eq!(roundtripped.fields, fields);
+        assert_eq!(roundtripped.fields(), fields);
     }
 }

--- a/lindera-python/src/schema.rs
+++ b/lindera-python/src/schema.rs
@@ -446,16 +446,13 @@ mod tests {
         assert!(schema.get_field_by_name("nonexistent").is_none());
     }
 
-    #[test]
-    fn test_pyschema_validate_record() {
-        let schema = PySchema::new(vec!["surface".to_string(), "reading".to_string()]);
-        assert!(
-            schema
-                .validate_record(vec!["x".to_string(), "y".to_string()])
-                .is_ok()
-        );
-        assert!(schema.validate_record(vec!["x".to_string()]).is_err());
-    }
+    // Note: `validate_record` is intentionally not unit-tested here. It maps
+    // `CoreError` to a Python exception via `to_py_error`, which references the
+    // Python C-API exception types; exercising it would pull those symbols into
+    // the standalone `cargo test --lib` binary, which (with pyo3
+    // `extension-module`) does not link libpython. The logic is covered by
+    // `lindera-binding-core`'s `core_schema_validate_record` test and by the
+    // Python pytest suite.
 
     #[test]
     fn test_pyschema_roundtrip() {

--- a/lindera-python/src/token.rs
+++ b/lindera-python/src/token.rs
@@ -67,9 +67,8 @@ impl PyToken {
 }
 
 impl PyToken {
-    pub fn from_token(token: Token) -> Self {
-        let view = lindera_binding_core::TokenView::from_token(token);
-
+    /// Builds a `PyToken` from a binding-core [`TokenView`].
+    pub fn from_view(view: lindera_binding_core::TokenView) -> Self {
         Self {
             surface: view.surface,
             byte_start: view.byte_start,
@@ -79,6 +78,11 @@ impl PyToken {
             is_unknown: view.is_unknown,
             details: Some(view.details),
         }
+    }
+
+    /// Builds a `PyToken` from a `lindera` token via [`TokenView`].
+    pub fn from_token(token: Token) -> Self {
+        Self::from_view(lindera_binding_core::TokenView::from_token(token))
     }
 }
 

--- a/lindera-python/src/tokenizer.rs
+++ b/lindera-python/src/tokenizer.rs
@@ -1,6 +1,9 @@
 //! Tokenizer implementation for morphological analysis.
 //!
 //! This module provides a builder pattern for creating tokenizers and the tokenizer itself.
+//! The build-flow orchestration is delegated to
+//! [`lindera_binding_core::CoreTokenizerBuilder`] / [`lindera_binding_core::CoreTokenizer`];
+//! this module only adds the PyO3 wrappers and the PyDict-to-JSON conversion.
 //!
 //! # Examples
 //!
@@ -16,21 +19,24 @@
 //! ```
 
 use std::path::Path;
-use std::str::FromStr;
 
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use lindera::mode::Mode;
-use lindera::segmenter::Segmenter;
-use lindera::tokenizer::{Tokenizer, TokenizerBuilder};
+use lindera_binding_core::{CoreTokenizer, CoreTokenizerBuilder};
 
 use crate::dictionary::{PyDictionary, PyUserDictionary};
+use crate::error::to_py_error;
 use crate::token::PyToken;
 use crate::util::pydict_to_value;
 
-pub type PyDictRef<'a> = &'a Bound<'a, PyDict>;
+/// Converts the optional filter-argument dict into a JSON value.
+fn filter_args(args: Option<&Bound<'_, PyDict>>) -> PyResult<serde_json::Value> {
+    match args {
+        Some(dict) => pydict_to_value(dict),
+        None => Ok(serde_json::Value::Object(serde_json::Map::new())),
+    }
+}
 
 /// Builder for creating a `Tokenizer` with custom configuration.
 ///
@@ -47,7 +53,7 @@ pub type PyDictRef<'a> = &'a Bound<'a, PyDict>;
 /// ```
 #[pyclass(name = "TokenizerBuilder")]
 pub struct PyTokenizerBuilder {
-    pub inner: TokenizerBuilder,
+    pub inner: CoreTokenizerBuilder,
 }
 
 #[pymethods]
@@ -64,10 +70,7 @@ impl PyTokenizerBuilder {
     #[new]
     #[pyo3(signature = ())]
     fn new() -> PyResult<Self> {
-        let inner = TokenizerBuilder::new().map_err(|err| {
-            PyValueError::new_err(format!("Failed to create TokenizerBuilder: {err}"))
-        })?;
-
+        let inner = CoreTokenizerBuilder::new().map_err(to_py_error)?;
         Ok(Self { inner })
     }
 
@@ -83,10 +86,7 @@ impl PyTokenizerBuilder {
     #[pyo3(signature = (file_path))]
     #[allow(clippy::wrong_self_convention)]
     fn from_file(&self, file_path: &str) -> PyResult<Self> {
-        let inner = TokenizerBuilder::from_file(Path::new(file_path)).map_err(|err| {
-            PyValueError::new_err(format!("Failed to load config from file: {err}"))
-        })?;
-
+        let inner = CoreTokenizerBuilder::from_file(Path::new(file_path)).map_err(to_py_error)?;
         Ok(Self { inner })
     }
 
@@ -101,11 +101,7 @@ impl PyTokenizerBuilder {
     /// Self for method chaining.
     #[pyo3(signature = (mode))]
     fn set_mode<'a>(mut slf: PyRefMut<'a, Self>, mode: &str) -> PyResult<PyRefMut<'a, Self>> {
-        let m = Mode::from_str(mode)
-            .map_err(|err| PyValueError::new_err(format!("Failed to create mode: {err}")))?;
-
-        slf.inner.set_segmenter_mode(&m);
-
+        slf.inner.set_mode(mode).map_err(to_py_error)?;
         Ok(slf)
     }
 
@@ -120,8 +116,7 @@ impl PyTokenizerBuilder {
     /// Self for method chaining.
     #[pyo3(signature = (path))]
     fn set_dictionary<'a>(mut slf: PyRefMut<'a, Self>, path: &str) -> PyResult<PyRefMut<'a, Self>> {
-        slf.inner.set_segmenter_dictionary(path);
-
+        slf.inner.set_dictionary(path);
         Ok(slf)
     }
 
@@ -139,7 +134,7 @@ impl PyTokenizerBuilder {
         mut slf: PyRefMut<'a, Self>,
         uri: &str,
     ) -> PyResult<PyRefMut<'a, Self>> {
-        slf.inner.set_segmenter_user_dictionary(uri);
+        slf.inner.set_user_dictionary(uri);
         Ok(slf)
     }
 
@@ -157,7 +152,7 @@ impl PyTokenizerBuilder {
         mut slf: PyRefMut<'a, Self>,
         keep_whitespace: bool,
     ) -> PyResult<PyRefMut<'a, Self>> {
-        slf.inner.set_segmenter_keep_whitespace(keep_whitespace);
+        slf.inner.set_keep_whitespace(keep_whitespace);
         Ok(slf)
     }
 
@@ -177,14 +172,8 @@ impl PyTokenizerBuilder {
         kind: &str,
         args: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<PyRefMut<'a, Self>> {
-        let filter_args = if let Some(dict) = args {
-            pydict_to_value(dict)?
-        } else {
-            serde_json::Value::Object(serde_json::Map::new())
-        };
-
-        slf.inner.append_character_filter(kind, &filter_args);
-
+        let args = filter_args(args)?;
+        slf.inner.append_character_filter(kind, &args);
         Ok(slf)
     }
 
@@ -204,14 +193,8 @@ impl PyTokenizerBuilder {
         kind: &str,
         args: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<PyRefMut<'a, Self>> {
-        let filter_args = if let Some(dict) = args {
-            pydict_to_value(dict)?
-        } else {
-            serde_json::Value::Object(serde_json::Map::new())
-        };
-
-        slf.inner.append_token_filter(kind, &filter_args);
-
+        let args = filter_args(args)?;
+        slf.inner.append_token_filter(kind, &args);
         Ok(slf)
     }
 
@@ -226,12 +209,8 @@ impl PyTokenizerBuilder {
     /// Returns an error if the tokenizer cannot be built with the current configuration.
     #[pyo3(signature = ())]
     fn build(&self) -> PyResult<PyTokenizer> {
-        let tokenizer = self
-            .inner
-            .build()
-            .map_err(|err| PyValueError::new_err(format!("Failed to build tokenizer: {err}")))?;
-
-        Ok(PyTokenizer { inner: tokenizer })
+        let inner = self.inner.build().map_err(to_py_error)?;
+        Ok(PyTokenizer { inner })
     }
 }
 
@@ -251,7 +230,7 @@ impl PyTokenizerBuilder {
 /// ```
 #[pyclass(name = "Tokenizer")]
 pub struct PyTokenizer {
-    inner: Tokenizer,
+    inner: CoreTokenizer,
 }
 
 #[pymethods]
@@ -274,16 +253,11 @@ impl PyTokenizer {
         mode: &str,
         user_dictionary: Option<PyUserDictionary>,
     ) -> PyResult<Self> {
-        let m = Mode::from_str(mode)
-            .map_err(|err| PyValueError::new_err(format!("Failed to create mode: {err}")))?;
+        let inner =
+            CoreTokenizer::from_segmenter(mode, dictionary.inner, user_dictionary.map(|d| d.inner))
+                .map_err(to_py_error)?;
 
-        let dict = dictionary.inner;
-        let user_dict = user_dictionary.map(|d| d.inner);
-
-        let segmenter = Segmenter::new(m, dict, user_dict);
-        let tokenizer = Tokenizer::new(segmenter);
-
-        Ok(Self { inner: tokenizer })
+        Ok(Self { inner })
     }
 
     /// Tokenizes the given text.
@@ -301,16 +275,8 @@ impl PyTokenizer {
     /// Returns an error if tokenization fails.
     #[pyo3(signature = (text))]
     fn tokenize(&self, text: &str) -> PyResult<Vec<PyToken>> {
-        // Tokenize the processed text
-        let tokens = self
-            .inner
-            .tokenize(text)
-            .map_err(|err| PyValueError::new_err(format!("Failed to tokenize text: {err}")))?;
-
-        // Convert to PyToken objects
-        let py_tokens: Vec<PyToken> = tokens.into_iter().map(PyToken::from_token).collect();
-
-        Ok(py_tokens)
+        let views = self.inner.tokenize(text).map_err(to_py_error)?;
+        Ok(views.into_iter().map(PyToken::from_view).collect())
     }
 
     /// Tokenizes the given text and returns N-best results.
@@ -338,13 +304,11 @@ impl PyTokenizer {
         let results = self
             .inner
             .tokenize_nbest(text, n, unique, cost_threshold)
-            .map_err(|err| {
-                PyValueError::new_err(format!("Failed to tokenize_nbest text: {err}"))
-            })?;
+            .map_err(to_py_error)?;
 
         let py_results: Vec<(Vec<PyToken>, i64)> = results
             .into_iter()
-            .map(|(tokens, cost)| (tokens.into_iter().map(PyToken::from_token).collect(), cost))
+            .map(|(views, cost)| (views.into_iter().map(PyToken::from_view).collect(), cost))
             .collect();
 
         Ok(py_results)


### PR DESCRIPTION
# Migrate lindera-python to the full lindera-binding-core facade (#714)

Part of #708 (Phase 6 / v4.0.0). Refs #714. This is the design-defining binding migration; #715–#718
follow this pattern.

## Summary

Reduce the PyO3 wrappers to thin adapters over the binding-core facade
(`CoreSchema`/`CoreMetadata`/`CoreTokenizer`/`CoreError`), removing the field-management,
metadata-default, and tokenizer build-flow logic that `lindera-python` previously reimplemented.

**The Python API is preserved exactly** — `Token.details` stays `Option<Vec<String>>` and the default
schema keeps the `middle_pos` naming. The cross-binding unifications are tracked separately:
`Token.details` type (#719) and default schema names (#720).

## What changed

- `error.rs`: `to_py_error(CoreError) -> PyErr` (`Io` → `IOError`, else `ValueError`; a `From` impl is
  impossible due to the orphan rule, matching the other bindings' helper-function pattern).
- `token.rs`: `PyToken::from_view(TokenView)` (the tokenizer now yields `TokenView`s).
- `schema.rs`: `PySchema` wraps `CoreSchema`; `PyFieldType` / `PyFieldDefinition` convert through
  `CoreFieldType` / `CoreFieldDefinition` (lindera conversions kept).
- `metadata.rs`: `PyMetadata` wraps `CoreMetadata`; getters/setters delegate; `From`/`Into`
  `lindera::Metadata` preserved (so `dictionary.rs` is unaffected).
- `tokenizer.rs`: `PyTokenizerBuilder` / `PyTokenizer` wrap the core builder/tokenizer; the
  `PyDict` → `serde_json::Value` conversion stays in `util.rs`.
- `Cargo.lock`: synced with the `serde_json` dependency added to `lindera-binding-core` in #713.

## Verification

- `cargo clippy -p lindera-python --all-targets -- -D warnings`: clean
- `cargo fmt -p lindera-python -- --check`: clean
- **Python test suite: 8/8 passed** via `maturin develop --features embed-ipadic,train` + `pytest`
  (module structure, token objects, ipadic tokenization, trainer/export, metadata).

> Note: `cargo test -p lindera-python --lib` builds a standalone test binary that requires `libpython`
> at link time (pyo3 `extension-module`); that linkage is provided by the CI Python toolchain. Locally
> the migration was validated via clippy (typecheck) + the full pytest suite.
