### PR TITLE
refactor(bindings)!: unify default schema field names on pos_detail_*

### DIFF
--- a/lindera-binding-core/src/metadata.rs
+++ b/lindera-binding-core/src/metadata.rs
@@ -168,9 +168,9 @@ mod tests {
         assert!(!m.flexible_csv);
         assert!(!m.skip_invalid_cost_or_id);
         assert!(!m.normalize_details);
-        // Binding default keeps `middle_pos` naming (unification tracked in #720).
+        // The default dictionary schema uses the unified `pos_detail_*` names.
         assert_eq!(m.dictionary_schema.field_count(), 13);
-        assert_eq!(m.dictionary_schema.fields()[5], "middle_pos");
+        assert_eq!(m.dictionary_schema.fields()[5], "pos_detail_1");
         assert_eq!(m.user_dictionary_schema.fields().len(), 3);
         assert_eq!(m.user_dictionary_schema.fields()[1], "reading");
     }
@@ -209,6 +209,6 @@ mod tests {
 
         let back: CoreMetadata = lindera.into();
         assert_eq!(back.name, "default");
-        assert_eq!(back.dictionary_schema.fields()[5], "middle_pos");
+        assert_eq!(back.dictionary_schema.fields()[5], "pos_detail_1");
     }
 }

--- a/lindera-binding-core/src/schema.rs
+++ b/lindera-binding-core/src/schema.rs
@@ -8,16 +8,13 @@ use lindera::dictionary::{FieldDefinition, FieldType, Schema};
 
 use crate::error::{CoreError, CoreResult};
 
-/// Default dictionary schema field names used by the Python/PHP/Ruby/Node.js
-/// bindings' `Schema.create_default()`.
+/// Default dictionary schema field names shared by all bindings'
+/// `Schema.create_default()`.
 ///
