### PR TITLE
docs(migration): add v3 to v4 migration guide (en + ja)

### DIFF
--- a/docs/ja/src/SUMMARY.md
+++ b/docs/ja/src/SUMMARY.md
@@ -115,6 +115,10 @@
 
 ---
 
+- [v3 から v4 への移行](./migration_v3_to_v4.md)
+
+---
+
 - [開発ガイド](./development.md)
     - [ビルドとテスト](./development/build_and_test.md)
     - [Feature フラグ](./development/feature_flags.md)

--- a/docs/ja/src/lindera-python/dictionary_management.md
+++ b/docs/ja/src/lindera-python/dictionary_management.md
@@ -147,4 +147,3 @@ print(metadata.name)  # "custom_dict"
 metadata = Metadata(name="test")
 print(metadata.to_dict())
 ```
-

--- a/docs/ja/src/lindera-ruby/dictionary_management.md
+++ b/docs/ja/src/lindera-ruby/dictionary_management.md
@@ -119,4 +119,3 @@ metadata = dictionary.metadata
 | `flexible_csv` | `Boolean` | `false` | 柔軟な CSV パースを許可 |
 | `skip_invalid_cost_or_id` | `Boolean` | `false` | 無効なコストまたは ID のエントリーをスキップ |
 | `normalize_details` | `Boolean` | `false` | 形態素の詳細情報を正規化 |
-

--- a/docs/ja/src/migration_v3_to_v4.md
+++ b/docs/ja/src/migration_v3_to_v4.md
@@ -1,0 +1,155 @@
+# v3 から v4 への移行
+
+Lindera v4.0.0 は、v3 系で意図的に先送りしていた破壊的変更をまとめて取り込んだメジャー
+リリースです。個々の変更は小さいものですが、安心してアップグレードできるよう、すべての変更を
+本ガイドに列挙します。
+
+破壊的変更は、v3.0.7 と v4 の公開サーフェスを `cargo public-api` で機械的に差分比較して検証
+しています（リポジトリの `public-api/` にコミット済み）。
+
+## 概要
+
+| 変更 | 対象 | 対応 |
+| --- | --- | --- |
+| デフォルトスキーマのフィールド名が `pos_detail_*` に統一 | Python, Node.js, Ruby, PHP | `middle_pos` / `small_pos` / `fine_pos` を `pos_detail_1` / `pos_detail_2` / `pos_detail_3` に変更 |
+| `Token.details` が常にリスト | Python, Node.js, Ruby | `null` / `None` / `nil` の処理を削除 |
+| バインディングの `Segmenter` を削除 | Python, WASM | 代わりに tokenizer を使用 |
+| `LINDERA_CACHE` 環境変数を削除 | Rust ビルド, CLI | `LINDERA_DICTIONARIES_PATH` を使用 |
+| ユーザー辞書のバイナリ形式が変更 | すべて（ビルド済み `.bin`） | ユーザー辞書を CSV から再ビルド |
+| `lindera-dictionary` の viterbi 内部をカプセル化 | Rust クレート利用者 | 新しいアクセサを使用 |
+
+最上位の `lindera` クレートの公開 Rust API は v3.0.7 と v4 で変わりません。
+
+## デフォルト辞書スキーマのフィールド名
+
+`Schema.create_default()`（およびデフォルト辞書スキーマ）は、3 つの品詞詳細フィールドを
+`middle_pos` / `small_pos` / `fine_pos` ではなく `pos_detail_1` / `pos_detail_2` /
+`pos_detail_3`（インデックス 5, 6, 7）と命名するようになりました。これにより、すべての
+バインディングが、すでに `pos_detail_*` を使用していたコアの
+`lindera::dictionary::Schema::default()` と一致します。
+
+対象は Python・Node.js・Ruby・PHP バインディングです。WASM バインディングはすでに
+`pos_detail_*` を使用していたため変更ありません。
+
+Python の例:
+
+```python
+schema = Schema.create_default()
+# v3: schema.fields[5] == "middle_pos"
+# v4: schema.fields[5] == "pos_detail_1"
+
+# v3
+index = schema.get_field_index("middle_pos")
+# v4
+index = schema.get_field_index("pos_detail_1")
+```
+
+これらのフィールド名を文字列で参照している箇所（ルックアップ、カスタムスキーマ、シリアライズ
+された設定など）があれば、`pos_detail_*` 形式に更新してください。
+
+## `Token.details` は常にリスト
+
+`Token.details` は常に文字列のリストになり、`null` / `None` / `nil` を返さなくなりました。
+詳細を持たないトークンは空リストで表現されます。以前は Python・Node.js・Ruby バインディングが
+（実際には常に値が入っているにもかかわらず）nullable 型でラップしていました。PHP と WASM
+バインディングはもともと非 nullable でした。
+
+Python では型が `list[str] | None` から `list[str]` に変わります:
+
+```python
+# v3 — 型の都合で null チェックが必要だった
+if token.details is not None:
+    pos = token.details[0]
+
+# v4 — details は常にリスト
+pos = token.details[0]
+```
+
+Node.js では `Array<string> | null` から `Array<string>` に、Ruby では `Array | nil` から
+`Array` に変わります。`null` / `nil` チェックを削除してください。
+
+## バインディングの `Segmenter` を削除
+
+使われていなかった `Segmenter` ラッパーをバインディングから削除しました。コンストラクタが無く
+使用できないもので、形態素分割は常に tokenizer から利用できます。
+
+- Python: `lindera.segmenter` サブモジュールと `lindera.segmenter.Segmenter` が無くなりました。
+- WASM: `Segmenter` クラスのエクスポートが無くなりました。
+
+代わりに tokenizer でトークン化してください:
+
+```python
+from lindera import Tokenizer, TokenizerBuilder
+
+tokenizer = TokenizerBuilder().build()
+tokens = tokenizer.tokenize("関西国際空港")
+```
+
+## `LINDERA_CACHE` 環境変数を削除
+
+非推奨だったビルド時環境変数 `LINDERA_CACHE` を削除しました。数リリース前から正式に
+サポートされている `LINDERA_DICTIONARIES_PATH` を使用してください:
+
+```sh
+# v3（非推奨）
+export LINDERA_CACHE=/path/to/dicts
+
+# v4
+export LINDERA_DICTIONARIES_PATH=/path/to/dicts
+```
+
+## ユーザー辞書のバイナリ形式が変更
+
+ユーザー辞書は、システム辞書と同じ 8-bit のバリアント数エンコーディングを使うようになりました
+（1 表層あたり最大 255 バリアント、以前は 31）。そのため、v3 でビルドしたユーザー辞書の `.bin`
+ファイルは v4 では誤ってデコードされます。形式バージョンのガードが無いため、失敗はサイレントで
+す（トークンは生成されますが、誤った詳細になります）。
+
+v4 でユーザー辞書を CSV から再ビルドしてください:
+
+```sh
+lindera build --user \
+  --src user_dict.csv \
+  --dest ./build \
+  --metadata lindera-ipadic/metadata.json
+```
+
+ユーザー辞書をビルド済み `.bin` ではなく `.csv` から読み込んでいる場合は、読み込み時に再ビルド
+されるため対応は不要です。
+
+## Rust ライブラリ: `lindera-dictionary` の viterbi 内部
+
+これは `lindera-dictionary` クレートを直接利用している場合にのみ影響します。`lindera` クレートの
+API は変わりません。
+
+内部の viterbi 構造体は公開フィールドを持たなくなりました。代わりにアクセサを使用してください:
+
+```rust
+// v3 — フィールドへ直接アクセス
+let id = word_id.id;
+let cost = word_entry.word_cost;
+
+// v4 — アクセサ
+let id = word_id.id();
+let cost = word_entry.word_cost();
+```
+
+`lindera_dictionary::viterbi` のその他の変更:
+
+- `EdgeType` を削除しました。
+- `WordEntry` に `new()` / `word_cost()` / `word_id()` を、`WordId` に `id()` を追加しました。
+- `WordEntry::serialize` / `WordEntry::deserialize` / `WordEntry::SERIALIZED_LEN` を非公開に
+  しました。
+- `util::read_aligned_file` と `embedded_dictionary!` マクロを追加しました。
+
+機械生成された完全な差分は、リポジトリの `public-api/lindera-dictionary.diff` にあります。
+
+## アップグレードチェックリスト
+
+- `middle_pos` / `small_pos` / `fine_pos` を `pos_detail_1` / `pos_detail_2` /
+  `pos_detail_3` に置き換える（Python, Node.js, Ruby, PHP）。
+- `Token.details` の `null` / `None` / `nil` チェックを削除する（Python, Node.js, Ruby）。
+- バインディングの `Segmenter` の使用を tokenizer に置き換える（Python, WASM）。
+- `LINDERA_CACHE` を `LINDERA_DICTIONARIES_PATH` に置き換える。
+- ビルド済みユーザー辞書 `.bin` を CSV から再ビルドする。
+- `lindera-dictionary` の viterbi フィールド直接アクセスを新しいアクセサに切り替える（Rust）。

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -115,6 +115,10 @@
 
 ---
 
+- [Migration v3 to v4](./migration_v3_to_v4.md)
+
+---
+
 - [Development Guide](./development.md)
     - [Build & Test](./development/build_and_test.md)
     - [Feature Flags](./development/feature_flags.md)

--- a/docs/src/migration_v3_to_v4.md
+++ b/docs/src/migration_v3_to_v4.md
@@ -1,0 +1,160 @@
+# Migrating from v3 to v4
+
+Lindera v4.0.0 is a major release that bundles the breaking changes that were
+deliberately deferred during the v3 series. Each change is small on its own; this
+guide lists every one so you can upgrade with confidence.
+
+The breaking changes were verified mechanically against a `cargo public-api` diff of
+the v3.0.7 and v4 public surfaces (committed under `public-api/` in the repository).
+
+## Overview
+
+| Change | Affects | What you do |
+| --- | --- | --- |
+| Default schema field names use `pos_detail_*` | Python, Node.js, Ruby, PHP | Update field names `middle_pos` / `small_pos` / `fine_pos` to `pos_detail_1` / `pos_detail_2` / `pos_detail_3` |
+| `Token.details` is always a list | Python, Node.js, Ruby | Remove `null` / `None` / `nil` handling |
+| Binding `Segmenter` removed | Python, WASM | Use the tokenizer instead |
+| `LINDERA_CACHE` env var removed | Rust build, CLI | Use `LINDERA_DICTIONARIES_PATH` |
+| User-dictionary binary format changed | All (prebuilt `.bin`) | Rebuild user dictionaries from their CSV source |
+| `lindera-dictionary` viterbi internals encapsulated | Rust crate users | Use the new accessors |
+
+The top-level `lindera` crate's public Rust API is unchanged between v3.0.7 and v4.
+
+## Default dictionary schema field names
+
+`Schema.create_default()` (and the default dictionary schema) now names the three
+part-of-speech detail fields `pos_detail_1`, `pos_detail_2`, and `pos_detail_3`
+(indices 5, 6, 7), instead of `middle_pos`, `small_pos`, and `fine_pos`. This makes
+every binding match the core `lindera::dictionary::Schema::default()`, which already
+used `pos_detail_*`.
+
+This affects the Python, Node.js, Ruby, and PHP bindings. The WASM binding already
+used `pos_detail_*`, so it is unchanged.
+
+In Python:
+
+```python
+schema = Schema.create_default()
+# v3: schema.fields[5] == "middle_pos"
+# v4: schema.fields[5] == "pos_detail_1"
+
+# v3
+index = schema.get_field_index("middle_pos")
+# v4
+index = schema.get_field_index("pos_detail_1")
+```
+
+If you reference these field names by string anywhere (lookups, custom schemas,
+serialized configuration), update them to the `pos_detail_*` form.
+
+## `Token.details` is always a list
+
+`Token.details` is now always a list of strings and is never `null` / `None` / `nil`.
+A token with no details is represented by an empty list. Previously the Python,
+Node.js, and Ruby bindings wrapped it in a nullable type even though it was always
+populated in practice; the PHP and WASM bindings were already non-nullable.
+
+In Python the type changes from `list[str] | None` to `list[str]`:
+
+```python
+# v3 — defensive null check was required by the type
+if token.details is not None:
+    pos = token.details[0]
+
+# v4 — details is always a list
+pos = token.details[0]
+```
+
+In Node.js the type changes from `Array<string> | null` to `Array<string>`, and in
+Ruby from `Array | nil` to `Array`. Remove any `null` / `nil` checks accordingly.
+
+## Binding `Segmenter` removed
+
+The vestigial `Segmenter` wrappers were removed from the bindings. They had no
+constructor and could not be used; segmentation has always been reachable through the
+tokenizer.
+
+- Python: the `lindera.segmenter` submodule and `lindera.segmenter.Segmenter` are gone.
+- WASM: the `Segmenter` class export is gone.
+
+Tokenize through the tokenizer instead:
+
+```python
+from lindera import Tokenizer, TokenizerBuilder
+
+tokenizer = TokenizerBuilder().build()
+tokens = tokenizer.tokenize("関西国際空港")
+```
+
+## `LINDERA_CACHE` environment variable removed
+
+The deprecated `LINDERA_CACHE` build-time environment variable was removed. Use
+`LINDERA_DICTIONARIES_PATH`, which has been the supported variable for several
+releases:
+
+```sh
+# v3 (deprecated)
+export LINDERA_CACHE=/path/to/dicts
+
+# v4
+export LINDERA_DICTIONARIES_PATH=/path/to/dicts
+```
+
+## User-dictionary binary format changed
+
+User dictionaries now use the same 8-bit variant-count encoding as system
+dictionaries (supporting up to 255 variants per surface, previously 31). As a result,
+a user-dictionary `.bin` file built with v3 is decoded incorrectly by v4. There is no
+format-version guard, so the failure is silent — tokens are produced, but with the
+wrong details.
+
+Rebuild user dictionaries from their CSV source with v4:
+
+```sh
+lindera build --user \
+  --src user_dict.csv \
+  --dest ./build \
+  --metadata lindera-ipadic/metadata.json
+```
+
+If you load a user dictionary from a `.csv` file (rather than a prebuilt `.bin`), it is
+rebuilt at load time and no action is needed.
+
+## Rust library: `lindera-dictionary` viterbi internals
+
+This affects only direct users of the `lindera-dictionary` crate; the `lindera` crate
+API is unchanged.
+
+The internal viterbi structs no longer expose public fields. Use the accessors
+instead:
+
+```rust
+// v3 — direct field access
+let id = word_id.id;
+let cost = word_entry.word_cost;
+
+// v4 — accessors
+let id = word_id.id();
+let cost = word_entry.word_cost();
+```
+
+Other changes in `lindera_dictionary::viterbi`:
+
+- `EdgeType` was removed.
+- `WordEntry` gained `new()`, `word_cost()`, and `word_id()`; `WordId` gained `id()`.
+- `WordEntry::serialize`, `WordEntry::deserialize`, and `WordEntry::SERIALIZED_LEN` are
+  no longer public.
+- `util::read_aligned_file` and the `embedded_dictionary!` macro were added.
+
+The complete machine-generated diff lives in `public-api/lindera-dictionary.diff` in
+the repository.
+
+## Upgrade checklist
+
+- Replace `middle_pos` / `small_pos` / `fine_pos` with `pos_detail_1` / `pos_detail_2`
+  / `pos_detail_3` (Python, Node.js, Ruby, PHP).
+- Remove `null` / `None` / `nil` checks on `Token.details` (Python, Node.js, Ruby).
+- Replace any use of the binding `Segmenter` with the tokenizer (Python, WASM).
+- Replace `LINDERA_CACHE` with `LINDERA_DICTIONARIES_PATH`.
+- Rebuild prebuilt user-dictionary `.bin` files from their CSV source.
+- Switch direct `lindera-dictionary` viterbi field access to the new accessors (Rust).


### PR DESCRIPTION
## Summary

Add a v3 → v4 migration guide to the mdBook in **both** languages and wire it into both
`SUMMARY.md` files. The guide gives users an authoritative, mechanically-verified upgrade
path for the breaking changes bundled into v4.0.0.

Every breaking change was reconciled against the committed `cargo public-api` diff
(`public-api/` from #723) and the merged Phase 6 PRs.

## New pages

- `docs/src/migration_v3_to_v4.md` (English)
- `docs/ja/src/migration_v3_to_v4.md` (Japanese)

Both are registered in `docs/src/SUMMARY.md` and `docs/ja/src/SUMMARY.md`, slotted
between the dictionary sections and the Development Guide.

## Documented breaking changes

The guide is organized by change, each with before/after snippets and the affected
bindings:

- **Default schema field names** → `pos_detail_1/2/3` (Python, Node.js, Ruby, PHP; WASM already matched).
- **`Token.details` is always a list** (non-nullable) — Python, Node.js, Ruby.
- **Binding `Segmenter` removed** — Python (`lindera.segmenter`), WASM (`Segmenter`).
- **`LINDERA_CACHE` removed** → use `LINDERA_DICTIONARIES_PATH`.
- **User-dictionary `.bin` format changed** (5-bit → 8-bit) — rebuild from CSV.
- **`lindera-dictionary` viterbi internals encapsulated** — Rust crate users; the `lindera` crate API is unchanged.

While reconciling, I confirmed the facade migrations (#727–#736) did **not** introduce
attribute → method breaks: e.g. Python's `Schema.fields` moved from `#[pyo3(get)]` to
`#[getter]`, but both expose the same `schema.fields` property, so the guide does not
document a non-existent break.

## Also

Fixes two pre-existing `MD012` (multiple consecutive blank lines) errors in the Japanese
`lindera-python` / `lindera-ruby` `dictionary_management.md` pages — the JA counterparts
of the EN fix from #721 — so markdownlint is clean across `docs/ja/src` too.

## Verification

- `markdownlint-cli2 "docs/src/**/*.md"` — 0 errors.
- `markdownlint-cli2 "docs/ja/src/**/*.md"` — 0 errors.
- `mdbook build docs` (en) and `mdbook build docs/ja` (ja) — both exit 0; the migration page renders and is reachable from the table of contents.
- `cargo fmt --all -- --check` — clean (docs-only change; no Rust touched, so clippy is unaffected from the green v4 baseline).

Refs #724