### PR TITLE
feat(nodejs): migrate lindera-nodejs to the lindera-binding-core facade

### DIFF
--- a/lindera-nodejs/src/metadata.rs
+++ b/lindera-nodejs/src/metadata.rs
@@ -1,13 +1,14 @@
 //! Dictionary metadata configuration.
 //!
 //! This module provides structures for configuring dictionary metadata, including
-//! character encodings and schema definitions.
+//! character encodings and schema definitions. The defaults and schema wiring are
+//! delegated to [`lindera_binding_core::CoreMetadata`]; this module only adds the
+//! napi wrappers.
 
 use std::collections::HashMap;
 
 use lindera::dictionary::Metadata;
-
-use crate::schema::JsSchema;
+use lindera_binding_core::CoreMetadata;
 
 /// Options for creating a Metadata instance.
 ///
@@ -36,20 +37,12 @@ pub struct MetadataOptions {
 
 /// Dictionary metadata configuration.
 ///
-/// Contains all configuration parameters for building and using dictionaries.
+/// A thin napi wrapper over [`lindera_binding_core::CoreMetadata`], which owns
+/// the default values and the schema wiring.
 #[napi(js_name = "Metadata")]
 pub struct JsMetadata {
-    name: String,
-    encoding: String,
-    default_word_cost: i16,
-    default_left_context_id: u16,
-    default_right_context_id: u16,
-    default_field_value: String,
-    flexible_csv: bool,
-    skip_invalid_cost_or_id: bool,
-    normalize_details: bool,
-    dictionary_schema: JsSchema,
-    user_dictionary_schema: JsSchema,
+    /// The backing binding-core metadata.
+    inner: CoreMetadata,
 }
 
 #[napi]
@@ -74,21 +67,19 @@ impl JsMetadata {
         });
 
         JsMetadata {
-            name: opts.name.unwrap_or_else(|| "default".to_string()),
-            encoding: opts.encoding.unwrap_or_else(|| "UTF-8".to_string()),
-            default_word_cost: opts.default_word_cost.unwrap_or(-10000) as i16,
-            default_left_context_id: opts.default_left_context_id.unwrap_or(1288) as u16,
-            default_right_context_id: opts.default_right_context_id.unwrap_or(1288) as u16,
-            default_field_value: opts.default_field_value.unwrap_or_else(|| "*".to_string()),
-            flexible_csv: opts.flexible_csv.unwrap_or(false),
-            skip_invalid_cost_or_id: opts.skip_invalid_cost_or_id.unwrap_or(false),
-            normalize_details: opts.normalize_details.unwrap_or(false),
-            dictionary_schema: JsSchema::create_default(),
-            user_dictionary_schema: JsSchema::new(vec![
-                "surface".to_string(),
-                "reading".to_string(),
-                "pronunciation".to_string(),
-            ]),
+            inner: CoreMetadata::new(
+                opts.name,
+                opts.encoding,
+                opts.default_word_cost.map(|c| c as i16),
+                opts.default_left_context_id.map(|id| id as u16),
+                opts.default_right_context_id.map(|id| id as u16),
+                opts.default_field_value,
+                opts.flexible_csv,
+                opts.skip_invalid_cost_or_id,
+                opts.normalize_details,
+                None,
+                None,
+            ),
         }
     }
 
