### PR TITLE
refactor(bindings)!: unify Token.details to always be Vec<String>

### DIFF
--- a/lindera-nodejs/src/token.rs
+++ b/lindera-nodejs/src/token.rs
@@ -25,7 +25,7 @@ pub struct JsToken {
     /// Whether this token is an unknown word.
     is_unknown: bool,
     /// Morphological details of the token.
-    details: Option<Vec<String>>,
+    details: Vec<String>,
 }
 
 #[napi]
@@ -68,7 +68,7 @@ impl JsToken {
 
     /// Morphological details of the token (part of speech, reading, etc.).
     #[napi(getter)]
-    pub fn details(&self) -> Option<Vec<String>> {
+    pub fn details(&self) -> Vec<String> {
         self.details.clone()
     }
 
@@ -83,9 +83,7 @@ impl JsToken {
     /// The detail string if found, or `null` if the index is out of range.
     #[napi]
     pub fn get_detail(&self, index: u32) -> Option<String> {
-        self.details
-            .as_ref()
-            .and_then(|d| d.get(index as usize).cloned())
+        self.details.get(index as usize).cloned()
     }
 }
 
@@ -120,7 +118,7 @@ impl JsToken {
             position: view.position as u32,
             word_id: view.word_id,
             is_unknown: view.is_unknown,
-            details: Some(view.details),
+            details: view.details,
         }
     }
 }

--- a/lindera-python/src/token.rs
+++ b/lindera-python/src/token.rs
@@ -33,7 +33,7 @@ pub struct PyToken {
 
     /// Morphological details of the token.
     #[pyo3(get)]
-    pub details: Option<Vec<String>>,
+    pub details: Vec<String>,
 }
 
 #[pymethods]
@@ -49,7 +49,7 @@ impl PyToken {
     /// The detail string if found, otherwise None.
     #[pyo3(signature = (index))]
     fn get_detail(&self, index: usize) -> Option<String> {
-        self.details.as_ref().and_then(|d| d.get(index).cloned())
+        self.details.get(index).cloned()
     }
 
     /// Returns a string representation of the token.
@@ -76,7 +76,7 @@ impl PyToken {
             position: view.position,
             word_id: view.word_id,
             is_unknown: view.is_unknown,
-            details: Some(view.details),
+            details: view.details,
         }
     }
 

--- a/lindera-ruby/src/token.rs
+++ b/lindera-ruby/src/token.rs
@@ -25,7 +25,7 @@ pub struct RbToken {
     /// Whether this token is an unknown word.
     is_unknown: bool,
     /// Morphological details of the token.
-    details: Option<Vec<String>>,
+    details: Vec<String>,
 }
 
 impl RbToken {
@@ -59,7 +59,7 @@ impl RbToken {
             position: view.position,
             word_id: view.word_id,
             is_unknown: view.is_unknown,
-            details: Some(view.details),
+            details: view.details,
         }
     }
 
@@ -94,7 +94,7 @@ impl RbToken {
     }
 
     /// Returns the morphological details of the token.
-    fn details(&self) -> Option<Vec<String>> {
+    fn details(&self) -> Vec<String> {
         self.details.clone()
     }
 
@@ -108,7 +108,7 @@ impl RbToken {
     ///
     /// The detail string if found, otherwise nil.
     fn get_detail(&self, index: usize) -> Option<String> {
-        self.details.as_ref().and_then(|d| d.get(index).cloned())
+        self.details.get(index).cloned()
     }
 
     /// Returns the string representation of the token.


### PR DESCRIPTION
## Summary

Unify `Token.details` to always be `Vec<String>` across all five bindings, removing
the `Option<Vec<String>>` wrapper from the Python, Node.js, and Ruby bindings.

`lindera-binding-core` already exposes `TokenView.details` as `Vec<String>`, and the
PHP and WASM bindings already use `Vec<String>`. Only Python/Node.js/Ruby re-wrapped
it in `Option` — and `from_view` unconditionally set `details: Some(view.details)`, so
the `Option` was always `Some`. That forced three language packages to handle a
`null`/`None`/`nil` case for a value that is never absent. Absent details is now an
empty list, consistent everywhere.

## Changes

- **Python** (`lindera-python/src/token.rs`): `details` field → `Vec<String>`;
  `from_view` sets `details: view.details`; `get_detail` → `self.details.get(index).cloned()`.
- **Node.js** (`lindera-nodejs/src/token.rs`): field + `details()` getter → `Vec<String>`;
  `from_view` → `view.details`; `get_detail` → `self.details.get(..).cloned()`.
- **Ruby** (`lindera-ruby/src/token.rs`): field + `details()` method → `Vec<String>`;
  `from_view` → `view.details`; `get_detail` → `self.details.get(index).cloned()`.
- **PHP / WASM / binding-core**: already `Vec<String>`, unchanged.

## Breaking change

The host-language type of `Token.details` narrows from nullable to non-nullable:

| Binding | Before | After |
| --- | --- | --- |
| Python | `list[str] \| None` | `list[str]` |
| Node.js | `Array<string> \| null` | `Array<string>` |
| Ruby | `Array \| nil` | `Array` |

Runtime behavior is unchanged (the value was always a populated list); only the
nullable type goes away. The per-language migration note (`None`/null/nil → empty
array) will be captured in the v3→v4 migration guide (#724). Targeted at the `v4`
integration branch.

## Verification

- `rg "details: Option" lindera-*/src/token.rs` — empty (acceptance criterion)
- `cargo test -p lindera-python --lib` (23), `-p lindera-nodejs --lib` (27), `-p lindera-wasm --lib` (24) — pass
- `cargo check -p lindera-ruby -p lindera-php` — clean
- Golden: `cargo test -p lindera --features embed-ipadic,embed-ko-dic,embed-jieba,train --test golden_tokenization` — 8/8
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` — clean
- Per-language integration tests: pytest 8, node 15, ruby 18 runs/74 assertions, phpunit 25 tests/69 assertions — all pass

Refs #719