### PR TITLE
fix(release): publish lindera-binding-core to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -772,7 +772,7 @@ jobs:
 
       - name: Publish crates
         run: |
-          for crate in lindera-crf lindera-dictionary lindera-cc-cedict lindera-jieba lindera-ipadic lindera-ipadic-neologd lindera-ko-dic lindera-unidic lindera lindera-python lindera-nodejs lindera-ruby lindera-cli lindera-wasm lindera-cli; do
+          for crate in lindera-crf lindera-dictionary lindera-cc-cedict lindera-jieba lindera-ipadic lindera-ipadic-neologd lindera-ko-dic lindera-unidic lindera lindera-binding-core lindera-python lindera-nodejs lindera-ruby lindera-cli lindera-wasm; do
             VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r ".packages[] | select(.name==\"$crate\") | .version")
             PUBLISHED_VERSIONS=$(curl -s -A "lindera-release-workflow (https://github.com/lindera/lindera)" "https://crates.io/api/v1/crates/$crate" | jq -r 'select(.versions != null) | .versions[].num')
             if echo "${PUBLISHED_VERSIONS}" | grep -Fx "${VERSION}" >/dev/null; then


### PR DESCRIPTION
## Summary

Fix the `v4.0.0` crates.io publish failure. The `Publish crates` loop in
`release.yml` did not include **`lindera-binding-core`** — the facade crate added in v4
that `lindera-python` / `-nodejs` / `-ruby` / `-wasm` now depend on. When the loop
reached `lindera-python`, `cargo publish` failed with:

```
error: failed to prepare local package for uploading
  no matching package named `lindera-binding-core` found
```

## Change

Add `lindera-binding-core` to the publish list, right after `lindera` (its only lindera
dependency), so it is on crates.io before the binding crates that depend on it. Also
drop the duplicate trailing `lindera-cli` entry.

```diff
-for crate in ... lindera lindera-python lindera-nodejs lindera-ruby lindera-cli lindera-wasm lindera-cli; do
+for crate in ... lindera lindera-binding-core lindera-python lindera-nodejs lindera-ruby lindera-cli lindera-wasm; do
```

## Context — the v4.0.0 release is partially published

From the failed run (tag `v4.0.0`):

| Registry | Status |
| --- | --- |
| PyPI | published ✅ |
| RubyGems | published ✅ |
| crates.io | partial — `lindera-crf`, `lindera-dictionary`, `lindera`, dictionaries published; `lindera-binding-core`, `lindera-cli`, `lindera-python`, `lindera-nodejs`, `lindera-ruby`, `lindera-wasm` not yet |
| npm | failed — separately, `NODE_AUTH_TOKEN` was invalid/expired (the maintainer has rotated it) |

The `npm` E404 failures were an unrelated credentials issue, already addressed by
rotating the token secret.

## After merge

Re-run `release.yml` via **`workflow_dispatch` on `main`** (the `v4.0.0` tag points at
the pre-fix commit). The publish steps are idempotent — every job skips versions already
on its registry — so the re-run only publishes the missing crates.io crates and the npm
packages; the already-published PyPI / RubyGems / partial crates.io 4.0.0 artifacts are
skipped.

Refs #725