### PR TITLE
docs: add lindera-sudachidict documentation

### DIFF
--- a/docs/ja/src/SUMMARY.md
+++ b/docs/ja/src/SUMMARY.md
@@ -105,6 +105,10 @@
     - [辞書フォーマット](./lindera-unidic/dictionary_format.md)
     - [ビルド](./lindera-unidic/build.md)
     - [使用例](./lindera-unidic/examples.md)
+- [Lindera SudachiDict](./lindera-sudachidict.md)
+    - [辞書フォーマット](./lindera-sudachidict/dictionary_format.md)
+    - [ビルド](./lindera-sudachidict/build.md)
+    - [使用例](./lindera-sudachidict/examples.md)
 
 - [Lindera ko-dic](./lindera-ko-dic.md)
     - [辞書フォーマット](./lindera-ko-dic/dictionary_format.md)
@@ -121,7 +125,7 @@
     - [ビルド](./lindera-jieba/build.md)
     - [使用例](./lindera-jieba/examples.md)
 
-- [SudachiDict（コミュニティレシピ）](./sudachidict.md)
+- [SudachiDict（カスタムビルド）](./sudachidict.md)
 
 ---
 

--- a/docs/ja/src/architecture.md
+++ b/docs/ja/src/architecture.md
@@ -11,6 +11,7 @@ graph TB
     TRAINER["lindera-trainer\n(CRF Training)"]
     IPADIC["lindera-ipadic"]
     UNIDIC["lindera-unidic"]
+    SUDACHIDICT["lindera-sudachidict"]
     KODIC["lindera-ko-dic"]
     CCCEDICT["lindera-cc-cedict"]
     JIEBA["lindera-jieba"]
@@ -30,6 +31,7 @@ graph TB
     TRAINER -.->|"train feature"| LIB
     DICT --> IPADIC
     DICT --> UNIDIC
+    DICT --> SUDACHIDICT
     DICT --> KODIC
     DICT --> CCCEDICT
     DICT --> JIEBA
@@ -39,6 +41,7 @@ graph TB
     DICT --> WASM
     IPADIC --> LIB
     UNIDIC --> LIB
+    SUDACHIDICT --> LIB
     KODIC --> LIB
     CCCEDICT --> LIB
     JIEBA --> LIB
@@ -69,6 +72,7 @@ graph TB
 | `lindera-ipadic` | 辞書 | IPADICベースの日本語辞書。 |
 | `lindera-ipadic-neologd` | 辞書 | IPADIC NEologdベースの日本語辞書（新語対応）。 |
 | `lindera-unidic` | 辞書 | UniDicベースの日本語辞書。 |
+| `lindera-sudachidict` | 辞書 | SudachiDictベースの日本語辞書。 |
 | `lindera-ko-dic` | 辞書 | ko-dicベースの韓国語辞書。 |
 | `lindera-cc-cedict` | 辞書 | CC-CEDICTベースの中国語辞書。 |
 | `lindera-jieba` | 辞書 | Jiebaベースの中国語辞書。 |
@@ -109,12 +113,14 @@ Output Tokens
 | `embed-ipadic` | IPADIC辞書をバイナリに埋め込み | 無効 |
 | `embed-ipadic-neologd` | IPADIC NEologd辞書をバイナリに埋め込み | 無効 |
 | `embed-unidic` | UniDic辞書をバイナリに埋め込み | 無効 |
+| `embed-sudachidict` | SudachiDict辞書をバイナリに埋め込み | 無効 |
 | `embed-ko-dic` | ko-dic辞書をバイナリに埋め込み | 無効 |
 | `embed-cc-cedict` | CC-CEDICT辞書をバイナリに埋め込み | 無効 |
 | `embed-jieba` | Jieba辞書をバイナリに埋め込み | 無効 |
 | `embed-cjk` | IPADIC + ko-dic + Jieba辞書を埋め込み | 無効 |
 | `embed-cjk2` | UniDic + ko-dic + Jieba辞書を埋め込み | 無効 |
 | `embed-cjk3` | IPADIC NEologd + ko-dic + Jieba辞書を埋め込み | 無効 |
+| `embed-cjk4` | SudachiDict + ko-dic + Jieba辞書を埋め込み | 無効 |
 
 ## 詳細
 

--- a/docs/ja/src/concepts/dictionaries.md
+++ b/docs/ja/src/concepts/dictionaries.md
@@ -7,6 +7,7 @@ Linderaは、日本語・韓国語・中国語の形態素解析のための様�
 | [IPADIC](../lindera-ipadic.md) | 日本語 | `lindera-ipadic` | 日本語で最も一般的な辞書 |
 | [IPADIC NEologd](../lindera-ipadic-neologd.md) | 日本語 | `lindera-ipadic-neologd` | 新語に対応したIPADIC |
 | [UniDic](../lindera-unidic.md) | 日本語 | `lindera-unidic` | 均一な単語単位定義を持つ辞書 |
+| [SudachiDict](../lindera-sudachidict.md) | 日本語 | `lindera-sudachidict` | 活発にメンテナンスされている語彙（上流で年数回更新） |
 | [ko-dic](../lindera-ko-dic.md) | 韓国語 | `lindera-ko-dic` | 韓国語の形態素解析 |
 | [CC-CEDICT](../lindera-cc-cedict.md) | 中国語 | `lindera-cc-cedict` | 中英辞書 |
 | [Jieba](../lindera-jieba.md) | 中国語 | `lindera-jieba` | Jiebaベースの中国語辞書 |

--- a/docs/ja/src/development/feature_flags.md
+++ b/docs/ja/src/development/feature_flags.md
@@ -34,6 +34,7 @@ let dictionary = load_dictionary("/path/to/ipadic")?;
 | `embed-ipadic` | IPADIC | 日本語 |
 | `embed-ipadic-neologd` | IPADIC NEologd | 日本語 |
 | `embed-unidic` | UniDic | 日本語 |
+| `embed-sudachidict` | SudachiDict | 日本語 |
 | `embed-ko-dic` | ko-dic | 韓国語 |
 | `embed-cc-cedict` | CC-CEDICT | 中国語 |
 | `embed-jieba` | Jieba | 中国語 |
@@ -66,6 +67,7 @@ let dictionary = load_dictionary("embedded://ipadic")?;
 | `embed-cjk` | IPADIC + ko-dic + Jieba |
 | `embed-cjk2` | UniDic + ko-dic + Jieba |
 | `embed-cjk3` | IPADIC NEologd + ko-dic + Jieba |
+| `embed-cjk4` | SudachiDict + ko-dic + Jieba |
 
 ### Feature フラグの組み合わせ
 

--- a/docs/ja/src/development/project_structure.md
+++ b/docs/ja/src/development/project_structure.md
@@ -16,6 +16,7 @@ lindera/
 ├── lindera-ipadic/         # IPADIC dictionary (Japanese)
 ├── lindera-ipadic-neologd/ # IPADIC NEologd dictionary (Japanese)
 ├── lindera-unidic/         # UniDic dictionary (Japanese)
+├── lindera-sudachidict/    # SudachiDict dictionary (Japanese)
 ├── lindera-ko-dic/         # ko-dic dictionary (Korean)
 ├── lindera-cc-cedict/      # CC-CEDICT dictionary (Chinese)
 ├── lindera-jieba/          # Jieba dictionary (Chinese)
