### PR TITLE
feat(php): migrate lindera-php to the lindera-binding-core facade

### DIFF
--- a/lindera-php/src/metadata.rs
+++ b/lindera-php/src/metadata.rs
@@ -1,45 +1,29 @@
 //! Dictionary metadata configuration for PHP.
 //!
 //! This module provides structures for configuring dictionary metadata, including
-//! character encodings and schema definitions.
+//! character encodings and schema definitions. The defaults and schema wiring are
+//! delegated to [`lindera_binding_core::CoreMetadata`]; this module only adds the
+//! ext-php-rs wrappers.
 
 use std::collections::HashMap;
 
 use ext_php_rs::prelude::*;
 
 use lindera::dictionary::Metadata;
+use lindera_binding_core::CoreMetadata;
 
 use crate::error::lindera_value_err;
-use crate::schema::PhpSchema;
 
 /// Dictionary metadata configuration.
 ///
-/// Contains all configuration parameters for building and using dictionaries.
+/// A thin ext-php-rs wrapper over [`lindera_binding_core::CoreMetadata`], which
+/// owns the default values and the schema wiring.
 #[php_class]
 #[php(name = "Lindera\\Metadata")]
+#[derive(Clone)]
 pub struct PhpMetadata {
-    /// Dictionary name.
-    name: String,
-    /// Character encoding.
-    encoding: String,
-    /// Default cost for unknown words.
-    default_word_cost: i16,
-    /// Default left context ID.
-    default_left_context_id: u16,
-    /// Default right context ID.
-    default_right_context_id: u16,
-    /// Default value for missing fields.
-    default_field_value: String,
-    /// Allow flexible CSV parsing.
-    flexible_csv: bool,
-    /// Skip entries with invalid cost/ID.
-    skip_invalid_cost_or_id: bool,
-    /// Normalize morphological details.
-    normalize_details: bool,
-    /// Schema for main dictionary.
-    dictionary_schema_fields: Vec<String>,
-    /// Schema for user dictionary.
-    user_dictionary_schema_fields: Vec<String>,
+    /// The backing binding-core metadata.
+    inner: CoreMetadata,
 }
 
 #[php_impl]
@@ -75,25 +59,20 @@ impl PhpMetadata {
         skip_invalid_cost_or_id: Option<bool>,
         normalize_details: Option<bool>,
     ) -> Self {
-        let dict_schema = PhpSchema::create_default();
-        let user_schema = PhpSchema::__construct(vec![
-            "surface".to_string(),
-            "reading".to_string(),
-            "pronunciation".to_string(),
-        ]);
-
         Self {
-            name: name.unwrap_or_else(|| "default".to_string()),
-            encoding: encoding.unwrap_or_else(|| "UTF-8".to_string()),
-            default_word_cost: default_word_cost.unwrap_or(-10000) as i16,
-            default_left_context_id: default_left_context_id.unwrap_or(1288) as u16,
-            default_right_context_id: default_right_context_id.unwrap_or(1288) as u16,
-            default_field_value: default_field_value.unwrap_or_else(|| "*".to_string()),
-            flexible_csv: flexible_csv.unwrap_or(false),
-            skip_invalid_cost_or_id: skip_invalid_cost_or_id.unwrap_or(false),
-            normalize_details: normalize_details.unwrap_or(false),
-            dictionary_schema_fields: dict_schema.fields,
-            user_dictionary_schema_fields: user_schema.fields,
+            inner: CoreMetadata::new(
+                name,
+                encoding,
+                default_word_cost.map(|v| v as i16),
+                default_left_context_id.map(|v| v as u16),
+                default_right_context_id.map(|v| v as u16),
+                default_field_value,
+                flexible_csv,
+                skip_invalid_cost_or_id,
+                normalize_details,
+                None,
+                None,
+            ),
         }
     }
 
