### PR TITLE
refactor(dictionary)!: remove deprecated LINDERA_CACHE env var

### DIFF
--- a/docs/ja/src/getting_started/installation.md
+++ b/docs/ja/src/getting_started/installation.md
@@ -44,9 +44,6 @@ cargo build --features=ipadic
 
 設定された場合、辞書ソースファイルは `$LINDERA_DICTIONARIES_PATH/<version>/` （`<version>` は lindera-dictionary クレートのバージョン）に保存されます。キャッシュはMD5チェックサムを使用してファイルを検証し、無効なファイルは自動的に再ダウンロードされます。
 
-> [!NOTE]
-> `LINDERA_CACHE` は非推奨ですが、後方互換性のために引き続きサポートされています。`LINDERA_DICTIONARIES_PATH` が設定されていない場合に使用されます。
-
 ### LINDERA_CONFIG_PATH
 
 `LINDERA_CONFIG_PATH` 環境変数は、トークナイザーの設定ファイル（YAML形式）へのパスを指定します。これにより、Rustコードを変更せずにトークナイザーの動作を設定できます。

--- a/docs/src/getting_started/installation.md
+++ b/docs/src/getting_started/installation.md
@@ -44,9 +44,6 @@ cargo build --features=ipadic
 
 When set, dictionary source files are stored in `$LINDERA_DICTIONARIES_PATH/<version>/` where `<version>` is the lindera-dictionary crate version. The cache validates files using MD5 checksums - invalid files are automatically re-downloaded.
 
-> [!NOTE]
-> `LINDERA_CACHE` is deprecated but still supported for backward compatibility. It will be used if `LINDERA_DICTIONARIES_PATH` is not set.
-
 ### LINDERA_CONFIG_PATH
 
 The `LINDERA_CONFIG_PATH` environment variable specifies the path to a YAML configuration file for the tokenizer. This allows you to configure tokenizer behavior without modifying Rust code.

--- a/docs/src/lindera-python/dictionary_management.md
+++ b/docs/src/lindera-python/dictionary_management.md
@@ -147,4 +147,3 @@ Returns a dictionary representation of the metadata:
 metadata = Metadata(name="test")
 print(metadata.to_dict())
 ```
-

--- a/lindera-dictionary/src/assets.rs
+++ b/lindera-dictionary/src/assets.rs
@@ -223,7 +223,6 @@ pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaRe
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-env-changed=LINDERA_DICTIONARIES_PATH");
-    println!("cargo:rerun-if-env-changed=LINDERA_CACHE");
     println!("cargo:rerun-if-env-changed=DOCS_RS");
 
     // Directory path for build package
@@ -231,14 +230,7 @@ pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaRe
     // - on new lindera-assets version
     // - if the LINDERA_DICTS dir changed
     // otherwise, keeps behavior of always redownloading and rebuilding
-    let (build_dir, is_cache) = if let Some(path) = std::env::var_os("LINDERA_DICTIONARIES_PATH")
-        .or_else(|| {
-            std::env::var_os("LINDERA_CACHE").inspect(|_| {
-                println!(
-                    "cargo:warning=LINDERA_CACHE is deprecated. Please use LINDERA_DICTIONARIES_PATH instead."
-                );
-            })
-        }) {
+    let (build_dir, is_cache) = if let Some(path) = std::env::var_os("LINDERA_DICTIONARIES_PATH") {
         let mut cache_dir = PathBuf::from(path);
         if !cache_dir.is_absolute()
             && let Ok(current_dir) = std::env::current_dir()
@@ -255,8 +247,9 @@ pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaRe
 
         (
             cache_dir.join(std::env::var_os("CARGO_PKG_VERSION").ok_or_else(|| {
-                LinderaErrorKind::Io
-                    .with_error(anyhow::anyhow!("CARGO_PKG_VERSION environment variable is not set"))
+                LinderaErrorKind::Io.with_error(anyhow::anyhow!(
+                    "CARGO_PKG_VERSION environment variable is not set"
+                ))
             })?),
             true,
         )
@@ -559,16 +552,13 @@ pub async fn fetch(params: FetchParams, builder: DictionaryBuilder) -> LinderaRe
 /// `LINDERA_WORKDIR`.
 ///
 /// When the crate's embed feature is disabled (`embed_enabled == false`) and
-/// no cache override is set via `LINDERA_DICTIONARIES_PATH` / `LINDERA_CACHE`,
-/// this is a no-op so the crate builds without downloading any data.
+/// no cache override is set via `LINDERA_DICTIONARIES_PATH`, this is a no-op so
+/// the crate builds without downloading any data.
 pub async fn build_embedded_dictionary(
     embed_enabled: bool,
     params: FetchParams,
 ) -> Result<(), Box<dyn Error>> {
-    if std::env::var_os("LINDERA_DICTIONARIES_PATH").is_none()
-        && std::env::var_os("LINDERA_CACHE").is_none()
-        && !embed_enabled
-    {
+    if std::env::var_os("LINDERA_DICTIONARIES_PATH").is_none() && !embed_enabled {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

Remove the deprecated `LINDERA_CACHE` environment variable, standardizing on
`LINDERA_DICTIONARIES_PATH`. `lindera-dictionary/src/assets.rs` honored
`LINDERA_CACHE` as a fallback for `LINDERA_DICTIONARIES_PATH` and emitted a
`cargo:warning` deprecation notice. This build-time env-var shim was kept through
the non-breaking phases (0–5); v4.0.0 is the place to drop it.

## Changes

- **`lindera-dictionary/src/assets.rs`**:
  - Remove `println!("cargo:rerun-if-env-changed=LINDERA_CACHE")`.
  - Drop the `.or_else(|| std::env::var_os("LINDERA_CACHE") ...)` fallback and its
    deprecation `cargo:warning` in `fetch()`.
  - Drop the `&& std::env::var_os("LINDERA_CACHE").is_none()` check in
    `build_embedded_dictionary()` and update its doc comment.
- **`docs/src/getting_started/installation.md`** + **`docs/ja/...`**: remove the
  `LINDERA_CACHE` deprecation NOTE.
- **`docs/src/lindera-python/dictionary_management.md`**: fix a pre-existing MD012
  (trailing blank lines) so `markdownlint-cli2` passes cleanly. Unrelated to the
  env-var change but required for the acceptance criterion to go green.

## Breaking change

`LINDERA_CACHE` is no longer recognized at build time. Users who still set it must
switch to `LINDERA_DICTIONARIES_PATH` (the documented variable for several releases).
Targeted at the `v4` integration branch.

## Verification

- `rg LINDERA_CACHE` returns hits only in the planning docs (`REFACTORING_PLAN.md`,
  `PHASE6_HANDOFF.md`, edited separately at a milestone) and the local, gitignored
  `.claude/settings.local.json` — none in shipping code or docs.
- `cargo test -p lindera --features embed-ipadic,embed-ko-dic,embed-jieba,train --test golden_tokenization` — 8/8 (no snapshot drift)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p lindera-dictionary --all-targets -- -D warnings` — clean
- `markdownlint-cli2 "docs/src/**/*.md"` — 0 errors

Refs #721