### PR TITLE
feat(ruby): migrate lindera-ruby to the lindera-binding-core facade

### DIFF
--- a/lindera-ruby/src/metadata.rs
+++ b/lindera-ruby/src/metadata.rs
@@ -1,7 +1,9 @@
 //! Dictionary metadata configuration.
 //!
 //! This module provides structures for configuring dictionary metadata, including
-//! character encodings and schema definitions.
+//! character encodings and schema definitions. The defaults and schema wiring are
+//! delegated to [`lindera_binding_core::CoreMetadata`]; this module only adds the
+//! magnus wrappers.
 
 use std::collections::HashMap;
 
@@ -9,37 +11,17 @@ use magnus::prelude::*;
 use magnus::{Error, Ruby, function, method};
 
 use lindera::dictionary::Metadata;
-
-use crate::schema::RbSchema;
+use lindera_binding_core::CoreMetadata;
 
 /// Dictionary metadata configuration.
 ///
-/// Contains all configuration parameters for building and using dictionaries.
+/// A thin magnus wrapper over [`lindera_binding_core::CoreMetadata`], which owns
+/// the default values and the schema wiring.
 #[magnus::wrap(class = "Lindera::Metadata", free_immediately, size)]
 #[derive(Debug, Clone)]
 pub struct RbMetadata {
-    /// Dictionary name.
-    name: String,
-    /// Character encoding.
-    encoding: String,
-    /// Default cost for unknown words.
-    default_word_cost: i16,
-    /// Default left context ID.
-    default_left_context_id: u16,
-    /// Default right context ID.
-    default_right_context_id: u16,
-    /// Default value for missing fields.
-    default_field_value: String,
-    /// Allow flexible CSV parsing.
-    flexible_csv: bool,
-    /// Skip entries with invalid cost/ID.
-    skip_invalid_cost_or_id: bool,
-    /// Normalize morphological details.
-    normalize_details: bool,
-    /// Schema for main dictionary.
-    dictionary_schema: RbSchema,
-    /// Schema for user dictionary.
-    user_dictionary_schema: RbSchema,
+    /// The backing binding-core metadata.
+    inner: CoreMetadata,
 }
 
 impl RbMetadata {
@@ -65,21 +47,19 @@ impl RbMetadata {
         normalize_details: Option<bool>,
     ) -> Self {
         RbMetadata {
-            name: name.unwrap_or_else(|| "default".to_string()),
-            encoding: encoding.unwrap_or_else(|| "UTF-8".to_string()),
-            default_word_cost: default_word_cost.unwrap_or(-10000),
-            default_left_context_id: default_left_context_id.unwrap_or(1288),
-            default_right_context_id: default_right_context_id.unwrap_or(1288),
-            default_field_value: default_field_value.unwrap_or_else(|| "*".to_string()),
-            flexible_csv: flexible_csv.unwrap_or(false),
-            skip_invalid_cost_or_id: skip_invalid_cost_or_id.unwrap_or(false),
-            normalize_details: normalize_details.unwrap_or(false),
-            dictionary_schema: RbSchema::create_default_internal(),
-            user_dictionary_schema: RbSchema::new_internal(vec![
-                "surface".to_string(),
-                "reading".to_string(),
-                "pronunciation".to_string(),
-            ]),
+            inner: CoreMetadata::new(
+                name,
+                encoding,
+                default_word_cost,
+                default_left_context_id,
+                default_right_context_id,
+                default_field_value,
+                flexible_csv,
+                skip_invalid_cost_or_id,
+                normalize_details,
+                None,
+                None,
+            ),
         }
     }
 
@@ -123,47 +103,47 @@ impl RbMetadata {
 
     /// Returns the dictionary name.
     fn name(&self) -> String {
-        self.name.clone()
+        self.inner.name.clone()
     }
 
     /// Returns the character encoding.
     fn encoding(&self) -> String {
-        self.encoding.clone()
+        self.inner.encoding.clone()
     }
 
     /// Returns the default word cost.
     fn default_word_cost(&self) -> i16 {
-        self.default_word_cost
+        self.inner.default_word_cost
     }
 
     /// Returns the default left context ID.
     fn default_left_context_id(&self) -> u16 {
-        self.default_left_context_id
+        self.inner.default_left_context_id
     }
 
     /// Returns the default right context ID.
     fn default_right_context_id(&self) -> u16 {
-        self.default_right_context_id
+        self.inner.default_right_context_id
     }
 
     /// Returns the default field value.
     fn default_field_value(&self) -> String {
-        self.default_field_value.clone()
+        self.inner.default_field_value.clone()
     }
 
     /// Returns whether flexible CSV parsing is enabled.
     fn flexible_csv(&self) -> bool {
-        self.flexible_csv
+        self.inner.flexible_csv
     }
 
     /// Returns whether invalid cost/ID entries should be skipped.
     fn skip_invalid_cost_or_id(&self) -> bool {
-        self.skip_invalid_cost_or_id
+        self.inner.skip_invalid_cost_or_id
     }
 
     /// Returns whether morphological details should be normalized.
     fn normalize_details(&self) -> bool {
-        self.normalize_details
+        self.inner.normalize_details
     }
 
     /// Converts the metadata to a Ruby hash.
@@ -173,40 +153,43 @@ impl RbMetadata {
     /// A HashMap of metadata properties.
     fn to_hash(&self) -> HashMap<String, String> {
         let mut dict = HashMap::new();
-        dict.insert("name".to_string(), self.name.clone());
-        dict.insert("encoding".to_string(), self.encoding.clone());
+        dict.insert("name".to_string(), self.inner.name.clone());
+        dict.insert("encoding".to_string(), self.inner.encoding.clone());
         dict.insert(
             "default_word_cost".to_string(),
-            self.default_word_cost.to_string(),
+            self.inner.default_word_cost.to_string(),
         );
         dict.insert(
             "default_left_context_id".to_string(),
-            self.default_left_context_id.to_string(),
+            self.inner.default_left_context_id.to_string(),
         );
         dict.insert(
             "default_right_context_id".to_string(),
-            self.default_right_context_id.to_string(),
+            self.inner.default_right_context_id.to_string(),
         );
         dict.insert(
             "default_field_value".to_string(),
-            self.default_field_value.clone(),
+            self.inner.default_field_value.clone(),
         );
-        dict.insert("flexible_csv".to_string(), self.flexible_csv.to_string());
+        dict.insert(
+            "flexible_csv".to_string(),
+            self.inner.flexible_csv.to_string(),
+        );
         dict.insert(
             "skip_invalid_cost_or_id".to_string(),
-            self.skip_invalid_cost_or_id.to_string(),
+            self.inner.skip_invalid_cost_or_id.to_string(),
         );
         dict.insert(
             "normalize_details".to_string(),
-            self.normalize_details.to_string(),
+            self.inner.normalize_details.to_string(),
         );
         dict.insert(
             "dictionary_schema_fields".to_string(),
-            self.dictionary_schema.fields.join(","),
+            self.inner.dictionary_schema.fields().join(","),
         );
         dict.insert(
             "user_dictionary_schema_fields".to_string(),
-            self.user_dictionary_schema.fields.join(","),
+            self.inner.user_dictionary_schema.fields().join(","),
         );
         dict
     }
@@ -215,7 +198,7 @@ impl RbMetadata {
     fn to_s(&self) -> String {
         format!(
             "Metadata(name='{}', encoding='{}')",
-            self.name, self.encoding,
+            self.inner.name, self.inner.encoding,
         )
     }
 
@@ -223,45 +206,23 @@ impl RbMetadata {
     fn inspect(&self) -> String {
         format!(
             "#<Lindera::Metadata: name='{}', encoding='{}', schema_fields={}>",
-            self.name,
-            self.encoding,
-            self.dictionary_schema.fields.len()
+            self.inner.name,
+            self.inner.encoding,
+            self.inner.dictionary_schema.field_count()
         )
     }
 }
 
 impl From<RbMetadata> for Metadata {
     fn from(metadata: RbMetadata) -> Self {
-        Metadata::new(
-            metadata.name,
-            metadata.encoding,
-            metadata.default_word_cost,
-            metadata.default_left_context_id,
-            metadata.default_right_context_id,
-            metadata.default_field_value,
-            metadata.flexible_csv,
-            metadata.skip_invalid_cost_or_id,
-            metadata.normalize_details,
-            metadata.dictionary_schema.into(),
-            metadata.user_dictionary_schema.into(),
-        )
+        metadata.inner.into()
     }
 }
 
 impl From<Metadata> for RbMetadata {
     fn from(metadata: Metadata) -> Self {
         RbMetadata {
-            name: metadata.name,
-            encoding: metadata.encoding,
-            default_word_cost: metadata.default_word_cost,
-            default_left_context_id: metadata.default_left_context_id,
-            default_right_context_id: metadata.default_right_context_id,
-            default_field_value: metadata.default_field_value,
-            flexible_csv: metadata.flexible_csv,
-            skip_invalid_cost_or_id: metadata.skip_invalid_cost_or_id,
-            normalize_details: metadata.normalize_details,
-            dictionary_schema: metadata.dictionary_schema.into(),
-            user_dictionary_schema: metadata.user_dictionary_schema.into(),
+            inner: CoreMetadata::from(metadata),
         }
     }
 }
@@ -321,24 +282,27 @@ pub fn define(ruby: &Ruby, module: &magnus::RModule) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lindera_binding_core::CoreSchema;
 
     #[test]
     fn test_rb_metadata_to_lindera_metadata() {
         let rb_metadata = RbMetadata {
-            name: "test_dict".to_string(),
-            encoding: "EUC-JP".to_string(),
-            default_word_cost: -5000,
-            default_left_context_id: 100,
-            default_right_context_id: 200,
-            default_field_value: "N/A".to_string(),
-            flexible_csv: true,
-            skip_invalid_cost_or_id: true,
-            normalize_details: true,
-            dictionary_schema: RbSchema::new_internal(vec![
-                "surface".to_string(),
-                "cost".to_string(),
-            ]),
-            user_dictionary_schema: RbSchema::new_internal(vec!["surface".to_string()]),
+            inner: CoreMetadata::new(
+                Some("test_dict".to_string()),
+                Some("EUC-JP".to_string()),
+                Some(-5000),
+                Some(100),
+                Some(200),
+                Some("N/A".to_string()),
+                Some(true),
+                Some(true),
+                Some(true),
+                Some(CoreSchema::new(vec![
+                    "surface".to_string(),
+                    "cost".to_string(),
+                ])),
+                Some(CoreSchema::new(vec!["surface".to_string()])),
+            ),
         };
 
         let lindera_metadata: Metadata = rb_metadata.into();
@@ -383,51 +347,45 @@ mod tests {
         );
 
         let rb_metadata: RbMetadata = lindera_metadata.into();
-        assert_eq!(rb_metadata.name, "my_dict");
-        assert_eq!(rb_metadata.encoding, "UTF-8");
-        assert_eq!(rb_metadata.default_word_cost, -8000);
-        assert_eq!(rb_metadata.default_left_context_id, 500);
-        assert_eq!(rb_metadata.default_right_context_id, 600);
-        assert_eq!(rb_metadata.default_field_value, "?");
-        assert!(!rb_metadata.flexible_csv);
-        assert!(rb_metadata.skip_invalid_cost_or_id);
-        assert!(!rb_metadata.normalize_details);
-        assert_eq!(rb_metadata.dictionary_schema.fields.len(), 2);
-        assert_eq!(rb_metadata.user_dictionary_schema.fields.len(), 2);
+        assert_eq!(rb_metadata.name(), "my_dict");
+        assert_eq!(rb_metadata.encoding(), "UTF-8");
+        assert_eq!(rb_metadata.default_word_cost(), -8000);
+        assert_eq!(rb_metadata.default_left_context_id(), 500);
+        assert_eq!(rb_metadata.default_right_context_id(), 600);
+        assert_eq!(rb_metadata.default_field_value(), "?");
+        assert!(!rb_metadata.flexible_csv());
+        assert!(rb_metadata.skip_invalid_cost_or_id());
+        assert!(!rb_metadata.normalize_details());
+        assert_eq!(rb_metadata.inner.dictionary_schema.field_count(), 2);
+        assert_eq!(rb_metadata.inner.user_dictionary_schema.field_count(), 2);
+    }
+
+    #[test]
+    fn test_rb_metadata_defaults() {
+        let rb_metadata = RbMetadata::create_default();
+        assert_eq!(rb_metadata.name(), "default");
+        assert_eq!(rb_metadata.encoding(), "UTF-8");
+        assert_eq!(rb_metadata.default_word_cost(), -10000);
+        assert_eq!(rb_metadata.default_left_context_id(), 1288);
+        assert_eq!(rb_metadata.default_right_context_id(), 1288);
+        assert_eq!(rb_metadata.default_field_value(), "*");
+        assert!(!rb_metadata.flexible_csv());
+        assert_eq!(rb_metadata.inner.dictionary_schema.field_count(), 13);
+        assert_eq!(rb_metadata.inner.user_dictionary_schema.field_count(), 3);
     }
 
     #[test]
     fn test_rb_metadata_roundtrip() {
-        let rb_metadata = RbMetadata {
-            name: "roundtrip".to_string(),
-            encoding: "UTF-8".to_string(),
-            default_word_cost: -10000,
-            default_left_context_id: 1288,
-            default_right_context_id: 1288,
-            default_field_value: "*".to_string(),
-            flexible_csv: false,
-            skip_invalid_cost_or_id: false,
-            normalize_details: false,
-            dictionary_schema: RbSchema::create_default_internal(),
-            user_dictionary_schema: RbSchema::new_internal(vec![
-                "surface".to_string(),
-                "reading".to_string(),
-                "pronunciation".to_string(),
-            ]),
-        };
-
+        let rb_metadata = RbMetadata::create_default();
         let lindera: Metadata = rb_metadata.into();
         let back: RbMetadata = lindera.into();
-        assert_eq!(back.name, "roundtrip");
-        assert_eq!(back.encoding, "UTF-8");
-        assert_eq!(back.default_word_cost, -10000);
-        assert_eq!(back.default_left_context_id, 1288);
-        assert_eq!(back.default_right_context_id, 1288);
-        assert_eq!(back.default_field_value, "*");
-        assert!(!back.flexible_csv);
-        assert!(!back.skip_invalid_cost_or_id);
-        assert!(!back.normalize_details);
-        assert_eq!(back.dictionary_schema.fields.len(), 13);
-        assert_eq!(back.user_dictionary_schema.fields.len(), 3);
+        assert_eq!(back.name(), "default");
+        assert_eq!(back.encoding(), "UTF-8");
+        assert_eq!(back.default_word_cost(), -10000);
+        assert_eq!(back.default_left_context_id(), 1288);
+        assert_eq!(back.default_right_context_id(), 1288);
+        assert_eq!(back.default_field_value(), "*");
+        assert_eq!(back.inner.dictionary_schema.field_count(), 13);
+        assert_eq!(back.inner.user_dictionary_schema.field_count(), 3);
     }
 }

--- a/lindera-ruby/src/schema.rs
+++ b/lindera-ruby/src/schema.rs
@@ -1,14 +1,14 @@
 //! Dictionary schema definitions.
 //!
 //! This module provides schema structures that define the format and fields
-//! of dictionary entries.
-
-use std::collections::HashMap;
+//! of dictionary entries. The field-management logic is delegated to
+//! [`lindera_binding_core::CoreSchema`]; this module only adds the magnus wrappers.
 
 use magnus::prelude::*;
 use magnus::{Error, RArray, Ruby, function, method};
 
 use lindera::dictionary::{FieldDefinition, FieldType, Schema};
+use lindera_binding_core::{CoreFieldDefinition, CoreFieldType, CoreSchema};
 
 /// Field type in dictionary schema.
 ///
@@ -53,28 +53,40 @@ impl RbFieldType {
     }
 }
 
+impl From<CoreFieldType> for RbFieldType {
+    fn from(field_type: CoreFieldType) -> Self {
+        let inner = match field_type {
+            CoreFieldType::Surface => RbFieldTypeKind::Surface,
+            CoreFieldType::LeftContextId => RbFieldTypeKind::LeftContextId,
+            CoreFieldType::RightContextId => RbFieldTypeKind::RightContextId,
+            CoreFieldType::Cost => RbFieldTypeKind::Cost,
+            CoreFieldType::Custom => RbFieldTypeKind::Custom,
+        };
+        RbFieldType { inner }
+    }
+}
+
+impl From<RbFieldType> for CoreFieldType {
+    fn from(field_type: RbFieldType) -> Self {
+        match field_type.inner {
+            RbFieldTypeKind::Surface => CoreFieldType::Surface,
+            RbFieldTypeKind::LeftContextId => CoreFieldType::LeftContextId,
+            RbFieldTypeKind::RightContextId => CoreFieldType::RightContextId,
+            RbFieldTypeKind::Cost => CoreFieldType::Cost,
+            RbFieldTypeKind::Custom => CoreFieldType::Custom,
+        }
+    }
+}
+
 impl From<FieldType> for RbFieldType {
     fn from(field_type: FieldType) -> Self {
-        let kind = match field_type {
-            FieldType::Surface => RbFieldTypeKind::Surface,
-            FieldType::LeftContextId => RbFieldTypeKind::LeftContextId,
-            FieldType::RightContextId => RbFieldTypeKind::RightContextId,
-            FieldType::Cost => RbFieldTypeKind::Cost,
-            FieldType::Custom => RbFieldTypeKind::Custom,
-        };
-        RbFieldType { inner: kind }
+        RbFieldType::from(CoreFieldType::from(field_type))
     }
 }
 
 impl From<RbFieldType> for FieldType {
     fn from(field_type: RbFieldType) -> Self {
-        match field_type.inner {
-            RbFieldTypeKind::Surface => FieldType::Surface,
-            RbFieldTypeKind::LeftContextId => FieldType::LeftContextId,
-            RbFieldTypeKind::RightContextId => FieldType::RightContextId,
-            RbFieldTypeKind::Cost => FieldType::Cost,
-            RbFieldTypeKind::Custom => FieldType::Custom,
-        }
+        FieldType::from(CoreFieldType::from(field_type))
     }
 }
 
@@ -129,8 +141,8 @@ impl RbFieldDefinition {
     }
 }
 
-impl From<FieldDefinition> for RbFieldDefinition {
-    fn from(field_def: FieldDefinition) -> Self {
+impl From<CoreFieldDefinition> for RbFieldDefinition {
+    fn from(field_def: CoreFieldDefinition) -> Self {
         RbFieldDefinition {
             index: field_def.index,
             name: field_def.name,
@@ -140,9 +152,9 @@ impl From<FieldDefinition> for RbFieldDefinition {
     }
 }
 
-impl From<RbFieldDefinition> for FieldDefinition {
+impl From<RbFieldDefinition> for CoreFieldDefinition {
     fn from(field_def: RbFieldDefinition) -> Self {
-        FieldDefinition {
+        CoreFieldDefinition {
             index: field_def.index,
             name: field_def.name,
             field_type: field_def.field_type.into(),
@@ -151,16 +163,27 @@ impl From<RbFieldDefinition> for FieldDefinition {
     }
 }
 
+impl From<FieldDefinition> for RbFieldDefinition {
+    fn from(field_def: FieldDefinition) -> Self {
+        RbFieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
+impl From<RbFieldDefinition> for FieldDefinition {
+    fn from(field_def: RbFieldDefinition) -> Self {
+        FieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
 /// Dictionary schema definition.
 ///
-/// Defines the structure and fields of dictionary entries.
+/// A thin magnus wrapper over [`lindera_binding_core::CoreSchema`], which owns
+/// the field storage, the name-to-index map, and the field lookups.
 #[magnus::wrap(class = "Lindera::Schema", free_immediately, size)]
 #[derive(Debug, Clone)]
 pub struct RbSchema {
-    /// List of field names.
-    pub fields: Vec<String>,
-    /// Map from field name to index.
-    field_index_map: HashMap<String, usize>,
+    /// The backing binding-core schema.
+    inner: CoreSchema,
 }
 
 impl RbSchema {
@@ -174,13 +197,8 @@ impl RbSchema {
     ///
     /// A new `RbSchema` instance.
     fn new(fields: Vec<String>) -> Self {
-        let mut field_index_map = HashMap::new();
-        for (i, field) in fields.iter().enumerate() {
-            field_index_map.insert(field.clone(), i);
-        }
         Self {
-            fields,
-            field_index_map,
+            inner: CoreSchema::new(fields),
         }
     }
 
@@ -190,12 +208,14 @@ impl RbSchema {
     ///
     /// A new `RbSchema` with default IPADIC fields.
     fn create_default() -> Self {
-        Self::new(lindera_binding_core::schema::default_dictionary_fields())
+        Self {
+            inner: CoreSchema::create_default(),
+        }
     }
 
     /// Returns the list of field names as a Ruby array.
     fn fields(&self) -> Vec<String> {
-        self.fields.clone()
+        self.inner.fields().to_vec()
     }
 
     /// Returns the index of the specified field name.
@@ -208,7 +228,7 @@ impl RbSchema {
     ///
     /// The index of the field, or None if not found.
     fn get_field_index(&self, field_name: String) -> Option<usize> {
-        self.field_index_map.get(&field_name).copied()
+        self.inner.get_field_index(&field_name)
     }
 
     /// Returns the number of fields in the schema.
@@ -217,7 +237,7 @@ impl RbSchema {
     ///
     /// The number of fields.
     fn field_count(&self) -> usize {
-        self.fields.len()
+        self.inner.field_count()
     }
 
     /// Returns the name of the field at the specified index.
@@ -230,7 +250,7 @@ impl RbSchema {
     ///
     /// The field name, or None if the index is out of bounds.
     fn get_field_name(&self, index: usize) -> Option<String> {
-        self.fields.get(index).cloned()
+        self.inner.get_field_name(index).map(str::to_string)
     }
 
     /// Returns the custom fields (fields after the first 4 standard fields).
@@ -239,11 +259,7 @@ impl RbSchema {
     ///
     /// A list of custom field names.
     fn get_custom_fields(&self) -> Vec<String> {
-        if self.fields.len() > 4 {
-            self.fields[4..].to_vec()
-        } else {
-            Vec::new()
-        }
+        self.inner.get_custom_fields().to_vec()
     }
 
     /// Returns all field names.
@@ -252,7 +268,7 @@ impl RbSchema {
     ///
     /// A list of all field names.
     fn get_all_fields(&self) -> Vec<String> {
-        self.fields.clone()
+        self.inner.fields().to_vec()
     }
 
     /// Returns the field definition for the specified field name.
@@ -265,36 +281,9 @@ impl RbSchema {
     ///
     /// The field definition, or None if not found.
     fn get_field_by_name(&self, name: String) -> Option<RbFieldDefinition> {
-        self.field_index_map.get(&name).map(|&index| {
-            let field_type = if index < 4 {
-                match index {
-                    0 => RbFieldType {
-                        inner: RbFieldTypeKind::Surface,
-                    },
-                    1 => RbFieldType {
-                        inner: RbFieldTypeKind::LeftContextId,
-                    },
-                    2 => RbFieldType {
-                        inner: RbFieldTypeKind::RightContextId,
-                    },
-                    3 => RbFieldType {
-                        inner: RbFieldTypeKind::Cost,
-                    },
-                    _ => unreachable!(),
-                }
-            } else {
-                RbFieldType {
-                    inner: RbFieldTypeKind::Custom,
-                }
-            };
-
-            RbFieldDefinition {
-                index,
-                name: name.clone(),
-                field_type,
-                description: None,
-            }
-        })
+        self.inner
+            .get_field_by_name(&name)
+            .map(RbFieldDefinition::from)
     }
 
     /// Validates a CSV record against the schema.
@@ -310,18 +299,19 @@ impl RbSchema {
         let ruby = Ruby::get().expect("Ruby runtime not initialized");
         let values: Vec<String> = record.to_vec()?;
 
-        lindera_binding_core::schema::validate_record(&self.fields, &values)
-            .map_err(|message| Error::new(ruby.exception_arg_error(), message))
+        self.inner
+            .validate_record(&values)
+            .map_err(|err| Error::new(ruby.exception_arg_error(), err.to_string()))
     }
 
     /// Returns the string representation of the schema.
     fn to_s(&self) -> String {
-        format!("Schema(fields={})", self.fields.len())
+        format!("Schema(fields={})", self.inner.field_count())
     }
 
     /// Returns the inspect representation of the schema.
     fn inspect(&self) -> String {
-        format!("#<Lindera::Schema: fields={:?}>", self.fields)
+        format!("#<Lindera::Schema: fields={:?}>", self.inner.fields())
     }
 }
 
@@ -337,15 +327,29 @@ impl RbSchema {
     }
 }
 
+impl From<CoreSchema> for RbSchema {
+    fn from(schema: CoreSchema) -> Self {
+        RbSchema { inner: schema }
+    }
+}
+
+impl From<RbSchema> for CoreSchema {
+    fn from(schema: RbSchema) -> Self {
+        schema.inner
+    }
+}
+
 impl From<RbSchema> for Schema {
     fn from(schema: RbSchema) -> Self {
-        Schema::new(schema.fields)
+        schema.inner.into()
     }
 }
 
 impl From<Schema> for RbSchema {
     fn from(schema: Schema) -> Self {
-        RbSchema::new(schema.get_all_fields().to_vec())
+        RbSchema {
+            inner: CoreSchema::from(schema),
+        }
     }
 }
 
@@ -404,33 +408,6 @@ mod tests {
     }
 
     #[test]
-    fn test_rb_field_type_left_context_id_to_lindera() {
-        let rb = RbFieldType {
-            inner: RbFieldTypeKind::LeftContextId,
-        };
-        let lindera: FieldType = rb.into();
-        assert!(matches!(lindera, FieldType::LeftContextId));
-    }
-
-    #[test]
-    fn test_rb_field_type_right_context_id_to_lindera() {
-        let rb = RbFieldType {
-            inner: RbFieldTypeKind::RightContextId,
-        };
-        let lindera: FieldType = rb.into();
-        assert!(matches!(lindera, FieldType::RightContextId));
-    }
-
-    #[test]
-    fn test_rb_field_type_cost_to_lindera() {
-        let rb = RbFieldType {
-            inner: RbFieldTypeKind::Cost,
-        };
-        let lindera: FieldType = rb.into();
-        assert!(matches!(lindera, FieldType::Cost));
-    }
-
-    #[test]
     fn test_rb_field_type_custom_to_lindera() {
         let rb = RbFieldType {
             inner: RbFieldTypeKind::Custom,
@@ -443,24 +420,6 @@ mod tests {
     fn test_lindera_field_type_surface_to_rb() {
         let rb: RbFieldType = FieldType::Surface.into();
         assert!(matches!(rb.inner, RbFieldTypeKind::Surface));
-    }
-
-    #[test]
-    fn test_lindera_field_type_left_context_id_to_rb() {
-        let rb: RbFieldType = FieldType::LeftContextId.into();
-        assert!(matches!(rb.inner, RbFieldTypeKind::LeftContextId));
-    }
-
-    #[test]
-    fn test_lindera_field_type_right_context_id_to_rb() {
-        let rb: RbFieldType = FieldType::RightContextId.into();
-        assert!(matches!(rb.inner, RbFieldTypeKind::RightContextId));
-    }
-
-    #[test]
-    fn test_lindera_field_type_cost_to_rb() {
-        let rb: RbFieldType = FieldType::Cost.into();
-        assert!(matches!(rb.inner, RbFieldTypeKind::Cost));
     }
 
     #[test]
@@ -510,30 +469,30 @@ mod tests {
             "cost".to_string(),
         ];
         let schema = RbSchema::new_internal(fields);
-        let custom = schema.get_custom_fields();
-        assert!(custom.is_empty());
+        assert!(schema.get_custom_fields().is_empty());
     }
 
     #[test]
-    fn test_rb_schema_get_custom_fields_empty() {
-        let schema = RbSchema::new_internal(vec![]);
-        let custom = schema.get_custom_fields();
-        assert!(custom.is_empty());
-    }
-
-    #[test]
-    fn test_rb_schema_create_default_has_13_fields() {
+    fn test_rb_schema_create_default() {
         let schema = RbSchema::create_default_internal();
         assert_eq!(schema.field_count(), 13);
+        assert_eq!(schema.fields()[0], "surface");
+        assert_eq!(schema.fields()[3], "cost");
+        assert_eq!(schema.fields()[5], "middle_pos");
     }
 
     #[test]
-    fn test_rb_schema_create_default_first_fields() {
+    fn test_rb_schema_get_field_by_name() {
         let schema = RbSchema::create_default_internal();
-        assert_eq!(schema.fields[0], "surface");
-        assert_eq!(schema.fields[1], "left_context_id");
-        assert_eq!(schema.fields[2], "right_context_id");
-        assert_eq!(schema.fields[3], "cost");
+        let surface = schema.get_field_by_name("surface".to_string()).unwrap();
+        assert_eq!(surface.index, 0);
+        assert!(matches!(surface.field_type.inner, RbFieldTypeKind::Surface));
+
+        let custom = schema.get_field_by_name("middle_pos".to_string()).unwrap();
+        assert_eq!(custom.index, 5);
+        assert!(matches!(custom.field_type.inner, RbFieldTypeKind::Custom));
+
+        assert!(schema.get_field_by_name("nope".to_string()).is_none());
     }
 
     #[test]
@@ -549,9 +508,8 @@ mod tests {
         let fields = vec!["x".to_string(), "y".to_string(), "z".to_string()];
         let lindera_schema = Schema::new(fields.clone());
         let rb_schema: RbSchema = lindera_schema.into();
-        assert_eq!(rb_schema.fields, fields);
+        assert_eq!(rb_schema.fields(), fields);
         assert_eq!(rb_schema.get_field_index("x".to_string()), Some(0));
-        assert_eq!(rb_schema.get_field_index("y".to_string()), Some(1));
         assert_eq!(rb_schema.get_field_index("z".to_string()), Some(2));
     }
 
@@ -567,7 +525,7 @@ mod tests {
         let rb_schema = RbSchema::new_internal(fields.clone());
         let lindera_schema: Schema = rb_schema.into();
         let back: RbSchema = lindera_schema.into();
-        assert_eq!(back.fields, fields);
+        assert_eq!(back.fields(), fields);
         assert_eq!(back.field_count(), 5);
     }
 

--- a/lindera-ruby/src/token.rs
+++ b/lindera-ruby/src/token.rs
@@ -39,8 +39,19 @@ impl RbToken {
     ///
     /// A new `RbToken` instance.
     pub fn from_token(token: Token) -> Self {
-        let view = lindera_binding_core::TokenView::from_token(token);
+        Self::from_view(lindera_binding_core::TokenView::from_token(token))
+    }
 
+    /// Creates a new `RbToken` from a binding-core `TokenView`.
+    ///
+    /// # Arguments
+    ///
+    /// * `view` - Token view produced by the binding-core tokenizer.
+    ///
+    /// # Returns
+    ///
+    /// A new `RbToken` instance.
+    pub fn from_view(view: lindera_binding_core::TokenView) -> Self {
         Self {
             surface: view.surface,
             byte_start: view.byte_start,

--- a/lindera-ruby/src/tokenizer.rs
+++ b/lindera-ruby/src/tokenizer.rs
@@ -1,17 +1,17 @@
 //! Tokenizer implementation for morphological analysis.
 //!
 //! This module provides a builder pattern for creating tokenizers and the tokenizer itself.
+//! The build-flow orchestration is delegated to
+//! [`lindera_binding_core::CoreTokenizerBuilder`] / [`lindera_binding_core::CoreTokenizer`];
+//! this module only adds the magnus wrappers and the Ruby-hash conversion.
 
 use std::cell::RefCell;
 use std::path::Path;
-use std::str::FromStr;
 
 use magnus::prelude::*;
 use magnus::{Error, RArray, RHash, Ruby, function, method};
 
-use lindera::mode::Mode;
-use lindera::segmenter::Segmenter;
-use lindera::tokenizer::{Tokenizer, TokenizerBuilder};
+use lindera_binding_core::{CoreTokenizer, CoreTokenizerBuilder};
 
 use crate::dictionary::{RbDictionary, RbUserDictionary};
 use crate::error::to_magnus_error;
@@ -24,8 +24,8 @@ use crate::util::rb_hash_to_json;
 /// Uses `RefCell` for interior mutability since Magnus `method!` requires `&self`.
 #[magnus::wrap(class = "Lindera::TokenizerBuilder", free_immediately, size)]
 pub struct RbTokenizerBuilder {
-    /// Inner Lindera tokenizer builder (wrapped in RefCell for interior mutability).
-    inner: RefCell<TokenizerBuilder>,
+    /// Inner binding-core tokenizer builder (wrapped in RefCell for interior mutability).
+    inner: RefCell<CoreTokenizerBuilder>,
 }
 
 impl RbTokenizerBuilder {
@@ -36,9 +36,8 @@ impl RbTokenizerBuilder {
     /// A new `RbTokenizerBuilder` instance.
     fn new() -> Result<Self, Error> {
         let ruby = Ruby::get().expect("Ruby runtime not initialized");
-        let inner = TokenizerBuilder::new().map_err(|err| {
-            to_magnus_error(&ruby, format!("Failed to create TokenizerBuilder: {err}"))
-        })?;
+        let inner =
+            CoreTokenizerBuilder::new().map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
         Ok(Self {
             inner: RefCell::new(inner),
         })
@@ -55,9 +54,8 @@ impl RbTokenizerBuilder {
     /// A new `RbTokenizerBuilder` with the loaded configuration.
     fn from_file(file_path: String) -> Result<Self, Error> {
         let ruby = Ruby::get().expect("Ruby runtime not initialized");
-        let inner = TokenizerBuilder::from_file(Path::new(&file_path)).map_err(|err| {
-            to_magnus_error(&ruby, format!("Failed to load config from file: {err}"))
-        })?;
+        let inner = CoreTokenizerBuilder::from_file(Path::new(&file_path))
+            .map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
         Ok(Self {
             inner: RefCell::new(inner),
         })
@@ -70,9 +68,10 @@ impl RbTokenizerBuilder {
     /// * `mode` - Mode string ("normal" or "decompose").
     fn set_mode(&self, mode: String) -> Result<(), Error> {
         let ruby = Ruby::get().expect("Ruby runtime not initialized");
-        let m = Mode::from_str(&mode)
-            .map_err(|err| to_magnus_error(&ruby, format!("Failed to create mode: {err}")))?;
-        self.inner.borrow_mut().set_segmenter_mode(&m);
+        let mut builder = self.inner.borrow_mut();
+        builder
+            .set_mode(&mode)
+            .map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
         Ok(())
     }
 
@@ -82,7 +81,7 @@ impl RbTokenizerBuilder {
     ///
     /// * `path` - Path to the dictionary directory.
     fn set_dictionary(&self, path: String) {
-        self.inner.borrow_mut().set_segmenter_dictionary(&path);
+        self.inner.borrow_mut().set_dictionary(&path);
     }
 
     /// Sets the user dictionary URI.
@@ -91,7 +90,7 @@ impl RbTokenizerBuilder {
     ///
     /// * `uri` - URI to the user dictionary.
     fn set_user_dictionary(&self, uri: String) {
-        self.inner.borrow_mut().set_segmenter_user_dictionary(&uri);
+        self.inner.borrow_mut().set_user_dictionary(&uri);
     }
 
     /// Sets whether to keep whitespace in tokenization results.
@@ -100,9 +99,7 @@ impl RbTokenizerBuilder {
     ///
     /// * `keep_whitespace` - If true, whitespace tokens will be included.
     fn set_keep_whitespace(&self, keep_whitespace: bool) {
-        self.inner
-            .borrow_mut()
-            .set_segmenter_keep_whitespace(keep_whitespace);
+        self.inner.borrow_mut().set_keep_whitespace(keep_whitespace);
     }
 
     /// Appends a character filter to the filter pipeline.
@@ -150,11 +147,12 @@ impl RbTokenizerBuilder {
     /// A configured `RbTokenizer` instance.
     fn build(&self) -> Result<RbTokenizer, Error> {
         let ruby = Ruby::get().expect("Ruby runtime not initialized");
-        let tokenizer =
-            self.inner.borrow().build().map_err(|err| {
-                to_magnus_error(&ruby, format!("Failed to build tokenizer: {err}"))
-            })?;
-        Ok(RbTokenizer { inner: tokenizer })
+        let inner = self
+            .inner
+            .borrow()
+            .build()
+            .map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
+        Ok(RbTokenizer { inner })
     }
 }
 
@@ -163,8 +161,8 @@ impl RbTokenizerBuilder {
 /// The tokenizer processes text and returns tokens with their morphological features.
 #[magnus::wrap(class = "Lindera::Tokenizer", free_immediately, size)]
 pub struct RbTokenizer {
-    /// Inner Lindera tokenizer.
-    inner: Tokenizer,
+    /// Inner binding-core tokenizer.
+    inner: CoreTokenizer,
 }
 
 /// Creates a new tokenizer with the given dictionary and mode.
@@ -185,16 +183,14 @@ fn tokenizer_new(
 ) -> Result<RbTokenizer, Error> {
     let ruby = Ruby::get().expect("Ruby runtime not initialized");
     let mode_str = mode.as_deref().unwrap_or("normal");
-    let m = Mode::from_str(mode_str)
-        .map_err(|err| to_magnus_error(&ruby, format!("Failed to create mode: {err}")))?;
 
     let dict = dictionary.inner.clone();
     let user_dict = user_dictionary.map(|d| d.inner.clone());
 
-    let segmenter = Segmenter::new(m, dict, user_dict);
-    let tokenizer = Tokenizer::new(segmenter);
+    let inner = CoreTokenizer::from_segmenter(mode_str, dict, user_dict)
+        .map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
 
-    Ok(RbTokenizer { inner: tokenizer })
+    Ok(RbTokenizer { inner })
 }
 
 impl RbTokenizer {
@@ -209,15 +205,14 @@ impl RbTokenizer {
     /// An array of Token objects.
     fn tokenize(&self, text: String) -> Result<RArray, Error> {
         let ruby = Ruby::get().expect("Ruby runtime not initialized");
-        let tokens = self
+        let views = self
             .inner
             .tokenize(&text)
-            .map_err(|err| to_magnus_error(&ruby, format!("Failed to tokenize text: {err}")))?;
+            .map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
 
-        let rb_tokens: Vec<RbToken> = tokens.into_iter().map(RbToken::from_token).collect();
-        let arr = ruby.ary_new_capa(rb_tokens.len());
-        for token in rb_tokens {
-            arr.push(ruby.into_value(token))?;
+        let arr = ruby.ary_new_capa(views.len());
+        for view in views {
+            arr.push(ruby.into_value(RbToken::from_view(view)))?;
         }
         Ok(arr)
     }
@@ -245,16 +240,13 @@ impl RbTokenizer {
         let results = self
             .inner
             .tokenize_nbest(&text, n, unique.unwrap_or(false), cost_threshold)
-            .map_err(|err| {
-                to_magnus_error(&ruby, format!("Failed to tokenize_nbest text: {err}"))
-            })?;
+            .map_err(|err| to_magnus_error(&ruby, err.to_string()))?;
 
         let rb_results = ruby.ary_new_capa(results.len());
-        for (tokens, cost) in results {
-            let rb_tokens: Vec<RbToken> = tokens.into_iter().map(RbToken::from_token).collect();
-            let token_arr = ruby.ary_new_capa(rb_tokens.len());
-            for token in rb_tokens {
-                token_arr.push(ruby.into_value(token))?;
+        for (views, cost) in results {
+            let token_arr = ruby.ary_new_capa(views.len());
+            for view in views {
+                token_arr.push(ruby.into_value(RbToken::from_view(view)))?;
             }
             let pair = ruby.ary_new_capa(2);
             pair.push(token_arr)?;


### PR DESCRIPTION
# Migrate lindera-ruby to the full lindera-binding-core facade (#716)

Part of #708 (Phase 6 / v4.0.0). Refs #716. Applies the pattern established by #714/#715.

## Summary

Reduce the Magnus wrappers to thin adapters over the binding-core facade
(`CoreSchema`/`CoreMetadata`/`CoreTokenizer`/`CoreError`). **The Ruby API and the magnus class
definitions are unchanged.**

## What changed

- `token.rs`: add `RbToken::from_view(TokenView)`.
- `schema.rs`: `RbSchema` wraps `CoreSchema`; `RbFieldType` / `RbFieldDefinition` convert through
  `CoreFieldType` / `CoreFieldDefinition` (`new_internal` / `create_default_internal` kept).
- `metadata.rs`: `RbMetadata` wraps `CoreMetadata`.
- `tokenizer.rs`: `RbTokenizerBuilder` / `RbTokenizer` wrap the core builder/tokenizer (`RefCell`
  retained for magnus interior mutability); the Ruby-hash → `serde_json::Value` conversion stays in
  `util.rs`. `error.rs` is unchanged (`to_magnus_error` accepts the `CoreError` message via `Display`).

Ruby already ships a `segmenter` module, so there is no parity gap here (the cross-binding segmenter
decision is tracked in #733).

## Verification

- `cargo test -p lindera-ruby --lib`: 28 passed (links cleanly)
- `cargo fmt -p lindera-ruby -- --check`: clean
- `cargo clippy -p lindera-ruby --all-targets -- -D warnings`: clean
- `make test-lindera-ruby` (rake compile + minitest): **18 runs, 0 failures**