@@ -132,7 +111,7 @@ impl PhpMetadata {
     /// The name string.
     #[php(getter)]
     pub fn name(&self) -> String {
-        self.name.clone()
+        self.inner.name.clone()
     }
 
     /// Returns the character encoding.
@@ -142,7 +121,7 @@ impl PhpMetadata {
     /// The encoding string.
     #[php(getter)]
     pub fn encoding(&self) -> String {
-        self.encoding.clone()
+        self.inner.encoding.clone()
     }
 
     /// Returns the default word cost.
@@ -152,7 +131,7 @@ impl PhpMetadata {
     /// The cost value.
     #[php(getter)]
     pub fn default_word_cost(&self) -> i64 {
-        self.default_word_cost as i64
+        self.inner.default_word_cost as i64
     }
 
     /// Returns the default left context ID.
@@ -162,7 +141,7 @@ impl PhpMetadata {
     /// The context ID.
     #[php(getter)]
     pub fn default_left_context_id(&self) -> i64 {
-        self.default_left_context_id as i64
+        self.inner.default_left_context_id as i64
     }
 
     /// Returns the default right context ID.
@@ -172,7 +151,7 @@ impl PhpMetadata {
     /// The context ID.
     #[php(getter)]
     pub fn default_right_context_id(&self) -> i64 {
-        self.default_right_context_id as i64
+        self.inner.default_right_context_id as i64
     }
 
     /// Returns the default field value.
@@ -182,7 +161,7 @@ impl PhpMetadata {
     /// The default value string.
     #[php(getter)]
     pub fn default_field_value(&self) -> String {
-        self.default_field_value.clone()
+        self.inner.default_field_value.clone()
     }
 
     /// Returns whether flexible CSV parsing is enabled.
@@ -192,7 +171,7 @@ impl PhpMetadata {
     /// True if flexible CSV is enabled.
     #[php(getter)]
     pub fn flexible_csv(&self) -> bool {
-        self.flexible_csv
+        self.inner.flexible_csv
     }
 
     /// Returns whether invalid cost/ID entries are skipped.
@@ -202,7 +181,7 @@ impl PhpMetadata {
     /// True if skip is enabled.
     #[php(getter)]
     pub fn skip_invalid_cost_or_id(&self) -> bool {
-        self.skip_invalid_cost_or_id
+        self.inner.skip_invalid_cost_or_id
     }
 
     /// Returns whether details normalization is enabled.
@@ -212,7 +191,7 @@ impl PhpMetadata {
     /// True if normalization is enabled.
     #[php(getter)]
     pub fn normalize_details(&self) -> bool {
-        self.normalize_details
+        self.inner.normalize_details
     }
 
     /// Returns the dictionary schema fields.
@@ -222,7 +201,7 @@ impl PhpMetadata {
     /// A list of field name strings.
     #[php(getter)]
     pub fn dictionary_schema_fields(&self) -> Vec<String> {
-        self.dictionary_schema_fields.clone()
+        self.inner.dictionary_schema.fields().to_vec()
     }
 
     /// Returns the user dictionary schema fields.
@@ -232,7 +211,7 @@ impl PhpMetadata {
     /// A list of field name strings.
     #[php(getter)]
     pub fn user_dictionary_schema_fields(&self) -> Vec<String> {
-        self.user_dictionary_schema_fields.clone()
+        self.inner.user_dictionary_schema.fields().to_vec()
     }
 
     /// Converts the metadata to an associative array.
@@ -242,32 +221,35 @@ impl PhpMetadata {
     /// A HashMap representing the metadata.
     pub fn to_array(&self) -> HashMap<String, String> {
         let mut dict = HashMap::new();
-        dict.insert("name".to_string(), self.name.clone());
-        dict.insert("encoding".to_string(), self.encoding.clone());
+        dict.insert("name".to_string(), self.inner.name.clone());
+        dict.insert("encoding".to_string(), self.inner.encoding.clone());
         dict.insert(
             "default_word_cost".to_string(),
-            self.default_word_cost.to_string(),
+            self.inner.default_word_cost.to_string(),
         );
         dict.insert(
             "default_left_context_id".to_string(),
-            self.default_left_context_id.to_string(),
+            self.inner.default_left_context_id.to_string(),
         );
         dict.insert(
             "default_right_context_id".to_string(),
-            self.default_right_context_id.to_string(),
+            self.inner.default_right_context_id.to_string(),
         );
         dict.insert(
             "default_field_value".to_string(),
-            self.default_field_value.clone(),
+            self.inner.default_field_value.clone(),
         );
-        dict.insert("flexible_csv".to_string(), self.flexible_csv.to_string());
+        dict.insert(
+            "flexible_csv".to_string(),
+            self.inner.flexible_csv.to_string(),
+        );
         dict.insert(
             "skip_invalid_cost_or_id".to_string(),
-            self.skip_invalid_cost_or_id.to_string(),
+            self.inner.skip_invalid_cost_or_id.to_string(),
         );
         dict.insert(
             "normalize_details".to_string(),
-            self.normalize_details.to_string(),
+            self.inner.normalize_details.to_string(),
         );
         dict
     }
@@ -280,67 +262,21 @@ impl PhpMetadata {
     pub fn __to_string(&self) -> String {
         format!(
             "Metadata(name='{}', encoding='{}')",
-            self.name, self.encoding
+            self.inner.name, self.inner.encoding
         )
     }
 }
 
 impl From<PhpMetadata> for Metadata {
     fn from(metadata: PhpMetadata) -> Self {
-        let dict_schema = PhpSchema::__construct(metadata.dictionary_schema_fields);
-        let user_schema = PhpSchema::__construct(metadata.user_dictionary_schema_fields);
-
-        Metadata::new(
-            metadata.name,
-            metadata.encoding,
-            metadata.default_word_cost,
-            metadata.default_left_context_id,
-            metadata.default_right_context_id,
-            metadata.default_field_value,
-            metadata.flexible_csv,
-            metadata.skip_invalid_cost_or_id,
-            metadata.normalize_details,
-            dict_schema.into(),
-            user_schema.into(),
-        )
+        metadata.inner.into()
     }
 }
 
 impl From<Metadata> for PhpMetadata {
     fn from(metadata: Metadata) -> Self {
-        let dict_schema: PhpSchema = metadata.dictionary_schema.into();
-        let user_schema: PhpSchema = metadata.user_dictionary_schema.into();
-
         PhpMetadata {
-            name: metadata.name,
-            encoding: metadata.encoding,
-            default_word_cost: metadata.default_word_cost,
-            default_left_context_id: metadata.default_left_context_id,
-            default_right_context_id: metadata.default_right_context_id,
-            default_field_value: metadata.default_field_value,
-            flexible_csv: metadata.flexible_csv,
-            skip_invalid_cost_or_id: metadata.skip_invalid_cost_or_id,
-            normalize_details: metadata.normalize_details,
-            dictionary_schema_fields: dict_schema.fields,
-            user_dictionary_schema_fields: user_schema.fields,
-        }
-    }
-}
-
-impl Clone for PhpMetadata {
-    fn clone(&self) -> Self {
-        Self {
-            name: self.name.clone(),
-            encoding: self.encoding.clone(),
-            default_word_cost: self.default_word_cost,
-            default_left_context_id: self.default_left_context_id,
-            default_right_context_id: self.default_right_context_id,
-            default_field_value: self.default_field_value.clone(),
-            flexible_csv: self.flexible_csv,
-            skip_invalid_cost_or_id: self.skip_invalid_cost_or_id,
-            normalize_details: self.normalize_details,
-            dictionary_schema_fields: self.dictionary_schema_fields.clone(),
-            user_dictionary_schema_fields: self.user_dictionary_schema_fields.clone(),
+            inner: CoreMetadata::from(metadata),
         }
     }
 }
@@ -353,17 +289,17 @@ mod tests {
     #[test]
     fn test_phpmetadata_default_values() {
         let meta = PhpMetadata::create_default();
-        assert_eq!(meta.name, "default");
-        assert_eq!(meta.encoding, "UTF-8");
-        assert_eq!(meta.default_word_cost, -10000);
-        assert_eq!(meta.default_left_context_id, 1288);
-        assert_eq!(meta.default_right_context_id, 1288);
-        assert_eq!(meta.default_field_value, "*");
-        assert!(!meta.flexible_csv);
-        assert!(!meta.skip_invalid_cost_or_id);
-        assert!(!meta.normalize_details);
-        assert_eq!(meta.dictionary_schema_fields.len(), 13);
-        assert_eq!(meta.user_dictionary_schema_fields.len(), 3);
+        assert_eq!(meta.name(), "default");
+        assert_eq!(meta.encoding(), "UTF-8");
+        assert_eq!(meta.default_word_cost(), -10000);
+        assert_eq!(meta.default_left_context_id(), 1288);
+        assert_eq!(meta.default_right_context_id(), 1288);
+        assert_eq!(meta.default_field_value(), "*");
+        assert!(!meta.flexible_csv());
+        assert!(!meta.skip_invalid_cost_or_id());
+        assert!(!meta.normalize_details());
+        assert_eq!(meta.dictionary_schema_fields().len(), 13);
+        assert_eq!(meta.user_dictionary_schema_fields().len(), 3);
     }
 
     #[test]
@@ -381,9 +317,9 @@ mod tests {
         );
         let lindera_meta: Metadata = meta.into();
         let roundtripped: PhpMetadata = lindera_meta.into();
-        assert_eq!(roundtripped.name, "test");
-        assert_eq!(roundtripped.encoding, "UTF-8");
-        assert_eq!(roundtripped.default_word_cost, -5000);
-        assert!(roundtripped.flexible_csv);
+        assert_eq!(roundtripped.name(), "test");
+        assert_eq!(roundtripped.encoding(), "UTF-8");
+        assert_eq!(roundtripped.default_word_cost(), -5000);
+        assert!(roundtripped.flexible_csv());
     }
 }

--- a/lindera-php/src/schema.rs
+++ b/lindera-php/src/schema.rs
@@ -1,13 +1,13 @@
 //! Dictionary schema definitions for PHP.
 //!
 //! This module provides schema structures that define the format and fields
-//! of dictionary entries.
-
-use std::collections::HashMap;
+//! of dictionary entries. The field-management logic is delegated to
+//! [`lindera_binding_core::CoreSchema`]; this module only adds the ext-php-rs wrappers.
 
 use ext_php_rs::prelude::*;
 
 use lindera::dictionary::{FieldDefinition, FieldType, Schema};
+use lindera_binding_core::{CoreFieldDefinition, CoreSchema};
 
 use crate::error::lindera_value_err;
 
@@ -200,6 +200,18 @@ impl PhpFieldDefinition {
     }
 }
 
+impl From<CoreFieldDefinition> for PhpFieldDefinition {
+    fn from(fd: CoreFieldDefinition) -> Self {
+        let field_type: FieldType = fd.field_type.into();
+        Self {
+            index: fd.index,
+            name: fd.name,
+            field_type: PhpFieldType::from_field_type(&field_type).value,
+            description: fd.description,
+        }
+    }
+}
+
 impl From<FieldDefinition> for PhpFieldDefinition {
     fn from(fd: FieldDefinition) -> Self {
         let field_type = PhpFieldType::from_field_type(&fd.field_type);
@@ -228,14 +240,14 @@ impl From<PhpFieldDefinition> for FieldDefinition {
 
 /// Dictionary schema definition.
 ///
-/// Defines the structure and fields of dictionary entries.
+/// A thin ext-php-rs wrapper over [`lindera_binding_core::CoreSchema`], which owns
+/// the field storage, the name-to-index map, and the field lookups.
 #[php_class]
 #[php(name = "Lindera\\Schema")]
+#[derive(Clone)]
 pub struct PhpSchema {
-    /// List of field names.
-    pub fields: Vec<String>,
-    /// Index map for fast field lookup.
-    field_index_map: Option<HashMap<String, usize>>,
+    /// The backing binding-core schema.
+    inner: CoreSchema,
 }
 
 #[php_impl]
@@ -250,12 +262,9 @@ impl PhpSchema {
     ///
     /// A new Schema instance.
     pub fn __construct(fields: Vec<String>) -> Self {
-        let mut schema = Self {
-            fields,
-            field_index_map: None,
-        };
-        schema.build_index_map();
-        schema
+        Self {
+            inner: CoreSchema::new(fields),
+        }
     }
 
     /// Creates a default IPADIC 13-field schema.
@@ -264,7 +273,9 @@ impl PhpSchema {
     ///
     /// A Schema with the default 13 fields.
     pub fn create_default() -> Self {
-        Self::__construct(lindera_binding_core::schema::default_dictionary_fields())
+        Self {
+            inner: CoreSchema::create_default(),
+        }
     }
 
     /// Returns the list of all field names.
@@ -274,7 +285,7 @@ impl PhpSchema {
     /// A list of field name strings.
     #[php(getter)]
     pub fn fields(&self) -> Vec<String> {
-        self.fields.clone()
+        self.inner.fields().to_vec()
     }
 
     /// Returns the index of a field by name.
@@ -287,10 +298,9 @@ impl PhpSchema {
     ///
     /// The field index, or -1 if not found.
     pub fn get_field_index(&self, field_name: String) -> i64 {
-        self.field_index_map
-            .as_ref()
-            .and_then(|map| map.get(&field_name))
-            .map(|&i| i as i64)
+        self.inner
+            .get_field_index(&field_name)
+            .map(|i| i as i64)
             .unwrap_or(-1)
     }
 
@@ -300,7 +310,7 @@ impl PhpSchema {
     ///
     /// The field count.
     pub fn field_count(&self) -> i64 {
-        self.fields.len() as i64
+        self.inner.field_count() as i64
     }
 
     /// Returns the field name at the given index.
@@ -313,7 +323,9 @@ impl PhpSchema {
     ///
     /// The field name, or null if index is out of bounds.
     pub fn get_field_name(&self, index: i64) -> Option<String> {
-        self.fields.get(index as usize).cloned()
+        self.inner
+            .get_field_name(index as usize)
+            .map(str::to_string)
     }
 
     /// Returns custom fields (fields after the first 4 standard fields).
@@ -322,11 +334,7 @@ impl PhpSchema {
     ///
     /// A list of custom field name strings.
     pub fn get_custom_fields(&self) -> Vec<String> {
-        if self.fields.len() > 4 {
-            self.fields[4..].to_vec()
-        } else {
-            Vec::new()
-        }
+        self.inner.get_custom_fields().to_vec()
     }
 
     /// Returns all field names.
@@ -335,7 +343,7 @@ impl PhpSchema {
     ///
     /// A list of all field name strings.
     pub fn get_all_fields(&self) -> Vec<String> {
-        self.fields.clone()
+        self.inner.fields().to_vec()
     }
 
     /// Returns a field definition by name.
@@ -348,29 +356,9 @@ impl PhpSchema {
     ///
     /// A FieldDefinition instance, or null if not found.
     pub fn get_field_by_name(&self, name: String) -> Option<PhpFieldDefinition> {
-        let index = self
-            .field_index_map
-            .as_ref()
-            .and_then(|map| map.get(&name))?;
-
-        let field_type = if *index < 4 {
-            match *index {
-                0 => "surface",
-                1 => "left_context_id",
-                2 => "right_context_id",
-                3 => "cost",
-                _ => unreachable!(),
-            }
-        } else {
-            "custom"
-        };
-
-        Some(PhpFieldDefinition {
-            index: *index,
-            name,
-            field_type: field_type.to_string(),
-            description: None,
-        })
+        self.inner
+            .get_field_by_name(&name)
+            .map(PhpFieldDefinition::from)
     }
 
     /// Validates a CSV record against this schema.
@@ -383,7 +371,8 @@ impl PhpSchema {
     ///
     /// Nothing on success, throws on validation failure.
     pub fn validate_record(&self, record: Vec<String>) -> PhpResult<()> {
-        lindera_binding_core::schema::validate_record(&self.fields, &record)
+        self.inner
+            .validate_record(&record)
             .map_err(lindera_value_err)
     }
 
@@ -393,36 +382,33 @@ impl PhpSchema {
     ///
     /// A string describing the schema.
     pub fn __to_string(&self) -> String {
-        format!("Schema(fields={})", self.fields.len())
-    }
-}
-
-impl PhpSchema {
-    /// Builds the internal index map for fast field lookup.
-    fn build_index_map(&mut self) {
-        let mut map = HashMap::new();
-        for (i, field) in self.fields.iter().enumerate() {
-            map.insert(field.clone(), i);
-        }
-        self.field_index_map = Some(map);
-    }
-}
-
-impl Clone for PhpSchema {
-    fn clone(&self) -> Self {
-        Self::__construct(self.fields.clone())
+        format!("Schema(fields={})", self.inner.field_count())
     }
 }
 
 impl From<PhpSchema> for Schema {
     fn from(schema: PhpSchema) -> Self {
-        Schema::new(schema.fields)
+        schema.inner.into()
     }
 }
 
 impl From<Schema> for PhpSchema {
     fn from(schema: Schema) -> Self {
-        PhpSchema::__construct(schema.get_all_fields().to_vec())
+        PhpSchema {
+            inner: CoreSchema::from(schema),
+        }
+    }
+}
+
+impl From<CoreSchema> for PhpSchema {
+    fn from(schema: CoreSchema) -> Self {
+        PhpSchema { inner: schema }
+    }
+}
+
+impl From<PhpSchema> for CoreSchema {
+    fn from(schema: PhpSchema) -> Self {
+        schema.inner
     }
 }
 
@@ -434,9 +420,10 @@ mod tests {
     #[test]
     fn test_phpschema_create_default_has_13_fields() {
         let schema = PhpSchema::create_default();
-        assert_eq!(schema.fields.len(), 13);
-        assert_eq!(schema.fields[0], "surface");
-        assert_eq!(schema.fields[12], "pronunciation");
+        assert_eq!(schema.fields().len(), 13);
+        assert_eq!(schema.fields()[0], "surface");
+        assert_eq!(schema.fields()[5], "middle_pos");
+        assert_eq!(schema.fields()[12], "pronunciation");
     }
 
     #[test]
@@ -445,6 +432,20 @@ mod tests {
         assert_eq!(schema.get_field_index("surface".to_string()), 0);
         assert_eq!(schema.get_field_index("cost".to_string()), 1);
         assert_eq!(schema.get_field_index("nonexistent".to_string()), -1);
+    }
+
+    #[test]
+    fn test_phpschema_get_field_by_name() {
+        let schema = PhpSchema::create_default();
+        let surface = schema.get_field_by_name("surface".to_string()).unwrap();
+        assert_eq!(surface.index, 0);
+        assert_eq!(surface.field_type, "surface");
+
+        let custom = schema.get_field_by_name("middle_pos".to_string()).unwrap();
+        assert_eq!(custom.index, 5);
+        assert_eq!(custom.field_type, "custom");
+
+        assert!(schema.get_field_by_name("nope".to_string()).is_none());
     }
 
     #[test]
@@ -459,7 +460,7 @@ mod tests {
         let php_schema = PhpSchema::__construct(fields.clone());
         let schema: Schema = php_schema.into();
         let roundtripped: PhpSchema = schema.into();
-        assert_eq!(roundtripped.fields, fields);
+        assert_eq!(roundtripped.fields(), fields);
     }
 
     #[test]

--- a/lindera-php/src/token.rs
+++ b/lindera-php/src/token.rs
@@ -145,8 +145,19 @@ impl PhpToken {
     ///
     /// A new PhpToken instance.
     pub fn from_token(token: Token) -> Self {
-        let view = lindera_binding_core::TokenView::from_token(token);
+        Self::from_view(lindera_binding_core::TokenView::from_token(token))
+    }
 
+    /// Creates a PhpToken from a binding-core `TokenView`.
+    ///
+    /// # Arguments
+    ///
+    /// * `view` - Token view produced by the binding-core tokenizer.
+    ///
+    /// # Returns
+    ///
+    /// A new PhpToken instance.
+    pub fn from_view(view: lindera_binding_core::TokenView) -> Self {
         Self {
             surface: view.surface,
             byte_start: view.byte_start,

--- a/lindera-php/src/tokenizer.rs
+++ b/lindera-php/src/tokenizer.rs
@@ -1,17 +1,17 @@
 //! Tokenizer implementation for morphological analysis in PHP.
 //!
 //! This module provides a builder pattern for creating tokenizers and the tokenizer itself.
+//! The build-flow orchestration is delegated to
+//! [`lindera_binding_core::CoreTokenizerBuilder`] / [`lindera_binding_core::CoreTokenizer`];
+//! this module only adds the ext-php-rs wrappers and the Zval conversion.
 
 use std::cell::RefCell;
 use std::path::Path;
-use std::str::FromStr;
 
 use ext_php_rs::prelude::*;
 use ext_php_rs::types::Zval;
 
-use lindera::mode::Mode;
-use lindera::segmenter::Segmenter;
-use lindera::tokenizer::{Tokenizer, TokenizerBuilder};
+use lindera_binding_core::{CoreTokenizer, CoreTokenizerBuilder};
 
 use crate::convert::zval_to_value;
 use crate::dictionary::{PhpDictionary, PhpUserDictionary};
@@ -26,7 +26,7 @@ use crate::token::PhpToken;
 #[php(name = "Lindera\\TokenizerBuilder")]
 pub struct PhpTokenizerBuilder {
     /// The inner builder (wrapped in RefCell for interior mutability).
-    inner: RefCell<TokenizerBuilder>,
+    inner: RefCell<CoreTokenizerBuilder>,
 }
 
 #[php_impl]
@@ -37,10 +37,7 @@ impl PhpTokenizerBuilder {
     ///
     /// A new TokenizerBuilder instance.
     pub fn __construct() -> PhpResult<Self> {
-        let inner = TokenizerBuilder::new().map_err(|err| {
-            lindera_value_err(format!("Failed to create TokenizerBuilder: {err}"))
-        })?;
-
+        let inner = CoreTokenizerBuilder::new().map_err(lindera_value_err)?;
         Ok(Self {
             inner: RefCell::new(inner),
         })
@@ -52,9 +49,8 @@ impl PhpTokenizerBuilder {
     ///
     /// * `file_path` - Path to the configuration file.
     pub fn from_file(&self, file_path: String) -> PhpResult<()> {
-        let builder = TokenizerBuilder::from_file(Path::new(&file_path))
-            .map_err(|err| lindera_value_err(format!("Failed to load config from file: {err}")))?;
-
+        let builder =
+            CoreTokenizerBuilder::from_file(Path::new(&file_path)).map_err(lindera_value_err)?;
         *self.inner.borrow_mut() = builder;
         Ok(())
     }
@@ -65,10 +61,8 @@ impl PhpTokenizerBuilder {
     ///
     /// * `mode` - Mode string ("normal" or "decompose").
     pub fn set_mode(&self, mode: String) -> PhpResult<()> {
-        let m = Mode::from_str(&mode)
-            .map_err(|err| lindera_value_err(format!("Failed to create mode: {err}")))?;
-
-        self.inner.borrow_mut().set_segmenter_mode(&m);
+        let mut builder = self.inner.borrow_mut();
+        builder.set_mode(&mode).map_err(lindera_value_err)?;
         Ok(())
     }
 
@@ -78,7 +72,7 @@ impl PhpTokenizerBuilder {
     ///
     /// * `path` - Path to the dictionary directory or embedded dictionary name.
     pub fn set_dictionary(&self, path: String) -> PhpResult<()> {
-        self.inner.borrow_mut().set_segmenter_dictionary(&path);
+        self.inner.borrow_mut().set_dictionary(&path);
         Ok(())
     }
 
@@ -88,7 +82,7 @@ impl PhpTokenizerBuilder {
     ///
     /// * `uri` - URI to the user dictionary.
     pub fn set_user_dictionary(&self, uri: String) -> PhpResult<()> {
-        self.inner.borrow_mut().set_segmenter_user_dictionary(&uri);
+        self.inner.borrow_mut().set_user_dictionary(&uri);
         Ok(())
     }
 
@@ -98,9 +92,7 @@ impl PhpTokenizerBuilder {
     ///
     /// * `keep_whitespace` - If true, whitespace tokens will be included.
     pub fn set_keep_whitespace(&self, keep_whitespace: bool) -> PhpResult<()> {
-        self.inner
-            .borrow_mut()
-            .set_segmenter_keep_whitespace(keep_whitespace);
+        self.inner.borrow_mut().set_keep_whitespace(keep_whitespace);
         Ok(())
     }
 
@@ -148,13 +140,8 @@ impl PhpTokenizerBuilder {
     ///
     /// A configured Tokenizer instance ready for use.
     pub fn build(&self) -> PhpResult<PhpTokenizer> {
-        let tokenizer = self
-            .inner
-            .borrow()
-            .build()
-            .map_err(|err| lindera_value_err(format!("Failed to build tokenizer: {err}")))?;
-
-        Ok(PhpTokenizer { inner: tokenizer })
+        let inner = self.inner.borrow().build().map_err(lindera_value_err)?;
+        Ok(PhpTokenizer { inner })
     }
 }
 
@@ -164,8 +151,8 @@ impl PhpTokenizerBuilder {
 #[php_class]
 #[php(name = "Lindera\\Tokenizer")]
 pub struct PhpTokenizer {
-    /// The inner Lindera tokenizer.
-    inner: Tokenizer,
+    /// The inner binding-core tokenizer.
+    inner: CoreTokenizer,
 }
 
 #[php_impl]
@@ -187,16 +174,14 @@ impl PhpTokenizer {
         user_dictionary: Option<&PhpUserDictionary>,
     ) -> PhpResult<Self> {
         let mode_str = mode.unwrap_or_else(|| "normal".to_string());
-        let m = Mode::from_str(&mode_str)
-            .map_err(|err| lindera_value_err(format!("Failed to create mode: {err}")))?;
 
         let dict = dictionary.inner.clone();
         let user_dict = user_dictionary.map(|d| d.inner.clone());
 
-        let segmenter = Segmenter::new(m, dict, user_dict);
-        let tokenizer = Tokenizer::new(segmenter);
+        let inner =
+            CoreTokenizer::from_segmenter(&mode_str, dict, user_dict).map_err(lindera_value_err)?;
 
-        Ok(Self { inner: tokenizer })
+        Ok(Self { inner })
     }
 
     /// Tokenizes the given text.
@@ -209,14 +194,8 @@ impl PhpTokenizer {
     ///
     /// A list of Token objects containing morphological features.
     pub fn tokenize(&self, text: String) -> PhpResult<Vec<PhpToken>> {
-        let tokens = self
-            .inner
-            .tokenize(&text)
-            .map_err(|err| lindera_value_err(format!("Failed to tokenize text: {err}")))?;
-
-        let php_tokens: Vec<PhpToken> = tokens.into_iter().map(PhpToken::from_token).collect();
-
-        Ok(php_tokens)
+        let views = self.inner.tokenize(&text).map_err(lindera_value_err)?;
+        Ok(views.into_iter().map(PhpToken::from_view).collect())
     }
 
     /// Tokenizes the given text and returns N-best results.
@@ -234,7 +213,7 @@ impl PhpTokenizer {
     ///
     /// # Returns
     ///
-    /// A Zval containing an array of {"tokens": [...], "cost": int} entries.
+    /// A list of NbestResult entries.
     pub fn tokenize_nbest(
         &self,
         text: String,
@@ -246,12 +225,12 @@ impl PhpTokenizer {
         let results = self
             .inner
             .tokenize_nbest(&text, n as usize, unique_flag, cost_threshold)
-            .map_err(|err| lindera_value_err(format!("Failed to tokenize_nbest text: {err}")))?;
+            .map_err(lindera_value_err)?;
 
         let php_results: Vec<PhpNbestResult> = results
             .into_iter()
-            .map(|(tokens, cost)| {
-                let php_tokens = tokens.into_iter().map(PhpToken::from_token).collect();
+            .map(|(views, cost)| {
+                let php_tokens = views.into_iter().map(PhpToken::from_view).collect();
                 PhpNbestResult {
                     tokens: php_tokens,
                     cost,


### PR DESCRIPTION
# Migrate lindera-php to the full lindera-binding-core facade (#717)

Part of #708 (Phase 6 / v4.0.0). Refs #717. Applies the pattern established by #714/#715/#716.

## Summary

Reduce the ext-php-rs wrappers to thin adapters over the binding-core facade
(`CoreSchema`/`CoreMetadata`/`CoreTokenizer`/`CoreError`). **The PHP API is preserved exactly.**

## What changed

- `token.rs`: add `PhpToken::from_view(TokenView)`.
- `schema.rs`: `PhpSchema` wraps `CoreSchema`; `PhpFieldDefinition` converts from
  `CoreFieldDefinition` (`PhpFieldType` stays string-based).
- `metadata.rs`: `PhpMetadata` wraps `CoreMetadata`.
- `tokenizer.rs`: `PhpTokenizerBuilder` / `PhpTokenizer` wrap the core builder/tokenizer (`RefCell`
  retained); the `Zval` → `serde_json::Value` conversion stays in `convert.rs`. `error.rs` is
  unchanged (`lindera_err` / `lindera_value_err` accept the `CoreError` message via `Display`).

Out of scope: `Token.details` stays `Vec<String>` (details-type unification is #719); the
unregistered `segmenter` class is left to #733.

## Verification

- `cargo test -p lindera-php --lib`: 10 passed
- `cargo fmt -p lindera-php -- --check`: clean
- `cargo clippy -p lindera-php --all-targets -- -D warnings`: exit 0 (only the pre-existing
  `ext-php-rs-clang-sys` dependency warnings remain)
- `make test-lindera-php` (build + PHPUnit): **25 tests, 69 assertions, OK**