@@ -78,6 +79,7 @@ lindera/
 | `lindera-ipadic` | 日本語 | IPADIC |
 | `lindera-ipadic-neologd` | 日本語 | IPADIC NEologd（拡張語彙） |
 | `lindera-unidic` | 日本語 | UniDic |
+| `lindera-sudachidict` | 日本語 | SudachiDict |
 | `lindera-ko-dic` | 韓国語 | ko-dic |
 | `lindera-cc-cedict` | 中国語 | CC-CEDICT |
 | `lindera-jieba` | 中国語 | Jieba |

--- a/docs/ja/src/lindera-analysis/architecture.md
+++ b/docs/ja/src/lindera-analysis/architecture.md
@@ -73,6 +73,7 @@ Segmenterが生成したトークンを後処理するフィルタのtraitです
 | `embed-ipadic` | IPADIC辞書をバイナリに埋め込む（`lindera/embed-ipadic`へ委譲） | No |
 | `embed-ipadic-neologd` | IPADIC-NEologd辞書をバイナリに埋め込む（`lindera/embed-ipadic-neologd`へ委譲） | No |
 | `embed-unidic` | UniDic辞書をバイナリに埋め込む（`lindera/embed-unidic`へ委譲） | No |
+| `embed-sudachidict` | SudachiDict辞書をバイナリに埋め込む（`lindera/embed-sudachidict`へ委譲） | No |
 | `embed-ko-dic` | ko-dic辞書をバイナリに埋め込む（`lindera/embed-ko-dic`へ委譲） | No |
 | `embed-cc-cedict` | CC-CEDICT辞書をバイナリに埋め込む（`lindera/embed-cc-cedict`へ委譲） | No |
 | `embed-jieba` | Jieba辞書をバイナリに埋め込む（`lindera/embed-jieba`へ委譲） | No |

--- a/docs/ja/src/lindera-cli/commands.md
+++ b/docs/ja/src/lindera-cli/commands.md
@@ -28,6 +28,7 @@ NAME            EMBEDDED  DOWNLOADED  PATH
 ipadic          yes       yes         /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-ipadic
 ipadic-neologd  no        no          -
 unidic          no        incomplete  /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-unidic
+sudachidict     no        no          -
 ko-dic          no        no          -
 cc-cedict       no        no          -
 jieba           no        no          -
@@ -720,6 +721,20 @@ Linderaで使用するための形態素解析辞書をCSVソースファイル�
   --user
 ```
 
+#### SudachiDictユーザー辞書（日本語）のビルド
+
+ユーザー辞書フォーマットの詳細については、以下のURLを参照してください：
+
+- [Lindera SudachiDict Builder/User Dictionary Format](https://github.com/lindera/lindera/tree/main/lindera-sudachidict#user-dictionary-format-csv)
+
+```shell
+% lindera build \
+  --src ./resources/user_dict/sudachidict_simple_userdic.csv \
+  --dest ./resources/user_dict \
+  --metadata ./lindera-sudachidict/metadata.json \
+  --user
+```
+
 #### CC-CEDICTユーザー辞書（中国語）のビルド
 
 ユーザー辞書フォーマットの詳細については、以下のURLを参照してください：
@@ -768,7 +783,7 @@ CLI と同じバージョンの学習済み辞書アーカイブを [GitHub リ�
 
 ### download パラメータ
 
-- 辞書名（必須）: `ipadic`, `ipadic-neologd`, `unidic`, `ko-dic`, `cc-cedict`, `jieba` のいずれか
+- 辞書名（必須）: `ipadic`, `ipadic-neologd`, `unidic`, `sudachidict`, `ko-dic`, `cc-cedict`, `jieba` のいずれか
 - `--force`: 既存の辞書を再ダウンロードして置き換える
 
 ### 保存場所

--- a/docs/ja/src/lindera-cli/installation.md
+++ b/docs/ja/src/lindera-cli/installation.md
@@ -82,6 +82,12 @@ CLI 使用時に展開した辞書パスを指定します（アーカイブに�
 % cargo build --release --features=embed-unidic
 ```
 