@@ -133,109 +124,109 @@ impl JsMetadata {
     /// Dictionary name.
     #[napi(getter)]
     pub fn name(&self) -> String {
-        self.name.clone()
+        self.inner.name.clone()
     }
 
     /// Sets the dictionary name.
     #[napi(setter)]
     pub fn set_name(&mut self, name: String) {
-        self.name = name;
+        self.inner.name = name;
     }
 
     /// Character encoding.
     #[napi(getter)]
     pub fn encoding(&self) -> String {
-        self.encoding.clone()
+        self.inner.encoding.clone()
     }
 
     /// Sets the character encoding.
     #[napi(setter)]
     pub fn set_encoding(&mut self, encoding: String) {
-        self.encoding = encoding;
+        self.inner.encoding = encoding;
     }
 
     /// Default word cost.
     #[napi(getter)]
     pub fn default_word_cost(&self) -> i32 {
-        self.default_word_cost as i32
+        self.inner.default_word_cost as i32
     }
 
     /// Sets the default word cost.
     #[napi(setter)]
     pub fn set_default_word_cost(&mut self, cost: i32) {
-        self.default_word_cost = cost as i16;
+        self.inner.default_word_cost = cost as i16;
     }
 
     /// Default left context ID.
     #[napi(getter)]
     pub fn default_left_context_id(&self) -> u32 {
-        self.default_left_context_id as u32
+        self.inner.default_left_context_id as u32
     }
 
     /// Sets the default left context ID.
     #[napi(setter)]
     pub fn set_default_left_context_id(&mut self, id: u32) {
-        self.default_left_context_id = id as u16;
+        self.inner.default_left_context_id = id as u16;
     }
 
     /// Default right context ID.
     #[napi(getter)]
     pub fn default_right_context_id(&self) -> u32 {
-        self.default_right_context_id as u32
+        self.inner.default_right_context_id as u32
     }
 
     /// Sets the default right context ID.
     #[napi(setter)]
     pub fn set_default_right_context_id(&mut self, id: u32) {
-        self.default_right_context_id = id as u16;
+        self.inner.default_right_context_id = id as u16;
     }
 
     /// Default field value for missing fields.
     #[napi(getter)]
     pub fn default_field_value(&self) -> String {
-        self.default_field_value.clone()
+        self.inner.default_field_value.clone()
     }
 
     /// Sets the default field value.
     #[napi(setter)]
     pub fn set_default_field_value(&mut self, value: String) {
-        self.default_field_value = value;
+        self.inner.default_field_value = value;
     }
 
     /// Whether flexible CSV parsing is enabled.
     #[napi(getter)]
     pub fn flexible_csv(&self) -> bool {
-        self.flexible_csv
+        self.inner.flexible_csv
     }
 
     /// Sets flexible CSV parsing.
     #[napi(setter)]
     pub fn set_flexible_csv(&mut self, value: bool) {
-        self.flexible_csv = value;
+        self.inner.flexible_csv = value;
     }
 
     /// Whether to skip entries with invalid cost or ID.
     #[napi(getter)]
     pub fn skip_invalid_cost_or_id(&self) -> bool {
-        self.skip_invalid_cost_or_id
+        self.inner.skip_invalid_cost_or_id
     }
 
     /// Sets whether to skip invalid entries.
     #[napi(setter)]
     pub fn set_skip_invalid_cost_or_id(&mut self, value: bool) {
-        self.skip_invalid_cost_or_id = value;
+        self.inner.skip_invalid_cost_or_id = value;
     }
 
     /// Whether to normalize morphological details.
     #[napi(getter)]
     pub fn normalize_details(&self) -> bool {
-        self.normalize_details
+        self.inner.normalize_details
     }
 
     /// Sets whether to normalize details.
     #[napi(setter)]
     pub fn set_normalize_details(&mut self, value: bool) {
-        self.normalize_details = value;
+        self.inner.normalize_details = value;
     }
 
     /// Returns a plain object representation of the metadata.
@@ -246,32 +237,35 @@ impl JsMetadata {
     #[napi]
     pub fn to_object(&self) -> HashMap<String, String> {
         let mut dict = HashMap::new();
-        dict.insert("name".to_string(), self.name.clone());
-        dict.insert("encoding".to_string(), self.encoding.clone());
+        dict.insert("name".to_string(), self.inner.name.clone());
+        dict.insert("encoding".to_string(), self.inner.encoding.clone());
         dict.insert(
             "defaultWordCost".to_string(),
-            self.default_word_cost.to_string(),
+            self.inner.default_word_cost.to_string(),
         );
         dict.insert(
             "defaultLeftContextId".to_string(),
-            self.default_left_context_id.to_string(),
+            self.inner.default_left_context_id.to_string(),
         );
         dict.insert(
             "defaultRightContextId".to_string(),
-            self.default_right_context_id.to_string(),
+            self.inner.default_right_context_id.to_string(),
         );
         dict.insert(
             "defaultFieldValue".to_string(),
-            self.default_field_value.clone(),
+            self.inner.default_field_value.clone(),
         );
-        dict.insert("flexibleCsv".to_string(), self.flexible_csv.to_string());
+        dict.insert(
+            "flexibleCsv".to_string(),
+            self.inner.flexible_csv.to_string(),
+        );
         dict.insert(
             "skipInvalidCostOrId".to_string(),
-            self.skip_invalid_cost_or_id.to_string(),
+            self.inner.skip_invalid_cost_or_id.to_string(),
         );
         dict.insert(
             "normalizeDetails".to_string(),
-            self.normalize_details.to_string(),
+            self.inner.normalize_details.to_string(),
         );
         dict
     }
@@ -288,54 +282,20 @@ impl JsMetadata {
     ///
     /// A lindera Metadata instance.
     pub fn to_lindera_metadata(metadata: &JsMetadata) -> Metadata {
-        Metadata::new(
-            metadata.name.clone(),
-            metadata.encoding.clone(),
-            metadata.default_word_cost,
-            metadata.default_left_context_id,
-            metadata.default_right_context_id,
-            metadata.default_field_value.clone(),
-            metadata.flexible_csv,
-            metadata.skip_invalid_cost_or_id,
-            metadata.normalize_details,
-            JsSchema::new(metadata.dictionary_schema.fields()).into(),
-            JsSchema::new(metadata.user_dictionary_schema.fields()).into(),
-        )
+        metadata.inner.clone().into()
     }
 }
 
 impl From<JsMetadata> for Metadata {
     fn from(metadata: JsMetadata) -> Self {
-        Metadata::new(
-            metadata.name,
-            metadata.encoding,
-            metadata.default_word_cost,
-            metadata.default_left_context_id,
-            metadata.default_right_context_id,
-            metadata.default_field_value,
-            metadata.flexible_csv,
-            metadata.skip_invalid_cost_or_id,
-            metadata.normalize_details,
-            metadata.dictionary_schema.into(),
-            metadata.user_dictionary_schema.into(),
-        )
+        metadata.inner.into()
     }
 }
 
 impl From<Metadata> for JsMetadata {
     fn from(metadata: Metadata) -> Self {
         JsMetadata {
-            name: metadata.name,
-            encoding: metadata.encoding,
-            default_word_cost: metadata.default_word_cost,
-            default_left_context_id: metadata.default_left_context_id,
-            default_right_context_id: metadata.default_right_context_id,
-            default_field_value: metadata.default_field_value,
-            flexible_csv: metadata.flexible_csv,
-            skip_invalid_cost_or_id: metadata.skip_invalid_cost_or_id,
-            normalize_details: metadata.normalize_details,
-            dictionary_schema: metadata.dictionary_schema.into(),
-            user_dictionary_schema: metadata.user_dictionary_schema.into(),
+            inner: CoreMetadata::from(metadata),
         }
     }
 }

--- a/lindera-nodejs/src/schema.rs
+++ b/lindera-nodejs/src/schema.rs
@@ -1,11 +1,13 @@
 //! Dictionary schema definitions.
 //!
 //! This module provides schema structures that define the format and fields
-//! of dictionary entries.
-
-use std::collections::HashMap;
+//! of dictionary entries. The field-management logic is delegated to
+//! [`lindera_binding_core::CoreSchema`]; this module only adds the napi wrappers.
 
 use lindera::dictionary::{FieldDefinition, FieldType, Schema};
+use lindera_binding_core::{CoreFieldDefinition, CoreFieldType, CoreSchema};
+
+use crate::error::to_napi_error;
 
 /// Field type in dictionary schema.
 ///
@@ -24,27 +26,39 @@ pub enum JsFieldType {
     Custom,
 }
 
+impl From<CoreFieldType> for JsFieldType {
+    fn from(field_type: CoreFieldType) -> Self {
+        match field_type {
+            CoreFieldType::Surface => JsFieldType::Surface,
+            CoreFieldType::LeftContextId => JsFieldType::LeftContextId,
+            CoreFieldType::RightContextId => JsFieldType::RightContextId,
+            CoreFieldType::Cost => JsFieldType::Cost,
+            CoreFieldType::Custom => JsFieldType::Custom,
+        }
+    }
+}
+
+impl From<JsFieldType> for CoreFieldType {
+    fn from(field_type: JsFieldType) -> Self {
+        match field_type {
+            JsFieldType::Surface => CoreFieldType::Surface,
+            JsFieldType::LeftContextId => CoreFieldType::LeftContextId,
+            JsFieldType::RightContextId => CoreFieldType::RightContextId,
+            JsFieldType::Cost => CoreFieldType::Cost,
+            JsFieldType::Custom => CoreFieldType::Custom,
+        }
+    }
+}
+
 impl From<FieldType> for JsFieldType {
     fn from(field_type: FieldType) -> Self {
-        match field_type {
-            FieldType::Surface => JsFieldType::Surface,
-            FieldType::LeftContextId => JsFieldType::LeftContextId,
-            FieldType::RightContextId => JsFieldType::RightContextId,
-            FieldType::Cost => JsFieldType::Cost,
-            FieldType::Custom => JsFieldType::Custom,
-        }
+        JsFieldType::from(CoreFieldType::from(field_type))
     }
 }
 
 impl From<JsFieldType> for FieldType {
     fn from(field_type: JsFieldType) -> Self {
-        match field_type {
-            JsFieldType::Surface => FieldType::Surface,
-            JsFieldType::LeftContextId => FieldType::LeftContextId,
-            JsFieldType::RightContextId => FieldType::RightContextId,
-            JsFieldType::Cost => FieldType::Cost,
-            JsFieldType::Custom => FieldType::Custom,
-        }
+        FieldType::from(CoreFieldType::from(field_type))
     }
 }
 
@@ -63,8 +77,8 @@ pub struct JsFieldDefinition {
     pub description: Option<String>,
 }
 
-impl From<FieldDefinition> for JsFieldDefinition {
-    fn from(field_def: FieldDefinition) -> Self {
+impl From<CoreFieldDefinition> for JsFieldDefinition {
+    fn from(field_def: CoreFieldDefinition) -> Self {
         JsFieldDefinition {
             index: field_def.index as u32,
             name: field_def.name,
@@ -74,9 +88,9 @@ impl From<FieldDefinition> for JsFieldDefinition {
     }
 }
 
-impl From<JsFieldDefinition> for FieldDefinition {
+impl From<JsFieldDefinition> for CoreFieldDefinition {
     fn from(field_def: JsFieldDefinition) -> Self {
-        FieldDefinition {
+        CoreFieldDefinition {
             index: field_def.index as usize,
             name: field_def.name,
             field_type: field_def.field_type.into(),
@@ -85,15 +99,26 @@ impl From<JsFieldDefinition> for FieldDefinition {
     }
 }
 
+impl From<FieldDefinition> for JsFieldDefinition {
+    fn from(field_def: FieldDefinition) -> Self {
+        JsFieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
+impl From<JsFieldDefinition> for FieldDefinition {
+    fn from(field_def: JsFieldDefinition) -> Self {
+        FieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
 /// Dictionary schema definition.
 ///
-/// Defines the structure and fields of dictionary entries.
+/// A thin napi wrapper over [`lindera_binding_core::CoreSchema`], which owns the
+/// field storage, the name-to-index map, and the field lookups.
 #[napi(js_name = "Schema")]
 pub struct JsSchema {
-    /// Field names in the schema.
-    fields: Vec<String>,
-    /// Index map for fast field lookup.
-    field_index_map: HashMap<String, usize>,
+    /// The backing binding-core schema.
+    inner: CoreSchema,
 }
 
 #[napi]
@@ -105,14 +130,8 @@ impl JsSchema {
     /// * `fields` - Array of field name strings.
     #[napi(constructor)]
     pub fn new(fields: Vec<String>) -> Self {
-        let field_index_map = fields
-            .iter()
-            .enumerate()
-            .map(|(i, f)| (f.clone(), i))
-            .collect();
         Self {
-            fields,
-            field_index_map,
+            inner: CoreSchema::new(fields),
         }
     }
 
@@ -123,13 +142,15 @@ impl JsSchema {
     /// A schema with the standard IPADIC field definitions.
     #[napi(factory)]
     pub fn create_default() -> Self {
-        Self::new(lindera_binding_core::schema::default_dictionary_fields())
+        Self {
+            inner: CoreSchema::create_default(),
+        }
     }
 
     /// Returns the field names in the schema.
     #[napi(getter)]
     pub fn fields(&self) -> Vec<String> {
-        self.fields.clone()
+        self.inner.fields().to_vec()
     }
 
     /// Returns the index of the specified field name.
@@ -143,13 +164,13 @@ impl JsSchema {
     /// The zero-based index of the field, or `undefined` if not found.
     #[napi]
     pub fn get_field_index(&self, field_name: String) -> Option<u32> {
-        self.field_index_map.get(&field_name).map(|&i| i as u32)
+        self.inner.get_field_index(&field_name).map(|i| i as u32)
     }
 
     /// Returns the total number of fields in the schema.
     #[napi]
     pub fn field_count(&self) -> u32 {
-        self.fields.len() as u32
+        self.inner.field_count() as u32
     }
 
     /// Returns the field name at the specified index.
@@ -163,7 +184,9 @@ impl JsSchema {
     /// The field name, or `undefined` if the index is out of range.
     #[napi]
     pub fn get_field_name(&self, index: u32) -> Option<String> {
-        self.fields.get(index as usize).cloned()
+        self.inner
+            .get_field_name(index as usize)
+            .map(str::to_string)
     }
 
     /// Returns the custom fields (index 4 and above).
@@ -173,11 +196,7 @@ impl JsSchema {
     /// An array of custom field names.
     #[napi]
     pub fn get_custom_fields(&self) -> Vec<String> {
-        if self.fields.len() > 4 {
-            self.fields[4..].to_vec()
-        } else {
-            Vec::new()
-        }
+        self.inner.get_custom_fields().to_vec()
     }
 
     /// Returns all field names in the schema.
@@ -187,7 +206,7 @@ impl JsSchema {
     /// An array of all field names.
     #[napi]
     pub fn get_all_fields(&self) -> Vec<String> {
-        self.fields.clone()
+        self.inner.fields().to_vec()
     }
 
     /// Returns the field definition for the specified field name.
@@ -201,22 +220,9 @@ impl JsSchema {
     /// The field definition, or `undefined` if not found.
     #[napi]
     pub fn get_field_by_name(&self, name: String) -> Option<JsFieldDefinition> {
-        self.field_index_map.get(&name).map(|&index| {
-            let field_type = match index {
-                0 => JsFieldType::Surface,
-                1 => JsFieldType::LeftContextId,
-                2 => JsFieldType::RightContextId,
-                3 => JsFieldType::Cost,
-                _ => JsFieldType::Custom,
-            };
-
-            JsFieldDefinition {
-                index: index as u32,
-                name,
-                field_type,
-                description: None,
-            }
-        })
+        self.inner
+            .get_field_by_name(&name)
+            .map(JsFieldDefinition::from)
     }
 
     /// Validates that a CSV record matches the schema.
@@ -226,20 +232,33 @@ impl JsSchema {
     /// * `record` - Array of field values to validate.
     #[napi]
     pub fn validate_record(&self, record: Vec<String>) -> napi::Result<()> {
-        lindera_binding_core::schema::validate_record(&self.fields, &record)
-            .map_err(|message| napi::Error::new(napi::Status::InvalidArg, message))
+        self.inner.validate_record(&record).map_err(to_napi_error)
+    }
+}
+
+impl From<CoreSchema> for JsSchema {
+    fn from(schema: CoreSchema) -> Self {
+        JsSchema { inner: schema }
+    }
+}
+
+impl From<JsSchema> for CoreSchema {
+    fn from(schema: JsSchema) -> Self {
+        schema.inner
     }
 }
 
 impl From<JsSchema> for Schema {
     fn from(schema: JsSchema) -> Self {
-        Schema::new(schema.fields)
+        schema.inner.into()
     }
 }
 
 impl From<Schema> for JsSchema {
     fn from(schema: Schema) -> Self {
-        JsSchema::new(schema.get_all_fields().to_vec())
+        JsSchema {
+            inner: CoreSchema::from(schema),
+        }
     }
 }
 
@@ -254,18 +273,6 @@ mod tests {
             FieldType::Surface
         ));
         assert!(matches!(
-            FieldType::from(JsFieldType::LeftContextId),
-            FieldType::LeftContextId
-        ));
-        assert!(matches!(
-            FieldType::from(JsFieldType::RightContextId),
-            FieldType::RightContextId
-        ));
-        assert!(matches!(
-            FieldType::from(JsFieldType::Cost),
-            FieldType::Cost
-        ));
-        assert!(matches!(
             FieldType::from(JsFieldType::Custom),
             FieldType::Custom
         ));
@@ -276,18 +283,6 @@ mod tests {
         assert!(matches!(
             JsFieldType::from(FieldType::Surface),
             JsFieldType::Surface
-        ));
-        assert!(matches!(
-            JsFieldType::from(FieldType::LeftContextId),
-            JsFieldType::LeftContextId
-        ));
-        assert!(matches!(
-            JsFieldType::from(FieldType::RightContextId),
-            JsFieldType::RightContextId
-        ));
-        assert!(matches!(
-            JsFieldType::from(FieldType::Cost),
-            JsFieldType::Cost
         ));
         assert!(matches!(
             JsFieldType::from(FieldType::Custom),
@@ -316,9 +311,10 @@ mod tests {
     }
 
     #[test]
-    fn test_js_schema_field_count_empty() {
-        let schema = JsSchema::new(vec![]);
-        assert_eq!(schema.field_count(), 0);
+    fn test_js_schema_get_field_name() {
+        let schema = JsSchema::new(vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(schema.get_field_name(0), Some("a".to_string()));
+        assert_eq!(schema.get_field_name(9), None);
     }
 
     #[test]
@@ -343,31 +339,33 @@ mod tests {
             "right_context_id".to_string(),
             "cost".to_string(),
         ]);
-        let custom = schema.get_custom_fields();
-        assert!(custom.is_empty());
+        assert!(schema.get_custom_fields().is_empty());
     }
 
     #[test]
-    fn test_js_schema_get_custom_fields_fewer_than_4() {
-        let schema = JsSchema::new(vec!["surface".to_string()]);
-        let custom = schema.get_custom_fields();
-        assert!(custom.is_empty());
-    }
-
-    #[test]
-    fn test_js_schema_create_default_has_13_fields() {
+    fn test_js_schema_create_default() {
         let schema = JsSchema::create_default();
         assert_eq!(schema.field_count(), 13);
-    }
-
-    #[test]
-    fn test_js_schema_create_default_field_names() {
-        let schema = JsSchema::create_default();
         assert_eq!(schema.get_field_index("surface".to_string()), Some(0));
+        assert_eq!(schema.fields()[5], "middle_pos");
         assert_eq!(
             schema.get_field_index("pronunciation".to_string()),
             Some(12)
         );
+    }
+
+    #[test]
+    fn test_js_schema_get_field_by_name() {
+        let schema = JsSchema::create_default();
+        let surface = schema.get_field_by_name("surface".to_string()).unwrap();
+        assert_eq!(surface.index, 0);
+        assert!(matches!(surface.field_type, JsFieldType::Surface));
+
+        let custom = schema.get_field_by_name("middle_pos".to_string()).unwrap();
+        assert_eq!(custom.index, 5);
+        assert!(matches!(custom.field_type, JsFieldType::Custom));
+
+        assert!(schema.get_field_by_name("nope".to_string()).is_none());
     }
 
     #[test]
@@ -392,6 +390,5 @@ mod tests {
         let js_schema: JsSchema = lindera_schema.into();
         assert_eq!(js_schema.field_count(), 2);
         assert_eq!(js_schema.get_field_index("a".to_string()), Some(0));
-        assert_eq!(js_schema.get_field_index("b".to_string()), Some(1));
     }
 }

--- a/lindera-nodejs/src/token.rs
+++ b/lindera-nodejs/src/token.rs
@@ -100,8 +100,19 @@ impl JsToken {
     ///
     /// A new JsToken instance.
     pub fn from_token(token: Token) -> Self {
-        let view = lindera_binding_core::TokenView::from_token(token);
+        Self::from_view(lindera_binding_core::TokenView::from_token(token))
+    }
 
+    /// Creates a JsToken from a binding-core `TokenView`.
+    ///
+    /// # Arguments
+    ///
+    /// * `view` - The token view produced by the binding-core tokenizer.
+    ///
+    /// # Returns
+    ///
+    /// A new JsToken instance.
+    pub fn from_view(view: lindera_binding_core::TokenView) -> Self {
         Self {
             surface: view.surface,
             byte_start: view.byte_start as u32,

--- a/lindera-nodejs/src/tokenizer.rs
+++ b/lindera-nodejs/src/tokenizer.rs
@@ -1,13 +1,13 @@
 //! Tokenizer implementation for morphological analysis.
 //!
 //! This module provides a builder pattern for creating tokenizers and the tokenizer itself.
+//! The build-flow orchestration is delegated to
+//! [`lindera_binding_core::CoreTokenizerBuilder`] / [`lindera_binding_core::CoreTokenizer`];
+//! this module only adds the napi wrappers and the JS-value conversion.
 
 use std::path::Path;
-use std::str::FromStr;
 
-use lindera::mode::Mode;
-use lindera::segmenter::Segmenter;
-use lindera::tokenizer::{Tokenizer, TokenizerBuilder};
+use lindera_binding_core::{CoreTokenizer, CoreTokenizerBuilder};
 
 use crate::dictionary::{JsDictionary, JsUserDictionary};
 use crate::error::to_napi_error;
@@ -20,7 +20,7 @@ use crate::util::js_value_to_serde_value;
 /// dictionaries, modes, and filter pipelines.
 #[napi(js_name = "TokenizerBuilder")]
 pub struct JsTokenizerBuilder {
-    inner: TokenizerBuilder,
+    inner: CoreTokenizerBuilder,
 }
 
 #[napi]
@@ -28,9 +28,7 @@ impl JsTokenizerBuilder {
     /// Creates a new TokenizerBuilder with default configuration.
     #[napi(constructor)]
     pub fn new() -> napi::Result<Self> {
-        let inner = TokenizerBuilder::new()
-            .map_err(|err| to_napi_error(format!("Failed to create TokenizerBuilder: {err}")))?;
-
+        let inner = CoreTokenizerBuilder::new().map_err(to_napi_error)?;
         Ok(Self { inner })
     }
 
@@ -45,9 +43,8 @@ impl JsTokenizerBuilder {
     /// A new TokenizerBuilder with the loaded configuration.
     #[napi]
     pub fn from_file(&self, file_path: String) -> napi::Result<JsTokenizerBuilder> {
-        let inner = TokenizerBuilder::from_file(Path::new(&file_path))
-            .map_err(|err| to_napi_error(format!("Failed to load config from file: {err}")))?;
-
+        let inner =
+            CoreTokenizerBuilder::from_file(Path::new(&file_path)).map_err(to_napi_error)?;
         Ok(JsTokenizerBuilder { inner })
     }
 
@@ -58,10 +55,7 @@ impl JsTokenizerBuilder {
     /// * `mode` - Mode string ("normal" or "decompose").
     #[napi]
     pub fn set_mode(&mut self, mode: String) -> napi::Result<()> {
-        let m = Mode::from_str(&mode)
-            .map_err(|err| to_napi_error(format!("Failed to create mode: {err}")))?;
-
-        self.inner.set_segmenter_mode(&m);
+        self.inner.set_mode(&mode).map_err(to_napi_error)?;
         Ok(())
     }
 
@@ -72,7 +66,7 @@ impl JsTokenizerBuilder {
     /// * `path` - Path to the dictionary directory or embedded URI (e.g. "embedded://ipadic").
     #[napi]
     pub fn set_dictionary(&mut self, path: String) {
-        self.inner.set_segmenter_dictionary(&path);
+        self.inner.set_dictionary(&path);
     }
 
     /// Sets the user dictionary URI.
@@ -82,7 +76,7 @@ impl JsTokenizerBuilder {
     /// * `uri` - URI to the user dictionary.
     #[napi]
     pub fn set_user_dictionary(&mut self, uri: String) {
-        self.inner.set_segmenter_user_dictionary(&uri);
+        self.inner.set_user_dictionary(&uri);
     }
 
     /// Sets whether to keep whitespace in tokenization results.
@@ -92,7 +86,7 @@ impl JsTokenizerBuilder {
     /// * `keep_whitespace` - If true, whitespace tokens will be included in results.
     #[napi]
     pub fn set_keep_whitespace(&mut self, keep_whitespace: bool) {
-        self.inner.set_segmenter_keep_whitespace(keep_whitespace);
+        self.inner.set_keep_whitespace(keep_whitespace);
     }
 
     /// Appends a character filter to the preprocessing pipeline.
@@ -136,12 +130,8 @@ impl JsTokenizerBuilder {
     /// A configured Tokenizer instance ready for use.
     #[napi]
     pub fn build(&self) -> napi::Result<JsTokenizer> {
-        let tokenizer = self
-            .inner
-            .build()
-            .map_err(|err| to_napi_error(format!("Failed to build tokenizer: {err}")))?;
-
-        Ok(JsTokenizer { inner: tokenizer })
+        let inner = self.inner.build().map_err(to_napi_error)?;
+        Ok(JsTokenizer { inner })
     }
 }
 
@@ -150,7 +140,7 @@ impl JsTokenizerBuilder {
 /// The tokenizer processes text and returns tokens with their morphological features.
 #[napi(js_name = "Tokenizer")]
 pub struct JsTokenizer {
-    inner: Tokenizer,
+    inner: CoreTokenizer,
 }
 
 #[napi]
@@ -169,16 +159,13 @@ impl JsTokenizer {
         user_dictionary: Option<&JsUserDictionary>,
     ) -> napi::Result<Self> {
         let mode_str = mode.unwrap_or_else(|| "normal".to_string());
-        let m = Mode::from_str(&mode_str)
-            .map_err(|err| to_napi_error(format!("Failed to create mode: {err}")))?;
-
         let dict = dictionary.inner.clone();
         let user_dict = user_dictionary.map(|d| d.inner.clone());
 
-        let segmenter = Segmenter::new(m, dict, user_dict);
-        let tokenizer = Tokenizer::new(segmenter);
+        let inner =
+            CoreTokenizer::from_segmenter(&mode_str, dict, user_dict).map_err(to_napi_error)?;
 
-        Ok(Self { inner: tokenizer })
+        Ok(Self { inner })
     }
 
     /// Tokenizes the given text.
@@ -192,14 +179,8 @@ impl JsTokenizer {
     /// An array of Token objects containing morphological features.
     #[napi]
     pub fn tokenize(&self, text: String) -> napi::Result<Vec<JsToken>> {
-        let tokens = self
-            .inner
-            .tokenize(&text)
-            .map_err(|err| to_napi_error(format!("Failed to tokenize text: {err}")))?;
-
-        let js_tokens: Vec<JsToken> = tokens.into_iter().map(JsToken::from_token).collect();
-
-        Ok(js_tokens)
+        let views = self.inner.tokenize(&text).map_err(to_napi_error)?;
+        Ok(views.into_iter().map(JsToken::from_view).collect())
     }
 
     /// Tokenizes the given text and returns N-best results.
@@ -225,12 +206,12 @@ impl JsTokenizer {
         let results = self
             .inner
             .tokenize_nbest(&text, n as usize, unique.unwrap_or(false), cost_threshold)
-            .map_err(|err| to_napi_error(format!("Failed to tokenize_nbest text: {err}")))?;
+            .map_err(to_napi_error)?;
 
         let js_results: Vec<JsNbestResult> = results
             .into_iter()
-            .map(|(tokens, cost)| {
-                JsNbestResult::new(tokens.into_iter().map(JsToken::from_token).collect(), cost)
+            .map(|(views, cost)| {
+                JsNbestResult::new(views.into_iter().map(JsToken::from_view).collect(), cost)
             })
             .collect();
 


### PR DESCRIPTION
# Migrate lindera-nodejs to the full lindera-binding-core facade (#715)

Part of #708 (Phase 6 / v4.0.0). Refs #715. Applies the pattern established by #714 (Python).

## Summary

Reduce the NAPI-RS wrappers to thin adapters over the binding-core facade
(`CoreSchema`/`CoreMetadata`/`CoreTokenizer`/`CoreError`), removing the field-management,
metadata-default, and tokenizer build-flow logic that `lindera-nodejs` reimplemented. **The JS API is
preserved exactly.**

## What changed

- `token.rs`: add `JsToken::from_view(TokenView)` (the tokenizer now yields `TokenView`s).
- `schema.rs`: `JsSchema` wraps `CoreSchema`; `JsFieldType` / `JsFieldDefinition` convert through
  `CoreFieldType` / `CoreFieldDefinition`.
- `metadata.rs`: `JsMetadata` wraps `CoreMetadata`; getters/setters delegate; `to_lindera_metadata`
  and the `From` conversions are preserved (so `dictionary.rs` is unaffected).
- `tokenizer.rs`: `JsTokenizerBuilder` / `JsTokenizer` wrap the core builder/tokenizer; the
  JS-value → `serde_json::Value` conversion stays in `util.rs`. `error.rs` is unchanged
  (`to_napi_error` already accepts `CoreError` via `Display`).

### Out of scope: segmenter-module parity

The original issue mentioned adding a `segmenter` module for parity with Python. Python's `segmenter`
module is a **vestigial, non-constructible 25-line stub** (no constructor, no real methods), so
replicating it adds no value. The segmenter story (remove it from Python, or design a real
cross-binding segmenter API) is left to a separate issue.

## Verification

- `cargo test -p lindera-nodejs --lib`: 27 passed (links cleanly — napi has no libpython-style issue)
- `cargo fmt -p lindera-nodejs -- --check`: clean
- `cargo clippy -p lindera-nodejs --all-targets -- -D warnings`: clean
- `make test-lindera-nodejs` (napi build + `npm test`): **15 passed, 0 failed**
