### PR TITLE
chore(release): bump version to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1771,7 +1771,7 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-binding-core"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera",
  "serde_json",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-cc-cedict"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera-dictionary",
  "tokio",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-cli"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-crf"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera-dictionary",
  "tokio",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic-neologd"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera-dictionary",
  "tokio",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-jieba"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera-dictionary",
  "tokio",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-ko-dic"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera-dictionary",
  "tokio",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-nodejs"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-php"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "ext-php-rs",
  "lindera",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-python"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-ruby"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1960,7 +1960,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-unidic"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "lindera-dictionary",
  "tokio",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-wasm"
-version = "3.0.7"
+version = "4.0.0"
 dependencies = [
  "js-sys",
  "lindera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.7"
+version = "4.0.0"
 edition = "2024"
 description = "A morphological analysis libraries and command line interface."
 documentation = "https://docs.rs/lindera"
@@ -36,22 +36,22 @@ anyhow = "1.0.102"
 byteorder = "1.5.0"
 csv = "1.4.0"
 daachorse = "2.1.0"
-lindera = { version = "3.0.7", path = "lindera" }
-lindera-binding-core = { version = "3.0.7", path = "lindera-binding-core" }
-lindera-crf = { version = "3.0.7", path = "lindera-crf" }
-lindera-cc-cedict = { version = "3.0.7", path = "lindera-cc-cedict" }
-lindera-cli = { version = "3.0.7", path = "lindera-cli" }
-lindera-dictionary = { version = "3.0.7", path = "lindera-dictionary" }
-lindera-ipadic = { version = "3.0.7", path = "lindera-ipadic" }
-lindera-ipadic-neologd = { version = "3.0.7", path = "lindera-ipadic-neologd" }
-lindera-jieba = { version = "3.0.7", path = "lindera-jieba" }
-lindera-ko-dic = { version = "3.0.7", path = "lindera-ko-dic" }
-lindera-nodejs = { version = "3.0.7", path = "lindera-nodejs" }
-lindera-python = { version = "3.0.7", path = "lindera-python" }
-lindera-ruby = { version = "3.0.7", path = "lindera-ruby" }
-lindera-unidic = { version = "3.0.7", path = "lindera-unidic" }
-lindera-php = { version = "3.0.7", path = "lindera-php" }
-lindera-wasm = { version = "3.0.7", path = "lindera-wasm" }
+lindera = { version = "4.0.0", path = "lindera" }
+lindera-binding-core = { version = "4.0.0", path = "lindera-binding-core" }
+lindera-crf = { version = "4.0.0", path = "lindera-crf" }
+lindera-cc-cedict = { version = "4.0.0", path = "lindera-cc-cedict" }
+lindera-cli = { version = "4.0.0", path = "lindera-cli" }
+lindera-dictionary = { version = "4.0.0", path = "lindera-dictionary" }
+lindera-ipadic = { version = "4.0.0", path = "lindera-ipadic" }
+lindera-ipadic-neologd = { version = "4.0.0", path = "lindera-ipadic-neologd" }
+lindera-jieba = { version = "4.0.0", path = "lindera-jieba" }
+lindera-ko-dic = { version = "4.0.0", path = "lindera-ko-dic" }
+lindera-nodejs = { version = "4.0.0", path = "lindera-nodejs" }
+lindera-python = { version = "4.0.0", path = "lindera-python" }
+lindera-ruby = { version = "4.0.0", path = "lindera-ruby" }
+lindera-unidic = { version = "4.0.0", path = "lindera-unidic" }
+lindera-php = { version = "4.0.0", path = "lindera-php" }
+lindera-wasm = { version = "4.0.0", path = "lindera-wasm" }
 log = "0.4.29"
 num_cpus = "1.17.0"
 once_cell = "1.21.4"

--- a/lindera-nodejs/package.json
+++ b/lindera-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera-nodejs",
-  "version": "2.3.4",
+  "version": "4.0.0",
   "description": "Node.js bindings for Lindera morphological analysis engine",
   "main": "index.js",
   "types": "index.d.ts",

--- a/lindera-ruby/lindera.gemspec
+++ b/lindera-ruby/lindera.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "lindera"
-  spec.version = "2.3.4"
+  spec.version = "4.0.0"
   spec.authors = ["Lindera contributors"]
   spec.summary = "Ruby bindings for Lindera morphological analysis engine"
   spec.description = "Ruby bindings for Lindera, a morphological analysis library for CJK text (Japanese, Korean, Chinese)."


### PR DESCRIPTION
## Summary

Bump the workspace and language packages to **4.0.0** for the v4 major release
(closing milestone of Phase 6). This is a version-only change — all the breaking code
and documentation changes were delivered by the sibling Phase 6 PRs.

The maintainer opted to release **4.0.0** directly (tag `v4.0.0`), without an alpha.

## Changes

- `Cargo.toml`: `[workspace.package] version` and all 16 `[workspace.dependencies]`
  lindera entries `3.0.7` → `4.0.0`; `Cargo.lock` refreshed.
- `lindera-nodejs/package.json`: `2.3.4` → `4.0.0`.
- `lindera-ruby/lindera.gemspec`: `2.3.4` → `4.0.0`.

The Python (maturin `dynamic = ["version"]`, derived from the crate), WASM (package
generated by wasm-pack from `Cargo.toml`), and PHP (no `version` in `composer.json`;
Packagist is tag-driven) packages pick up the version automatically and need no manual
edit.

Remaining `3.0.7` / `2.3.4` strings in the tree are intentional: `PHASE6_HANDOFF.md`
(planning doc), the migration guide (the v3.0.7 baseline being migrated from), the
`public-api/` diff snapshots, and `lindera-php/CHANGES.md` history.

## Verification

- `cargo test -p lindera --features embed-ipadic,embed-ko-dic,embed-jieba,train --test golden_tokenization` — 8/8.
- `cargo fmt --all -- --check` and `cargo clippy -p lindera -p lindera-dictionary -p lindera-binding-core --all-targets -- -D warnings` — clean.
- `cargo test --lib` for python (23), nodejs (27), wasm (24) — pass.
- No test hardcodes a version string, so the bump breaks nothing.

## Release steps (maintainer)

This PR only bumps versions. After it merges, the release itself — pushing the `v4.0.0`
tag (which triggers `release.yml` to publish to crates.io / PyPI / npm / RubyGems /
Packagist), validating downstream (`lindera-tantivy`, `lindera-sqlite`), and merging
`v4` → `main` — is performed by the maintainer.

Refs #725