+#### SudachiDict（日本語辞書）
+
+```shell
+% cargo build --release --features=embed-sudachidict
+```
+
 #### ko-dic（韓国語辞書）
 
 ```shell

--- a/docs/ja/src/lindera-nodejs/installation.md
+++ b/docs/ja/src/lindera-nodejs/installation.md
@@ -71,6 +71,7 @@ npm run build -- --features train
 | `train` | CRF 学習機能 | 有効 |
 | `embed-ipadic` | 日本語辞書（IPADIC）をバイナリに埋め込み | 無効 |
 | `embed-unidic` | 日本語辞書（UniDic）をバイナリに埋め込み | 無効 |
+| `embed-sudachidict` | 日本語辞書（SudachiDict）をバイナリに埋め込み | 無効 |
 | `embed-ipadic-neologd` | 日本語辞書（IPADIC NEologd）をバイナリに埋め込み | 無効 |
 | `embed-ko-dic` | 韓国語辞書（ko-dic）をバイナリに埋め込み | 無効 |
 | `embed-cc-cedict` | 中国語辞書（CC-CEDICT）をバイナリに埋め込み | 無効 |

--- a/docs/ja/src/lindera-php/installation.md
+++ b/docs/ja/src/lindera-php/installation.md
@@ -67,6 +67,7 @@ php -d extension=target/release/liblindera_php.so script.php
 | `train` | CRF 学習機能 | 有効 |
 | `embed-ipadic` | 日本語辞書（IPADIC）をバイナリに埋め込み | 無効 |
 | `embed-unidic` | 日本語辞書（UniDic）をバイナリに埋め込み | 無効 |
+| `embed-sudachidict` | 日本語辞書（SudachiDict）をバイナリに埋め込み | 無効 |
 | `embed-ipadic-neologd` | 日本語辞書（IPADIC NEologd）をバイナリに埋め込み | 無効 |
 | `embed-ko-dic` | 韓国語辞書（ko-dic）をバイナリに埋め込み | 無効 |
 | `embed-cc-cedict` | 中国語辞書（CC-CEDICT）をバイナリに埋め込み | 無効 |

--- a/docs/ja/src/lindera-python/installation.md
+++ b/docs/ja/src/lindera-python/installation.md
@@ -69,6 +69,7 @@ maturin develop --features train
 | `train` | CRF 学習機能 | 有効 |
 | `embed-ipadic` | 日本語辞書（IPADIC）をバイナリに埋め込み | 無効 |
 | `embed-unidic` | 日本語辞書（UniDic）をバイナリに埋め込み | 無効 |
+| `embed-sudachidict` | 日本語辞書（SudachiDict）をバイナリに埋め込み | 無効 |
 | `embed-ipadic-neologd` | 日本語辞書（IPADIC NEologd）をバイナリに埋め込み | 無効 |
 | `embed-ko-dic` | 韓国語辞書（ko-dic）をバイナリに埋め込み | 無効 |
 | `embed-cc-cedict` | 中国語辞書（CC-CEDICT）をバイナリに埋め込み | 無効 |

--- a/docs/ja/src/lindera-ruby/installation.md
+++ b/docs/ja/src/lindera-ruby/installation.md
@@ -59,6 +59,7 @@ Feature は環境変数 `LINDERA_FEATURES` にカンマ区切りリストで指�
 | `train` | CRF 学習機能 | 有効 |
 | `embed-ipadic` | 日本語辞書（IPADIC）をバイナリに埋め込み | 無効 |
 | `embed-unidic` | 日本語辞書（UniDic）をバイナリに埋め込み | 無効 |
+| `embed-sudachidict` | 日本語辞書（SudachiDict）をバイナリに埋め込み | 無効 |
 | `embed-ipadic-neologd` | 日本語辞書（IPADIC NEologd）をバイナリに埋め込み | 無効 |
 | `embed-ko-dic` | 韓国語辞書（ko-dic）をバイナリに埋め込み | 無効 |
 | `embed-cc-cedict` | 中国語辞書（CC-CEDICT）をバイナリに埋め込み | 無効 |

--- a/docs/ja/src/lindera-sudachidict.md
+++ b/docs/ja/src/lindera-sudachidict.md
@@ -1,0 +1,18 @@
+# Lindera SudachiDict
+
+Lindera SudachiDict は、Sudachi 形態素解析器が使用する、活発にメンテナンスされている辞書 [SudachiDict](https://github.com/WorksApplications/SudachiDict) に基づく日本語辞書クレートです。上流で年に数回更新されているため、最近の語彙（`令和`、`スマホ`、`推し活`、...）が語彙に含まれます。各エントリは 19 フィールドを持ち、正規化表記・分割情報・同義語グループ ID といった SudachiDict 固有のカラムを含みます。
+
+辞書のソースファイルは [lindera/sudachidict](https://github.com/lindera/sudachidict) にミラーされています。同梱バージョンは `20260723`（small + core + notcore レキシコン）です。
+
+> [!NOTE]
+> この辞書は SudachiDict の語彙とラティスの挙動を再現しますが、Sudachi のエンジンプラグイン（カタカナ・数詞の連結、入力正規化、A/B/C 分割モード）は再現しません。詳細は [Sudachi との挙動の違い](./sudachidict.md#sudachi-との挙動の違い)を参照してください。
+
+## 目次
+
+- [辞書フォーマット](./lindera-sudachidict/dictionary_format.md) -- システム辞書およびユーザー辞書のフィールド定義
+- [ビルド](./lindera-sudachidict/build.md) -- ソースからの辞書ビルド方法
+- [使用例](./lindera-sudachidict/examples.md) -- トークナイズの例
+
+## API リファレンス
+
+- [lindera-sudachidict](https://docs.rs/lindera-sudachidict)

--- a/docs/ja/src/lindera-sudachidict/build.md
+++ b/docs/ja/src/lindera-sudachidict/build.md
@@ -1,0 +1,52 @@
+# ビルド
+
+このページでは、ソースファイルから SudachiDict 辞書をビルドする方法を説明します。
+
+## システム辞書のビルド
+
+SudachiDict のソースアーカイブをダウンロードし、辞書をビルドします:
+
+```shell
+% curl -L -o /tmp/sudachidict-20260723.tar.gz "https://lindera.dev/sudachidict-20260723.tar.gz"
+% tar zxvf /tmp/sudachidict-20260723.tar.gz -C /tmp
+
+% lindera build \
+  --src /tmp/sudachidict-20260723 \
+  --dest /tmp/lindera-sudachidict \
+  --metadata ./lindera-sudachidict/metadata.json
+```
+
+アーカイブには raw レキシコン（small + core + notcore）、連接コスト行列、および位置合わせ済みの `char.def` / `unk.def` が同梱されているため、手動の前処理は不要です。ビルドされた辞書のサイズは約 570MB です。
+
+> [!TIP]
+> 同梱バージョンより新しい上流の SudachiDict リリースからビルドするには、
+> 上流の raw 配布物から直接ビルドする
+> [SudachiDict（カスタムビルド）](../sudachidict.md)を参照してください。
+
+## ユーザー辞書のビルド
+
+CSV ファイルからユーザー辞書をビルドします:
+
+```shell
+% lindera build \
+  --src ./resources/user_dict/sudachidict_simple_userdic.csv \
+  --dest ./resources/user_dict \
+  --metadata ./lindera-sudachidict/metadata.json \
+  --user
+```
+
+ユーザー辞書フォーマットの詳細については、[辞書フォーマット](./dictionary_format.md)を参照してください。
+
+## バイナリへの埋め込み
+
+SudachiDict 辞書をバイナリに直接埋め込むには、以下のようにビルドします:
+
+```shell
+cargo build --features=embed-sudachidict
+```
+
+これにより、外部辞書ファイルなしで `embedded://sudachidict` を辞書パスとして使用できるようになります。
+
+> [!NOTE]
+> 埋め込み辞書はバイナリサイズを約 570MB 増加させます。バイナリサイズが重要な場合は、
+> 上記のように辞書をディレクトリにビルドし、パス指定で読み込むことを推奨します。