-/// NOTE: these intentionally differ from
-/// [`lindera::dictionary::Schema::default()`], which uses
-/// `pos_detail_1/2/3` where these use `middle_pos/small_pos/fine_pos`. The
-/// WASM binding uses `Schema::default()`, so the two field-naming schemes
-/// currently diverge — a pre-existing API inconsistency left for a later
-/// reconciliation. This function preserves the historical
-/// Python/PHP/Ruby/Node.js naming exactly.
+/// These match [`lindera::dictionary::Schema::default()`] exactly, including the
+/// `pos_detail_1/2/3` POS-detail field names. (Earlier the Python/PHP/Ruby/Node.js
+/// bindings used `middle_pos/small_pos/fine_pos` while WASM used `pos_detail_*`;
+/// that inconsistency was reconciled onto `pos_detail_*` in v4.0.0.)
 pub fn default_dictionary_fields() -> Vec<String> {
     [
         "surface",
@@ -25,9 +22,9 @@ pub fn default_dictionary_fields() -> Vec<String> {
         "right_context_id",
         "cost",
         "major_pos",
-        "middle_pos",
-        "small_pos",
-        "fine_pos",
+        "pos_detail_1",
+        "pos_detail_2",
+        "pos_detail_3",
         "conjugation_type",
         "conjugation_form",
         "base_form",
@@ -252,7 +249,7 @@ mod tests {
     fn default_fields_count() {
         assert_eq!(default_dictionary_fields().len(), 13);
         assert_eq!(default_dictionary_fields()[0], "surface");
-        assert_eq!(default_dictionary_fields()[5], "middle_pos");
+        assert_eq!(default_dictionary_fields()[5], "pos_detail_1");
     }
 
     #[test]
@@ -313,14 +310,18 @@ mod tests {
     }
 
     #[test]
-    fn core_schema_default_matches_binding_fields() {
+    fn core_schema_default_matches_lindera() {
         let schema = CoreSchema::create_default();
         assert_eq!(schema.field_count(), 13);
         assert_eq!(schema.fields()[0], "surface");
-        // Binding default uses `middle_pos` (not lindera's `pos_detail_1`); the
-        // unification is tracked separately and intentionally not done here.
-        assert_eq!(schema.fields()[5], "middle_pos");
+        // The default now matches `lindera::dictionary::Schema::default()`,
+        // including the `pos_detail_*` POS-detail names (unified in v4.0.0).
+        assert_eq!(schema.fields()[5], "pos_detail_1");
         assert_eq!(schema.fields()[12], "pronunciation");
+        assert_eq!(
+            schema.fields(),
+            lindera::dictionary::Schema::default().get_all_fields()
+        );
     }
 
     #[test]

--- a/lindera-nodejs/src/schema.rs
+++ b/lindera-nodejs/src/schema.rs
@@ -347,7 +347,7 @@ mod tests {
         let schema = JsSchema::create_default();
         assert_eq!(schema.field_count(), 13);
         assert_eq!(schema.get_field_index("surface".to_string()), Some(0));
-        assert_eq!(schema.fields()[5], "middle_pos");
+        assert_eq!(schema.fields()[5], "pos_detail_1");
         assert_eq!(
             schema.get_field_index("pronunciation".to_string()),
             Some(12)
@@ -361,7 +361,9 @@ mod tests {
         assert_eq!(surface.index, 0);
         assert!(matches!(surface.field_type, JsFieldType::Surface));
 
-        let custom = schema.get_field_by_name("middle_pos".to_string()).unwrap();
+        let custom = schema
+            .get_field_by_name("pos_detail_1".to_string())
+            .unwrap();
         assert_eq!(custom.index, 5);
         assert!(matches!(custom.field_type, JsFieldType::Custom));
 

--- a/lindera-php/src/schema.rs
+++ b/lindera-php/src/schema.rs
@@ -422,7 +422,7 @@ mod tests {
         let schema = PhpSchema::create_default();
         assert_eq!(schema.fields().len(), 13);
         assert_eq!(schema.fields()[0], "surface");
-        assert_eq!(schema.fields()[5], "middle_pos");
+        assert_eq!(schema.fields()[5], "pos_detail_1");
         assert_eq!(schema.fields()[12], "pronunciation");
     }
 
@@ -441,7 +441,9 @@ mod tests {
         assert_eq!(surface.index, 0);
         assert_eq!(surface.field_type, "surface");
 
-        let custom = schema.get_field_by_name("middle_pos".to_string()).unwrap();
+        let custom = schema
+            .get_field_by_name("pos_detail_1".to_string())
+            .unwrap();
         assert_eq!(custom.index, 5);
         assert_eq!(custom.field_type, "custom");
 

--- a/lindera-python/src/schema.rs
+++ b/lindera-python/src/schema.rs
@@ -427,7 +427,7 @@ mod tests {
         let schema = PySchema::create_default();
         assert_eq!(schema.field_count(), 13);
         assert_eq!(schema.fields()[0], "surface");
-        assert_eq!(schema.fields()[5], "middle_pos");
+        assert_eq!(schema.fields()[5], "pos_detail_1");
         assert_eq!(schema.fields()[12], "pronunciation");
         assert_eq!(schema.get_field_index("cost"), Some(3));
     }

--- a/lindera-ruby/src/schema.rs
+++ b/lindera-ruby/src/schema.rs
@@ -478,7 +478,7 @@ mod tests {
         assert_eq!(schema.field_count(), 13);
         assert_eq!(schema.fields()[0], "surface");
         assert_eq!(schema.fields()[3], "cost");
-        assert_eq!(schema.fields()[5], "middle_pos");
+        assert_eq!(schema.fields()[5], "pos_detail_1");
     }
 
     #[test]
@@ -488,7 +488,9 @@ mod tests {
         assert_eq!(surface.index, 0);
         assert!(matches!(surface.field_type.inner, RbFieldTypeKind::Surface));
 
-        let custom = schema.get_field_by_name("middle_pos".to_string()).unwrap();
+        let custom = schema
+            .get_field_by_name("pos_detail_1".to_string())
+            .unwrap();
         assert_eq!(custom.index, 5);
         assert!(matches!(custom.field_type.inner, RbFieldTypeKind::Custom));
 

--- a/lindera-wasm/src/dictionary.rs
+++ b/lindera-wasm/src/dictionary.rs
@@ -35,9 +35,7 @@ impl JsDictionary {
 
     #[wasm_bindgen(getter)]
     pub fn metadata(&self) -> JsMetadata {
-        JsMetadata {
-            inner: self.inner.metadata.clone(),
-        }
+        JsMetadata::from(self.inner.metadata.clone())
     }
 }
 
@@ -64,8 +62,9 @@ pub fn load_dictionary(uri: &str) -> Result<JsDictionary, JsValue> {
 /// Loads a user dictionary from the specified URI.
 #[wasm_bindgen(js_name = "loadUserDictionary")]
 pub fn load_user_dictionary(uri: &str, metadata: JsMetadata) -> Result<JsUserDictionary, JsValue> {
-    let dict = lindera_load_user_dictionary(uri, &metadata.inner)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let meta: Metadata = metadata.into();
+    let dict =
+        lindera_load_user_dictionary(uri, &meta).map_err(|e| JsValue::from_str(&e.to_string()))?;
     Ok(JsUserDictionary { inner: dict })
 }
 
@@ -76,7 +75,8 @@ pub fn build_dictionary(
     output_dir: &str,
     metadata: JsMetadata,
 ) -> Result<(), JsValue> {
-    let builder = DictionaryBuilder::new(metadata.inner);
+    let meta: Metadata = metadata.into();
+    let builder = DictionaryBuilder::new(meta);
     builder
         .build_dictionary(Path::new(input_dir), Path::new(output_dir))
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
@@ -151,7 +151,7 @@ pub fn build_user_dictionary(
     output_dir: &str,
     metadata: Option<JsMetadata>,
 ) -> Result<(), JsValue> {
-    let meta = metadata.map(|m| m.inner).unwrap_or_default();
+    let meta: Metadata = metadata.map(Into::into).unwrap_or_default();
     let builder = DictionaryBuilder::new(meta);
     builder
         .build_user_dictionary(Path::new(input_file), Path::new(output_dir))

--- a/lindera-wasm/src/metadata.rs
+++ b/lindera-wasm/src/metadata.rs
@@ -1,34 +1,36 @@
 use wasm_bindgen::prelude::*;
 
 use lindera::dictionary::Metadata;
+use lindera_binding_core::CoreMetadata;
 
 use crate::schema::JsSchema;
 
 /// Dictionary metadata configuration.
+///
+/// A thin wasm-bindgen wrapper over [`lindera_binding_core::CoreMetadata`], which
+/// owns the default values and the schema wiring.
 #[wasm_bindgen(js_name = "Metadata")]
 #[derive(Clone)]
 pub struct JsMetadata {
-    pub(crate) inner: Metadata,
+    /// The backing binding-core metadata.
+    pub(crate) inner: CoreMetadata,
 }
 
 #[wasm_bindgen]
 impl JsMetadata {
     #[wasm_bindgen(constructor)]
     pub fn new(name: Option<String>, encoding: Option<String>) -> Self {
-        let mut inner = Metadata::default();
-        if let Some(n) = name {
-            inner.name = n;
+        Self {
+            inner: CoreMetadata::new(
+                name, encoding, None, None, None, None, None, None, None, None, None,
+            ),
         }
-        if let Some(e) = encoding {
-            inner.encoding = e;
-        }
-        Self { inner }
     }
 
     #[wasm_bindgen(js_name = "createDefault")]
     pub fn create_default() -> Self {
         Self {
-            inner: Metadata::default(),
+            inner: CoreMetadata::create_default(),
         }
     }
 
@@ -54,38 +56,36 @@ impl JsMetadata {
 
     #[wasm_bindgen(getter)]
     pub fn dictionary_schema(&self) -> JsSchema {
-        JsSchema {
-            inner: self.inner.dictionary_schema.clone(),
-        }
+        JsSchema::from(self.inner.dictionary_schema.clone())
     }
 
     #[wasm_bindgen(setter)]
     pub fn set_dictionary_schema(&mut self, schema: JsSchema) {
-        self.inner.dictionary_schema = schema.inner;
+        self.inner.dictionary_schema = schema.into();
     }
 
     #[wasm_bindgen(getter)]
     pub fn user_dictionary_schema(&self) -> JsSchema {
-        JsSchema {
-            inner: self.inner.user_dictionary_schema.clone(),
-        }
+        JsSchema::from(self.inner.user_dictionary_schema.clone())
     }
 
     #[wasm_bindgen(setter)]
     pub fn set_user_dictionary_schema(&mut self, schema: JsSchema) {
-        self.inner.user_dictionary_schema = schema.inner;
+        self.inner.user_dictionary_schema = schema.into();
     }
 }
 
 impl From<Metadata> for JsMetadata {
     fn from(metadata: Metadata) -> Self {
-        JsMetadata { inner: metadata }
+        JsMetadata {
+            inner: CoreMetadata::from(metadata),
+        }
     }
 }
 
 impl From<JsMetadata> for Metadata {
     fn from(metadata: JsMetadata) -> Self {
-        metadata.inner
+        metadata.inner.into()
     }
 }
 

--- a/lindera-wasm/src/schema.rs
+++ b/lindera-wasm/src/schema.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use lindera::dictionary::{FieldDefinition, FieldType, Schema};
+use lindera_binding_core::{CoreFieldDefinition, CoreFieldType, CoreSchema};
 
 /// Field type in dictionary schema.
 #[wasm_bindgen(js_name = "FieldType")]
@@ -18,27 +19,39 @@ pub enum JsFieldType {
     Custom,
 }
 
+impl From<CoreFieldType> for JsFieldType {
+    fn from(field_type: CoreFieldType) -> Self {
+        match field_type {
+            CoreFieldType::Surface => JsFieldType::Surface,
+            CoreFieldType::LeftContextId => JsFieldType::LeftContextId,
+            CoreFieldType::RightContextId => JsFieldType::RightContextId,
+            CoreFieldType::Cost => JsFieldType::Cost,
+            CoreFieldType::Custom => JsFieldType::Custom,
+        }
+    }
+}
+
+impl From<JsFieldType> for CoreFieldType {
+    fn from(field_type: JsFieldType) -> Self {
+        match field_type {
+            JsFieldType::Surface => CoreFieldType::Surface,
+            JsFieldType::LeftContextId => CoreFieldType::LeftContextId,
+            JsFieldType::RightContextId => CoreFieldType::RightContextId,
+            JsFieldType::Cost => CoreFieldType::Cost,
+            JsFieldType::Custom => CoreFieldType::Custom,
+        }
+    }
+}
+
 impl From<FieldType> for JsFieldType {
     fn from(field_type: FieldType) -> Self {
-        match field_type {
-            FieldType::Surface => JsFieldType::Surface,
-            FieldType::LeftContextId => JsFieldType::LeftContextId,
-            FieldType::RightContextId => JsFieldType::RightContextId,
-            FieldType::Cost => JsFieldType::Cost,
-            FieldType::Custom => JsFieldType::Custom,
-        }
+        JsFieldType::from(CoreFieldType::from(field_type))
     }
 }
 
 impl From<JsFieldType> for FieldType {
     fn from(field_type: JsFieldType) -> Self {
-        match field_type {
-            JsFieldType::Surface => FieldType::Surface,
-            JsFieldType::LeftContextId => FieldType::LeftContextId,
-            JsFieldType::RightContextId => FieldType::RightContextId,
-            JsFieldType::Cost => FieldType::Cost,
-            JsFieldType::Custom => FieldType::Custom,
-        }
+        FieldType::from(CoreFieldType::from(field_type))
     }
 }
 
@@ -72,8 +85,8 @@ impl JsFieldDefinition {
     }
 }
 
-impl From<FieldDefinition> for JsFieldDefinition {
-    fn from(field_def: FieldDefinition) -> Self {
+impl From<CoreFieldDefinition> for JsFieldDefinition {
+    fn from(field_def: CoreFieldDefinition) -> Self {
         JsFieldDefinition {
             index: field_def.index,
             name: field_def.name,
@@ -83,9 +96,9 @@ impl From<FieldDefinition> for JsFieldDefinition {
     }
 }
 
-impl From<JsFieldDefinition> for FieldDefinition {
+impl From<JsFieldDefinition> for CoreFieldDefinition {
     fn from(field_def: JsFieldDefinition) -> Self {
-        FieldDefinition {
+        CoreFieldDefinition {
             index: field_def.index,
             name: field_def.name,
             field_type: field_def.field_type.into(),
@@ -94,11 +107,27 @@ impl From<JsFieldDefinition> for FieldDefinition {
     }
 }
 
+impl From<FieldDefinition> for JsFieldDefinition {
+    fn from(field_def: FieldDefinition) -> Self {
+        JsFieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
+impl From<JsFieldDefinition> for FieldDefinition {
+    fn from(field_def: JsFieldDefinition) -> Self {
+        FieldDefinition::from(CoreFieldDefinition::from(field_def))
+    }
+}
+
 /// Dictionary schema definition.
+///
+/// A thin wasm-bindgen wrapper over [`lindera_binding_core::CoreSchema`], which
+/// owns the field storage, the name-to-index map, and the field lookups.
 #[wasm_bindgen(js_name = "Schema")]
 #[derive(Clone)]
 pub struct JsSchema {
-    pub(crate) inner: Schema,
+    /// The backing binding-core schema.
+    pub(crate) inner: CoreSchema,
 }
 
 #[wasm_bindgen]
@@ -106,13 +135,13 @@ impl JsSchema {
     #[wasm_bindgen(constructor)]
     pub fn new(fields: Vec<String>) -> Self {
         Self {
-            inner: Schema::new(fields),
+            inner: CoreSchema::new(fields),
         }
     }
 
     pub fn create_default() -> Self {
         Self {
-            inner: Schema::default(),
+            inner: CoreSchema::create_default(),
         }
     }
 
@@ -121,59 +150,51 @@ impl JsSchema {
     }
 
     pub fn field_count(&self) -> usize {
-        self.inner.get_all_fields().len()
+        self.inner.field_count()
     }
 
     pub fn get_field_name(&self, index: usize) -> Option<String> {
-        self.inner.get_all_fields().get(index).cloned()
+        self.inner.get_field_name(index).map(str::to_string)
     }
 
     pub fn get_custom_fields(&self) -> Vec<String> {
-        let fields = self.inner.get_all_fields();
-        if fields.len() > 4 {
-            fields[4..].to_vec()
-        } else {
-            Vec::new()
-        }
+        self.inner.get_custom_fields().to_vec()
     }
 
     pub fn get_all_fields(&self) -> Vec<String> {
-        self.inner.get_all_fields().to_vec()
+        self.inner.fields().to_vec()
     }
 
     pub fn get_field_by_name(&self, name: &str) -> Option<JsFieldDefinition> {
-        self.get_field_index(name).map(|index| {
-            let field_type = if index < 4 {
-                match index {
-                    0 => JsFieldType::Surface,
-                    1 => JsFieldType::LeftContextId,
-                    2 => JsFieldType::RightContextId,
-                    3 => JsFieldType::Cost,
-                    _ => unreachable!(),
-                }
-            } else {
-                JsFieldType::Custom
-            };
+        self.inner
+            .get_field_by_name(name)
+            .map(JsFieldDefinition::from)
+    }
+}
 
-            JsFieldDefinition {
-                index,
-                name: name.to_string(),
-                field_type,
-                description: None,
-            }
-        })
+impl From<CoreSchema> for JsSchema {
+    fn from(schema: CoreSchema) -> Self {
+        JsSchema { inner: schema }
+    }
+}
+
+impl From<JsSchema> for CoreSchema {
+    fn from(schema: JsSchema) -> Self {
+        schema.inner
     }
 }
 
 impl From<Schema> for JsSchema {
     fn from(schema: Schema) -> Self {
-        JsSchema { inner: schema }
+        JsSchema {
+            inner: CoreSchema::from(schema),
+        }
     }
 }
 
 impl From<JsSchema> for Schema {
     fn from(schema: JsSchema) -> Self {
-        schema.inner
+        schema.inner.into()
     }
 }
 
@@ -212,23 +233,13 @@ mod tests {
         ];
         let schema = JsSchema::new(fields.clone());
 
-        // field_count
         assert_eq!(schema.field_count(), 6);
-
-        // get_field_index
         assert_eq!(schema.get_field_index("surface"), Some(0));
         assert_eq!(schema.get_field_index("pos"), Some(4));
         assert_eq!(schema.get_field_index("nonexistent"), None);
-
-        // get_field_name
         assert_eq!(schema.get_field_name(0), Some("surface".to_string()));
         assert_eq!(schema.get_field_name(999), None);
-
-        // get_all_fields
-        let all = schema.get_all_fields();
-        assert_eq!(all, fields);
-
-        // get_custom_fields (fields beyond index 3)
+        assert_eq!(schema.get_all_fields(), fields);
         let custom = schema.get_custom_fields();
         assert_eq!(custom, vec!["pos".to_string(), "reading".to_string()]);
     }
@@ -245,18 +256,15 @@ mod tests {
         ];
         let schema = JsSchema::new(fields);
 
-        // Built-in field
         let surface_field = schema.get_field_by_name("surface").unwrap();
         assert_eq!(surface_field.index, 0);
         assert_eq!(surface_field.name, "surface");
         assert!(matches!(surface_field.field_type, JsFieldType::Surface));
 
-        // Custom field
         let pos_field = schema.get_field_by_name("pos").unwrap();
         assert_eq!(pos_field.index, 4);
         assert!(matches!(pos_field.field_type, JsFieldType::Custom));
 
-        // Non-existent field
         assert!(schema.get_field_by_name("nonexistent").is_none());
     }
 
@@ -325,6 +333,7 @@ mod tests {
         assert_eq!(schema.get_field_index("right_context_id"), Some(2));
         assert_eq!(schema.get_field_index("cost"), Some(3));
         assert_eq!(schema.get_field_index("major_pos"), Some(4));
+        assert_eq!(schema.get_field_index("pos_detail_1"), Some(5));
         assert_eq!(schema.get_field_index("pronunciation"), Some(12));
     }
 
@@ -349,13 +358,6 @@ mod tests {
         assert!(matches!(
             left_id_field.field_type,
             JsFieldType::LeftContextId
-        ));
-
-        let right_id_field = schema.get_field_by_name("right_id").unwrap();
-        assert_eq!(right_id_field.index, 2);
-        assert!(matches!(
-            right_id_field.field_type,
-            JsFieldType::RightContextId
         ));
 
         let cost_field = schema.get_field_by_name("cost").unwrap();
@@ -395,21 +397,6 @@ mod tests {
     }
 
     #[test]
-    fn test_field_definition_new() {
-        let field = JsFieldDefinition::new(
-            0,
-            "surface".to_string(),
-            JsFieldType::Surface,
-            Some("Surface form".to_string()),
-        );
-
-        assert_eq!(field.index, 0);
-        assert_eq!(field.name, "surface");
-        assert!(matches!(field.field_type, JsFieldType::Surface));
-        assert_eq!(field.description, Some("Surface form".to_string()));
-    }
-
-    #[test]
     fn test_field_definition_from_into_conversions() {
         let js_field = JsFieldDefinition::new(
             4,
@@ -422,10 +409,6 @@ mod tests {
         assert_eq!(lindera_field.index, 4);
         assert_eq!(lindera_field.name, "pos");
         assert!(matches!(lindera_field.field_type, FieldType::Custom));
-        assert_eq!(
-            lindera_field.description,
-            Some("Part of speech".to_string())
-        );
 
         let back: JsFieldDefinition = lindera_field.into();
         assert_eq!(back.index, 4);


### PR DESCRIPTION
## Summary

Converge all bindings onto the `pos_detail_1/2/3` POS-detail field names so that
`Schema.create_default()` matches `lindera::dictionary::Schema::default()` across
**every** binding.

Previously the Python/PHP/Ruby/Node.js bindings used `middle_pos/small_pos/fine_pos`
for fields 5–7 of the default dictionary schema, while the WASM binding used
`pos_detail_1/2/3` (because it wrapped `lindera::Schema` directly). This was a
pre-existing API inconsistency carried over from Phase 4 and explicitly deferred to
Phase 6. This PR resolves it by standardizing on `pos_detail_*`, the same names the
core `lindera` crate produces.

This also completes the WASM schema/metadata Core-ification that was deferred from
#718: `JsSchema` now wraps `CoreSchema` and `JsMetadata` wraps `CoreMetadata`,
bringing WASM in line with the other four bindings.

## Changes

- **`lindera-binding-core`**: `default_dictionary_fields()` now returns
  `pos_detail_1/2/3`; the default-schema test asserts exact equality with
  `lindera::dictionary::Schema::default().get_all_fields()`. Doc comments updated to
  describe the reconciliation.
- **WASM**: `JsSchema` wraps `CoreSchema`, `JsMetadata` wraps `CoreMetadata`;
  `dictionary.rs` conversions routed through `Into<Metadata>`. Behavior-neutral for
  WASM (it already used `pos_detail_*` via `lindera::Schema`).
- **Python / Node.js / Ruby / PHP**: schema unit-test assertions updated from
  `middle_pos` to `pos_detail_1`. No production-code behavior change beyond the
  shared `binding-core` default.

## Breaking change

The default schema field names returned by `Schema.create_default()` in the
Python/PHP/Ruby/Node.js bindings change from `middle_pos/small_pos/fine_pos` to
`pos_detail_1/2/3`. Targeted at the `v4` integration branch as part of the v4.0.0
breaking-change cycle.

## Verification

- `cargo test --lib`: binding-core 22, wasm 24, python 23, nodejs 27, ruby 28, php 10 — all pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p lindera-binding-core -p lindera-wasm --all-targets -- -D warnings` — clean
- `make test-lindera-wasm` (wasm-pack `--node`) — 28/28 pass
- `grep` confirms no remaining `middle_pos`/`small_pos`/`fine_pos` usage in code (only a historical note in a doc comment and the planning docs)

Refs #720