--- a/docs/ja/src/lindera-sudachidict/dictionary_format.md
+++ b/docs/ja/src/lindera-sudachidict/dictionary_format.md
@@ -1,0 +1,65 @@
+# Lindera SudachiDict
+
+## 辞書バージョン
+
+このリポジトリには [SudachiDict](https://github.com/lindera/sudachidict) 20260723（small + core + notcore レキシコン）が含まれています。
+
+## 辞書フォーマット
+
+辞書フォーマットおよび品詞タグの詳細については、[SudachiDict のドキュメント](https://github.com/WorksApplications/SudachiDict)を参照してください。
+
+| Index | Name (Japanese) | Name (English) | Notes |
+| --- | --- | --- | --- |
+| 0 | 表層形 | Surface | |
+| 1 | 左文脈ID | Left context ID | |
+| 2 | 右文脈ID | Right context ID | |
+| 3 | コスト | Cost | |
+| 4 | 見出し（解析結果表示用） | Display surface | |
+| 5 | 品詞大分類 | Part-of-speech | |
+| 6 | 品詞中分類 | Part-of-speech subcategory 1 | |
+| 7 | 品詞小分類 | Part-of-speech subcategory 2 | |
+| 8 | 品詞細分類 | Part-of-speech subcategory 3 | |
+| 9 | 活用型 | Conjugation type | |
+| 10 | 活用形 | Conjugation form | |
+| 11 | 読み | Reading | |
+| 12 | 正規化表記 | Normalized form | |
+| 13 | 辞書形ID | Dictionary form word ID | |
+| 14 | 分割タイプ | Split mode | A/B/C |
+| 15 | A単位分割情報 | Split references (A) | |
+| 16 | B単位分割情報 | Split references (B) | |
+| 17 | 語構成 | Word structure | |
+| 18 | 同義語グループID | Synonym group IDs | |
+
+> [!NOTE]
+> 見出し（解析結果表示用）が品詞カラムより前のインデックス 4 に位置するため、
+> トークン詳細（details）の先頭は、IPADIC や UniDic のような品詞ではなく見出しに
+> なります。先頭の詳細を品詞タグとして位置ベースで読み取るトークンフィルタ
+> （`japanese_stop_tags`、`japanese_keep_tags`、`japanese_compound_word`）は、
+> この辞書では期待どおりにマッチしません。`token.get("part_of_speech")` のような
+> スキーマを認識するアクセスは正しく動作します。詳細は
+> [lindera/lindera#997](https://github.com/lindera/lindera/issues/997) を参照してください。
+
+## ユーザー辞書フォーマット (CSV)
+
+### 簡易版
+
+| Index | Name (Japanese) | Name (English) | Notes |
+| --- | --- | --- | --- |
+| 0 | 表層形 | Surface | |
+| 1 | 品詞大分類 | Part-of-speech | |
+| 2 | 読み | Reading | |
+
+### 詳細版
+
+詳細版は上記の辞書フォーマット（19 カラム）に従います。
+
+| Index | Name (Japanese) | Name (English) | Notes |
+| --- | --- | --- | --- |
+| 0-18 | - | Same as the dictionary format | |
+| 19 | - | - | 19 以降は自由に拡張可能です。 |
+
+## API リファレンス
+
+API リファレンスは以下の URL から参照できます:
+
+- [lindera-sudachidict](https://docs.rs/lindera-sudachidict)

--- a/docs/ja/src/lindera-sudachidict/examples.md
+++ b/docs/ja/src/lindera-sudachidict/examples.md
@@ -1,0 +1,64 @@
+# 使用例
+
+このページでは、SudachiDict 辞書を使用したトークナイズの例を示します。
+
+## 外部 SudachiDict でトークナイズ
+
+```shell
+% echo "令和五年に始まった。推し活が楽しい。" | lindera tokenize \
+  --dict /tmp/lindera-sudachidict
+```
+
+```text
+令和	令和,名詞,固有名詞,一般,*,*,*,レイワ,令和,*,A,*,*,*,*
+五	五,名詞,数詞,*,*,*,*,ゴ,五,*,A,*,*,*,017040
+年	年,名詞,普通名詞,助数詞可能,*,*,*,ネン,年,*,A,*,*,*,*
+に	に,助詞,格助詞,*,*,*,*,ニ,に,*,A,*,*,*,*
+始まっ	始まっ,動詞,一般,*,*,五段-ラ行,連用形-促音便,ハジマッ,始まる,380965,A,*,*,*,000378
+た	た,助動詞,*,*,*,助動詞-タ,終止形-一般,タ,た,83558,A,*,*,*,*
+。	。,補助記号,句点,*,*,*,*,。,。,*,A,*,*,*,*
+推し活	推し活,名詞,普通名詞,一般,*,*,*,オシカツ,推し活,*,A,*,*,*,*
+が	が,助詞,格助詞,*,*,*,*,ガ,が,*,A,*,*,*,*
+楽しい	楽しい,形容詞,一般,*,*,形容詞,終止形-一般,タノシイ,楽しい,519727,A,*,*,*,*
+。	。,補助記号,句点,*,*,*,*,。,。,*,A,*,*,*,*
+EOS
+```
+
+`令和` が単一の固有名詞になり（IPADIC と UniDic 2.1.2 は `令` と `和` に分割します）、`推し活` が語彙に含まれている点に注目してください。詳細（details）の先頭カラムは見出し（解析結果表示用）で、その後に品詞カラムと SudachiDict 固有のカラム（正規化表記、分割タイプ、同義語グループID）が続きます。
+
+## 埋め込み SudachiDict でトークナイズ
+
+```shell
+% echo "令和五年に始まった。推し活が楽しい。" | lindera tokenize \
+  --dict embedded://sudachidict
+```
+
+出力は上記と同じです。
+
+注意: SudachiDict 辞書をバイナリに含めるには、`--features=embed-sudachidict` オプションを付けてビルドする必要があります。
+
+## Rust API の使用例
+
+```rust
+use lindera::dictionary::load_dictionary;
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+use lindera_analysis::tokenizer::Tokenizer;
+use lindera::LinderaResult;
+
+fn main() -> LinderaResult<()> {
+    let dictionary = load_dictionary("embedded://sudachidict")?;
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+    let tokenizer = Tokenizer::new(segmenter);
+
+    let text = "令和五年に始まった。推し活が楽しい。";
+    let mut tokens = tokenizer.tokenize(text)?;
+    for token in tokens.iter_mut() {
+        // Schema-aware access: works regardless of column positions
+        let pos = token.get("part_of_speech").unwrap_or_default().to_string();
+        let details = token.details().join(",");
+        println!("{}\t{}\t{}", token.surface.as_ref(), pos, details);
+    }
+    Ok(())
+}
+```

--- a/docs/ja/src/lindera-wasm/installation.md
+++ b/docs/ja/src/lindera-wasm/installation.md
@@ -55,6 +55,7 @@ wasm-pack のデフォルトの `--target` は `bundler` ですが、公開さ�
 | --- | --- | --- |
 | `embed-ipadic` | IPADIC | 日本語 |
 | `embed-unidic` | UniDic | 日本語 |
+| `embed-sudachidict` | SudachiDict | 日本語（注意: 約570MB、WASMでは通常非現実的） |
 | `embed-ko-dic` | ko-dic | 韓国語 |
 | `embed-cc-cedict` | CC-CEDICT | 中国語 |
 | `embed-jieba` | Jieba | 中国語 |

--- a/docs/ja/src/sudachidict.md
+++ b/docs/ja/src/sudachidict.md
@@ -1,9 +1,17 @@
-# SudachiDict（コミュニティレシピ）
+# SudachiDict（カスタムビルド）
 
 このページでは、[SudachiDict](https://github.com/WorksApplications/SudachiDict)
-— Sudachi が使用する、活発にメンテナンスされている日本語辞書 — を、汎用辞書ビルダーと
-メタデータファイルのみを使って Lindera 辞書としてビルドする方法を説明します。
-エンジン側の変更は不要です。
+— Sudachi が使用する、活発にメンテナンスされている日本語辞書 — を、上流の raw
+配布物から、汎用辞書ビルダーとメタデータファイルのみを使って Lindera 辞書として
+直接ビルドする方法を説明します。エンジン側の変更は不要です。
+
+> [!TIP]
+> SudachiDict は公式辞書クレート
+> [`lindera-sudachidict`](./lindera-sudachidict.md) としても利用できます。通常の用途では
+> クレートの利用を推奨します（`--features embed-sudachidict`、`lindera download sudachidict`、
+> またはビルド済みリリースアーカイブ）。同梱バージョンより新しい上流リリースを取り込みたい
+> 場合や、カスタムバリアント（例: small + core のみ）をビルドしたい場合に、このページを
+> 利用してください。
 
 関連 Issue: [lindera/lindera#487](https://github.com/lindera/lindera/issues/487)
 
@@ -14,10 +22,12 @@
 
 ## なぜ SudachiDict か
 
-Lindera が同梱する MeCab フォーマットの辞書（IPADIC、UniDic 2.1.2）は、語彙の更新が
+従来の MeCab フォーマットの辞書（IPADIC、UniDic 2.1.2）は、語彙の更新が
 何年も前に止まっています。SudachiDict は年に数回更新されており、MeCab 互換の raw CSV
 フォーマットで配布されているため、汎用ビルダーでそのままコンパイルできます。
-`20260723` リリースでは:
+公式の `lindera-sudachidict` クレートは `20260723` リリースを同梱しています。この
+レシピを使って上流の raw 配布物からビルドすれば、より新しいリリースを自分で
+取り込むことができます。`20260723` リリースでは:
 
 - `令和` が単一の固有名詞になります（IPADIC と UniDic 2.1.2 は `令|和` に分割します）
 - `スマホ`、`テレワーク`、`推し活`、`コロナ禍` が語彙に含まれます

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -105,6 +105,10 @@
     - [Dictionary Format](./lindera-unidic/dictionary_format.md)
     - [Build](./lindera-unidic/build.md)
     - [Examples](./lindera-unidic/examples.md)
+- [Lindera SudachiDict](./lindera-sudachidict.md)
+    - [Dictionary Format](./lindera-sudachidict/dictionary_format.md)
+    - [Build](./lindera-sudachidict/build.md)
+    - [Examples](./lindera-sudachidict/examples.md)
 
 - [Lindera ko-dic](./lindera-ko-dic.md)
     - [Dictionary Format](./lindera-ko-dic/dictionary_format.md)
@@ -121,7 +125,7 @@
     - [Build](./lindera-jieba/build.md)
     - [Examples](./lindera-jieba/examples.md)
 
-- [SudachiDict (Community Recipe)](./sudachidict.md)
+- [SudachiDict (Custom Build)](./sudachidict.md)
 
 ---
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -11,6 +11,7 @@ graph TB
     TRAINER["lindera-trainer\n(CRF Training)"]
     IPADIC["lindera-ipadic"]
     UNIDIC["lindera-unidic"]
+    SUDACHIDICT["lindera-sudachidict"]
     KODIC["lindera-ko-dic"]
     CCCEDICT["lindera-cc-cedict"]
     JIEBA["lindera-jieba"]
@@ -30,6 +31,7 @@ graph TB
     TRAINER -.->|"train feature"| LIB
     DICT --> IPADIC
     DICT --> UNIDIC
+    DICT --> SUDACHIDICT
     DICT --> KODIC
     DICT --> CCCEDICT
     DICT --> JIEBA
@@ -39,6 +41,7 @@ graph TB
     DICT --> WASM
     IPADIC --> LIB
     UNIDIC --> LIB
+    SUDACHIDICT --> LIB
     KODIC --> LIB
     CCCEDICT --> LIB
     JIEBA --> LIB
@@ -69,6 +72,7 @@ graph TB
 | `lindera-ipadic` | Dictionary | Japanese dictionary based on IPADIC. |
 | `lindera-ipadic-neologd` | Dictionary | Japanese dictionary based on IPADIC NEologd (includes neologisms). |
 | `lindera-unidic` | Dictionary | Japanese dictionary based on UniDic. |
+| `lindera-sudachidict` | Dictionary | Japanese dictionary based on SudachiDict. |
 | `lindera-ko-dic` | Dictionary | Korean dictionary based on ko-dic. |
 | `lindera-cc-cedict` | Dictionary | Chinese dictionary based on CC-CEDICT. |
 | `lindera-jieba` | Dictionary | Chinese dictionary based on Jieba. |
@@ -109,12 +113,14 @@ The **Segmenter** is the core component. It builds a lattice of candidate tokens
 | `embed-ipadic` | Embed the IPADIC dictionary into the binary | Disabled |
 | `embed-ipadic-neologd` | Embed the IPADIC NEologd dictionary into the binary | Disabled |
 | `embed-unidic` | Embed the UniDic dictionary into the binary | Disabled |
+| `embed-sudachidict` | Embed the SudachiDict dictionary into the binary | Disabled |
 | `embed-ko-dic` | Embed the ko-dic dictionary into the binary | Disabled |
 | `embed-cc-cedict` | Embed the CC-CEDICT dictionary into the binary | Disabled |
 | `embed-jieba` | Embed the Jieba dictionary into the binary | Disabled |
 | `embed-cjk` | Embed IPADIC + ko-dic + Jieba dictionaries | Disabled |
 | `embed-cjk2` | Embed UniDic + ko-dic + Jieba dictionaries | Disabled |
 | `embed-cjk3` | Embed IPADIC NEologd + ko-dic + Jieba dictionaries | Disabled |
+| `embed-cjk4` | Embed SudachiDict + ko-dic + Jieba dictionaries | Disabled |
 
 ## Learn More
 

--- a/docs/src/concepts/dictionaries.md
+++ b/docs/src/concepts/dictionaries.md
@@ -7,6 +7,7 @@ Lindera supports various dictionaries for Japanese, Korean, and Chinese morpholo
 | [IPADIC](../lindera-ipadic.md) | Japanese | `lindera-ipadic` | The most common dictionary for Japanese |
 | [IPADIC NEologd](../lindera-ipadic-neologd.md) | Japanese | `lindera-ipadic-neologd` | IPADIC with neologisms (new words) |
 | [UniDic](../lindera-unidic.md) | Japanese | `lindera-unidic` | Uniform word unit definitions |
+| [SudachiDict](../lindera-sudachidict.md) | Japanese | `lindera-sudachidict` | Actively maintained vocabulary, updated several times a year upstream |
 | [ko-dic](../lindera-ko-dic.md) | Korean | `lindera-ko-dic` | Korean morphological analysis |
 | [CC-CEDICT](../lindera-cc-cedict.md) | Chinese | `lindera-cc-cedict` | Chinese-English dictionary |
 | [Jieba](../lindera-jieba.md) | Chinese | `lindera-jieba` | Jieba-based Chinese dictionary |

--- a/docs/src/development/feature_flags.md
+++ b/docs/src/development/feature_flags.md
@@ -35,6 +35,7 @@ These features embed pre-built dictionaries directly into the binary, eliminatin
 | `embed-ipadic` | IPADIC | Japanese |
 | `embed-ipadic-neologd` | IPADIC NEologd | Japanese |
 | `embed-unidic` | UniDic | Japanese |
+| `embed-sudachidict` | SudachiDict | Japanese |
 | `embed-ko-dic` | ko-dic | Korean |
 | `embed-cc-cedict` | CC-CEDICT | Chinese |
 | `embed-jieba` | Jieba | Chinese |
@@ -68,6 +69,7 @@ These meta-features enable multiple dictionaries at once for multilingual applic
 | `embed-cjk` | IPADIC + ko-dic + Jieba |
 | `embed-cjk2` | UniDic + ko-dic + Jieba |
 | `embed-cjk3` | IPADIC NEologd + ko-dic + Jieba |
+| `embed-cjk4` | SudachiDict + ko-dic + Jieba |
 
 ### Combining Feature Flags
 

--- a/docs/src/development/project_structure.md
+++ b/docs/src/development/project_structure.md
@@ -16,6 +16,7 @@ lindera/
 ├── lindera-ipadic/         # IPADIC dictionary (Japanese)
 ├── lindera-ipadic-neologd/ # IPADIC NEologd dictionary (Japanese)
 ├── lindera-unidic/         # UniDic dictionary (Japanese)
+├── lindera-sudachidict/    # SudachiDict dictionary (Japanese)
 ├── lindera-ko-dic/         # ko-dic dictionary (Korean)
 ├── lindera-cc-cedict/      # CC-CEDICT dictionary (Chinese)
 ├── lindera-jieba/          # Jieba dictionary (Chinese)
@@ -78,6 +79,7 @@ Each dictionary crate contains pre-built dictionary data for a specific language
 | `lindera-ipadic` | Japanese | IPADIC |
 | `lindera-ipadic-neologd` | Japanese | IPADIC NEologd (extended vocabulary) |
 | `lindera-unidic` | Japanese | UniDic |
+| `lindera-sudachidict` | Japanese | SudachiDict |
 | `lindera-ko-dic` | Korean | ko-dic |
 | `lindera-cc-cedict` | Chinese | CC-CEDICT |
 | `lindera-jieba` | Chinese | Jieba |

--- a/docs/src/lindera-analysis/architecture.md
+++ b/docs/src/lindera-analysis/architecture.md
@@ -73,6 +73,7 @@ A trait for filters that post-process the tokens produced by the segmenter. Each
 | `embed-ipadic` | Embed the IPADIC dictionary in the binary (forwards to `lindera/embed-ipadic`) | No |
 | `embed-ipadic-neologd` | Embed the IPADIC-NEologd dictionary in the binary (forwards to `lindera/embed-ipadic-neologd`) | No |
 | `embed-unidic` | Embed the UniDic dictionary in the binary (forwards to `lindera/embed-unidic`) | No |
+| `embed-sudachidict` | Embed the SudachiDict dictionary in the binary (forwards to `lindera/embed-sudachidict`) | No |
 | `embed-ko-dic` | Embed the ko-dic dictionary in the binary (forwards to `lindera/embed-ko-dic`) | No |
 | `embed-cc-cedict` | Embed the CC-CEDICT dictionary in the binary (forwards to `lindera/embed-cc-cedict`) | No |
 | `embed-jieba` | Embed the Jieba dictionary in the binary (forwards to `lindera/embed-jieba`) | No |

--- a/docs/src/lindera-cli/commands.md
+++ b/docs/src/lindera-cli/commands.md
@@ -28,6 +28,7 @@ NAME            EMBEDDED  DOWNLOADED  PATH
 ipadic          yes       yes         /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-ipadic
 ipadic-neologd  no        no          -
 unidic          no        incomplete  /home/user/.local/share/lindera/dictionaries/5.1.0/lindera-unidic
+sudachidict     no        no          -
 ko-dic          no        no          -
 cc-cedict       no        no          -
 jieba           no        no          -
@@ -720,6 +721,20 @@ For more details about user dictionary format please refer to the following URL:
   --user
 ```
 
+#### Build SudachiDict user dictionary (Japanese)
+
+For more details about user dictionary format please refer to the following URL:
+
+- [Lindera SudachiDict Builder/User Dictionary Format](https://github.com/lindera/lindera/tree/main/lindera-sudachidict#user-dictionary-format-csv)
+
+```shell
+% lindera build \
+  --src ./resources/user_dict/sudachidict_simple_userdic.csv \
+  --dest ./resources/user_dict \
+  --metadata ./lindera-sudachidict/metadata.json \
+  --user
+```
+
 #### Build CC-CEDICT user dictionary (Chinese)
 
 For more details about user dictionary format please refer to the following URL:
@@ -768,7 +783,7 @@ Download the pre-built dictionary archive matching the CLI version from the [Git
 
 ### Download parameters
 
-- Dictionary name (required): one of `ipadic`, `ipadic-neologd`, `unidic`, `ko-dic`, `cc-cedict`, `jieba`
+- Dictionary name (required): one of `ipadic`, `ipadic-neologd`, `unidic`, `sudachidict`, `ko-dic`, `cc-cedict`, `jieba`
 - `--force`: Re-download and replace an existing dictionary
 
 ### Storage location

--- a/docs/src/lindera-cli/installation.md
+++ b/docs/src/lindera-cli/installation.md
@@ -82,6 +82,12 @@ For advanced users who want to embed dictionaries directly into the binary, use 
 % cargo build --release --features=embed-unidic
 ```
 
+#### SudachiDict (Japanese dictionary)
+
+```shell
+% cargo build --release --features=embed-sudachidict
+```
+
 #### ko-dic (Korean dictionary)
 
 ```shell

--- a/docs/src/lindera-nodejs/installation.md
+++ b/docs/src/lindera-nodejs/installation.md
@@ -71,6 +71,7 @@ npm run build -- --features train
 | `train` | CRF training functionality | Enabled |
 | `embed-ipadic` | Embed Japanese dictionary (IPADIC) into the binary | Disabled |
 | `embed-unidic` | Embed Japanese dictionary (UniDic) into the binary | Disabled |
+| `embed-sudachidict` | Embed Japanese dictionary (SudachiDict) into the binary | Disabled |
 | `embed-ipadic-neologd` | Embed Japanese dictionary (IPADIC NEologd) into the binary | Disabled |
 | `embed-ko-dic` | Embed Korean dictionary (ko-dic) into the binary | Disabled |
 | `embed-cc-cedict` | Embed Chinese dictionary (CC-CEDICT) into the binary | Disabled |

--- a/docs/src/lindera-php/installation.md
+++ b/docs/src/lindera-php/installation.md
@@ -52,6 +52,7 @@ cargo build -p lindera-php --features train
 | `train` | CRF training functionality | Enabled (default) |
 | `embed-ipadic` | Embed Japanese dictionary (IPADIC) into the binary | Disabled |
 | `embed-unidic` | Embed Japanese dictionary (UniDic) into the binary | Disabled |
+| `embed-sudachidict` | Embed Japanese dictionary (SudachiDict) into the binary | Disabled |
 | `embed-ipadic-neologd` | Embed Japanese dictionary (IPADIC NEologd) into the binary | Disabled |
 | `embed-ko-dic` | Embed Korean dictionary (ko-dic) into the binary | Disabled |
 | `embed-cc-cedict` | Embed Chinese dictionary (CC-CEDICT) into the binary | Disabled |

--- a/docs/src/lindera-python/installation.md
+++ b/docs/src/lindera-python/installation.md
@@ -69,6 +69,7 @@ maturin develop --features train
 | `train` | CRF training functionality | Enabled |
 | `embed-ipadic` | Embed Japanese dictionary (IPADIC) into the binary | Disabled |
 | `embed-unidic` | Embed Japanese dictionary (UniDic) into the binary | Disabled |
+| `embed-sudachidict` | Embed Japanese dictionary (SudachiDict) into the binary | Disabled |
 | `embed-ipadic-neologd` | Embed Japanese dictionary (IPADIC NEologd) into the binary | Disabled |
 | `embed-ko-dic` | Embed Korean dictionary (ko-dic) into the binary | Disabled |
 | `embed-cc-cedict` | Embed Chinese dictionary (CC-CEDICT) into the binary | Disabled |

--- a/docs/src/lindera-ruby/installation.md
+++ b/docs/src/lindera-ruby/installation.md
@@ -59,6 +59,7 @@ Features are specified through the `LINDERA_FEATURES` environment variable as a 
 | `train` | CRF training functionality | Enabled |
 | `embed-ipadic` | Embed Japanese dictionary (IPADIC) into the binary | Disabled |
 | `embed-unidic` | Embed Japanese dictionary (UniDic) into the binary | Disabled |
+| `embed-sudachidict` | Embed Japanese dictionary (SudachiDict) into the binary | Disabled |
 | `embed-ipadic-neologd` | Embed Japanese dictionary (IPADIC NEologd) into the binary | Disabled |
 | `embed-ko-dic` | Embed Korean dictionary (ko-dic) into the binary | Disabled |
 | `embed-cc-cedict` | Embed Chinese dictionary (CC-CEDICT) into the binary | Disabled |

--- a/docs/src/lindera-sudachidict.md
+++ b/docs/src/lindera-sudachidict.md
@@ -1,0 +1,18 @@
+# Lindera SudachiDict
+
+Lindera SudachiDict is a Japanese dictionary crate based on [SudachiDict](https://github.com/WorksApplications/SudachiDict), the actively maintained dictionary used by the Sudachi morphological analyzer. It is updated several times a year upstream, so recent vocabulary (`令和`, `スマホ`, `推し活`, ...) is in-vocabulary. Each entry has 19 fields, including SudachiDict-specific columns such as the normalized form, split references, and synonym group IDs.
+
+The dictionary source files are mirrored at [lindera/sudachidict](https://github.com/lindera/sudachidict). The bundled version is `20260723` (small + core + notcore lexicons).
+
+> [!NOTE]
+> This dictionary reproduces SudachiDict's vocabulary and lattice behavior, but not the Sudachi engine plugins (katakana/numeric joining, input normalization, A/B/C split modes). See [Behavioral differences from Sudachi](./sudachidict.md#behavioral-differences-from-sudachi) for details.
+
+## Contents
+
+- [Dictionary Format](./lindera-sudachidict/dictionary_format.md) -- Field definitions for system and user dictionaries
+- [Build](./lindera-sudachidict/build.md) -- How to build the dictionary from source
+- [Examples](./lindera-sudachidict/examples.md) -- Tokenization examples
+
+## API Reference
+
+- [lindera-sudachidict](https://docs.rs/lindera-sudachidict)

--- a/docs/src/lindera-sudachidict/build.md
+++ b/docs/src/lindera-sudachidict/build.md
@@ -1,0 +1,53 @@
+# Build
+
+This page describes how to build the SudachiDict dictionary from source files.
+
+## Build system dictionary
+
+Download the SudachiDict source archive and build the dictionary:
+
+```shell
+% curl -L -o /tmp/sudachidict-20260723.tar.gz "https://lindera.dev/sudachidict-20260723.tar.gz"
+% tar zxvf /tmp/sudachidict-20260723.tar.gz -C /tmp
+
+% lindera build \
+  --src /tmp/sudachidict-20260723 \
+  --dest /tmp/lindera-sudachidict \
+  --metadata ./lindera-sudachidict/metadata.json
+```
+
+The archive bundles the raw lexicons (small + core + notcore), the connection matrix, and pre-aligned `char.def` / `unk.def`, so no manual preprocessing is needed. The built dictionary is about 570MB.
+
+> [!TIP]
+> To build from a newer upstream SudachiDict release than the bundled one, see
+> [SudachiDict (Custom Build)](../sudachidict.md), which builds directly from
+> the upstream raw distribution.
+
+## Build user dictionary
+
+Build a user dictionary from a CSV file:
+
+```shell
+% lindera build \
+  --src ./resources/user_dict/sudachidict_simple_userdic.csv \
+  --dest ./resources/user_dict \
+  --metadata ./lindera-sudachidict/metadata.json \
+  --user
+```
+
+For more details about user dictionary format, see [Dictionary Format](./dictionary_format.md).
+
+## Embedding in binary
+
+To embed the SudachiDict dictionary directly into the binary:
+
+```shell
+cargo build --features=embed-sudachidict
+```
+
+This allows using `embedded://sudachidict` as the dictionary path without external dictionary files.
+
+> [!NOTE]
+> The embedded dictionary adds roughly 570MB to the binary. If binary size
+> matters, prefer building the dictionary to a directory as shown above and
+> loading it by path.

--- a/docs/src/lindera-sudachidict/dictionary_format.md
+++ b/docs/src/lindera-sudachidict/dictionary_format.md
@@ -1,0 +1,66 @@
+# Lindera SudachiDict
+
+## Dictionary version
+
+This repository contains [SudachiDict](https://github.com/lindera/sudachidict) 20260723 (small + core + notcore lexicons).
+
+## Dictionary format
+
+Refer to the [SudachiDict documentation](https://github.com/WorksApplications/SudachiDict) for details on the dictionary format and part-of-speech tags.
+
+| Index | Name (Japanese) | Name (English) | Notes |
+| --- | --- | --- | --- |
+| 0 | 表層形 | Surface | |
+| 1 | 左文脈ID | Left context ID | |
+| 2 | 右文脈ID | Right context ID | |
+| 3 | コスト | Cost | |
+| 4 | 見出し（解析結果表示用） | Display surface | |
+| 5 | 品詞大分類 | Part-of-speech | |
+| 6 | 品詞中分類 | Part-of-speech subcategory 1 | |
+| 7 | 品詞小分類 | Part-of-speech subcategory 2 | |
+| 8 | 品詞細分類 | Part-of-speech subcategory 3 | |
+| 9 | 活用型 | Conjugation type | |
+| 10 | 活用形 | Conjugation form | |
+| 11 | 読み | Reading | |
+| 12 | 正規化表記 | Normalized form | |
+| 13 | 辞書形ID | Dictionary form word ID | |
+| 14 | 分割タイプ | Split mode | A/B/C |
+| 15 | A単位分割情報 | Split references (A) | |
+| 16 | B単位分割情報 | Split references (B) | |
+| 17 | 語構成 | Word structure | |
+| 18 | 同義語グループID | Synonym group IDs | |
+
+> [!NOTE]
+> Because the display surface sits at index 4 (before the part-of-speech
+> columns), the first token detail is the display surface -- not the
+> part-of-speech as in IPADIC or UniDic. Token filters that read the leading
+> details positionally as part-of-speech tags (`japanese_stop_tags`,
+> `japanese_keep_tags`, `japanese_compound_word`) do not match as expected
+> with this dictionary; schema-aware access such as
+> `token.get("part_of_speech")` works correctly. See
+> [lindera/lindera#997](https://github.com/lindera/lindera/issues/997).
+
+## User dictionary format (CSV)
+
+### Simple version
+
+| Index | Name (Japanese) | Name (English) | Notes |
+| --- | --- | --- | --- |
+| 0 | 表層形 | Surface | |
+| 1 | 品詞大分類 | Part-of-speech | |
+| 2 | 読み | Reading | |
+
+### Detailed version
+
+The detailed version follows the dictionary format above (19 columns).
+
+| Index | Name (Japanese) | Name (English) | Notes |
+| --- | --- | --- | --- |
+| 0-18 | - | Same as the dictionary format | |
+| 19 | - | - | After 19, it can be freely expanded. |
+
+## API reference
+
+The API reference is available. Please see following URL:
+
+- [lindera-sudachidict](https://docs.rs/lindera-sudachidict)

--- a/docs/src/lindera-sudachidict/examples.md
+++ b/docs/src/lindera-sudachidict/examples.md
@@ -1,0 +1,64 @@
+# Examples
+
+This page shows tokenization examples using the SudachiDict dictionary.
+
+## Tokenize with external SudachiDict
+
+```shell
+% echo "令和五年に始まった。推し活が楽しい。" | lindera tokenize \
+  --dict /tmp/lindera-sudachidict
+```
+
+```text
+令和	令和,名詞,固有名詞,一般,*,*,*,レイワ,令和,*,A,*,*,*,*
+五	五,名詞,数詞,*,*,*,*,ゴ,五,*,A,*,*,*,017040
+年	年,名詞,普通名詞,助数詞可能,*,*,*,ネン,年,*,A,*,*,*,*
+に	に,助詞,格助詞,*,*,*,*,ニ,に,*,A,*,*,*,*
+始まっ	始まっ,動詞,一般,*,*,五段-ラ行,連用形-促音便,ハジマッ,始まる,380965,A,*,*,*,000378
+た	た,助動詞,*,*,*,助動詞-タ,終止形-一般,タ,た,83558,A,*,*,*,*
+。	。,補助記号,句点,*,*,*,*,。,。,*,A,*,*,*,*
+推し活	推し活,名詞,普通名詞,一般,*,*,*,オシカツ,推し活,*,A,*,*,*,*
+が	が,助詞,格助詞,*,*,*,*,ガ,が,*,A,*,*,*,*
+楽しい	楽しい,形容詞,一般,*,*,形容詞,終止形-一般,タノシイ,楽しい,519727,A,*,*,*,*
+。	。,補助記号,句点,*,*,*,*,。,。,*,A,*,*,*,*
+EOS
+```
+
+Notice that `令和` is a single proper noun (IPADIC and UniDic 2.1.2 split it into `令` and `和`) and `推し活` is in-vocabulary. The first detail column is the display surface, followed by the part-of-speech columns and SudachiDict-specific columns (normalized form, split mode, synonym group IDs).
+
+## Tokenize with embedded SudachiDict
+
+```shell
+% echo "令和五年に始まった。推し活が楽しい。" | lindera tokenize \
+  --dict embedded://sudachidict
+```
+
+The output is the same as above.
+
+NOTE: To include SudachiDict dictionary in the binary, you must build with the `--features=embed-sudachidict` option.
+
+## Rust API example
+
+```rust
+use lindera::dictionary::load_dictionary;
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+use lindera_analysis::tokenizer::Tokenizer;
+use lindera::LinderaResult;
+
+fn main() -> LinderaResult<()> {
+    let dictionary = load_dictionary("embedded://sudachidict")?;
+    let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+    let tokenizer = Tokenizer::new(segmenter);
+
+    let text = "令和五年に始まった。推し活が楽しい。";
+    let mut tokens = tokenizer.tokenize(text)?;
+    for token in tokens.iter_mut() {
+        // Schema-aware access: works regardless of column positions
+        let pos = token.get("part_of_speech").unwrap_or_default().to_string();
+        let details = token.details().join(",");
+        println!("{}\t{}\t{}", token.surface.as_ref(), pos, details);
+    }
+    Ok(())
+}
+```

--- a/docs/src/lindera-wasm/installation.md
+++ b/docs/src/lindera-wasm/installation.md
@@ -77,6 +77,7 @@ For advanced users who want to embed dictionaries directly into the WASM binary,
 | --- | --- | --- |
 | `embed-ipadic` | IPADIC | Japanese |
 | `embed-unidic` | UniDic | Japanese |
+| `embed-sudachidict` | SudachiDict | Japanese (note: ~570MB, generally impractical for WASM) |
 | `embed-ko-dic` | ko-dic | Korean |
 | `embed-cc-cedict` | CC-CEDICT | Chinese |
 | `embed-jieba` | Jieba | Chinese |

--- a/docs/src/sudachidict.md
+++ b/docs/src/sudachidict.md
@@ -1,9 +1,18 @@
-# SudachiDict (Community Recipe)
+# SudachiDict (Custom Build)
 
 This page describes how to build [SudachiDict](https://github.com/WorksApplications/SudachiDict)
 — the actively maintained Japanese dictionary used by Sudachi — as a Lindera
-dictionary, using only the generic dictionary builder and a metadata file.
-No engine changes are required.
+dictionary directly from the upstream raw distribution, using only the
+generic dictionary builder and a metadata file. No engine changes are
+required.
+
+> [!TIP]
+> SudachiDict is also available as an official dictionary crate:
+> [`lindera-sudachidict`](./lindera-sudachidict.md). Prefer the crate for
+> normal use (`--features embed-sudachidict`, `lindera download sudachidict`,
+> or the pre-built release archive). Use this page when you want to track a
+> newer upstream release than the bundled one, or to build a custom variant
+> (for example, small + core only).
 
 Related issue: [lindera/lindera#487](https://github.com/lindera/lindera/issues/487)
 
@@ -15,10 +24,13 @@ Related issue: [lindera/lindera#487](https://github.com/lindera/lindera/issues/4
 
 ## Why
 
-The MeCab-format dictionaries Lindera ships (IPADIC, UniDic 2.1.2) stopped
+The classic MeCab-format dictionaries (IPADIC, UniDic 2.1.2) stopped
 receiving vocabulary updates years ago. SudachiDict is updated several times a
 year and is distributed in a MeCab-compatible raw CSV format, which the
-generic builder can compile directly. With the `20260723` release:
+generic builder can compile directly. The official `lindera-sudachidict`
+crate bundles the `20260723` release; building from the upstream raw
+distribution with this recipe lets you pick up newer releases yourself.
+With the `20260723` release:
 
 - `令和` is a single proper noun (IPADIC and UniDic 2.1.2 split it into `令|和`)
 - `スマホ`, `テレワーク`, `推し活`, `コロナ禍` are in-vocabulary


### PR DESCRIPTION
## Summary

Documents the official SudachiDict dictionary crate across the mdBook, in both English (`docs/src/`) and Japanese (`docs/ja/src/`). Refs #998. This is the documentation follow-up to #999 — **merge after #999**, since the pages describe the `lindera-sudachidict` crate, the `embed-sudachidict` / `embed-cjk4` features, and `lindera download sudachidict` introduced there.

## What's included

- **New chapter** `Lindera SudachiDict` (overview / Dictionary Format / Build / Examples), modeled on the `Lindera UniDic` chapter. The examples use output verified against the actual built dictionary (`令和` as a single proper noun, `推し活` in-vocabulary), and the format page documents the `details[0]` = display-surface caveat with a pointer to #997. The Rust sample uses the schema-aware `token.get("part_of_speech")` accessor (signature checked against `lindera/src/token.rs`).
- **Enumeration pages updated**: dictionary comparison table (`concepts/dictionaries.md`), crate tables and dependency graph (`architecture.md`, `development/project_structure.md`), feature tables (`development/feature_flags.md`, `lindera-analysis/architecture.md`, per-binding `installation.md` for Python/Node.js/Ruby/PHP/WASM — the WASM row notes ~570MB is generally impractical), and CLI docs (`lindera list` sample output, `download` dictionary names, SudachiDict build sections in `commands.md` / `installation.md`).
- **Recipe page repositioned**: `sudachidict.md` is retitled "SudachiDict (Custom Build)" and now points readers to the official crate for normal use, keeping the manual recipe for tracking newer upstream releases or building custom variants.

## Verification

- `markdownlint-cli2 "docs/src/**/*.md" "docs/ja/src/**/*.md"`: 216 files, 0 errors
- `mdbook build docs` and `mdbook build docs/ja` both succeed
- English and Japanese trees are 1:1 (14 pages edited + 4 pages added on each side)
