### PR TITLE
chore: bump version to 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-analysis"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-binding-core"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "criterion",
  "lindera",
@@ -1627,14 +1627,14 @@ dependencies = [
 
 [[package]]
 name = "lindera-cc-cedict"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-cli"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-crf"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "argmin",
  "argmin-math",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1695,35 +1695,35 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-ipadic-neologd"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-jieba"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-ko-dic"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-nodejs"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-php"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "ext-php-rs",
  "lindera",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-python"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1762,7 +1762,7 @@ dependencies = [
 
 [[package]]
 name = "lindera-ruby"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera",
  "lindera-binding-core",
@@ -1774,14 +1774,14 @@ dependencies = [
 
 [[package]]
 name = "lindera-sudachidict"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-trainer"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "lindera-crf",
@@ -1795,14 +1795,14 @@ dependencies = [
 
 [[package]]
 name = "lindera-unidic"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-wasm"
-version = "5.3.0"
+version = "6.0.0"
 dependencies = [
  "js-sys",
  "lindera",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.3.0"
+version = "6.0.0"
 edition = "2024"
 # Edition 2024 alone implies 1.85, but `slice::as_chunks` (used by the
 # WordEntry decode path in lindera-dictionary) stabilized in 1.88. Declaring it
@@ -49,25 +49,25 @@ csv = "1.4.0"
 # loudly if the layout changes; review it before moving this pin.
 crawdad = "=0.4.1"
 daachorse = "5.0.0"
-lindera = { version = "5.3.0", path = "lindera" }
-lindera-analysis = { version = "5.3.0", path = "lindera-analysis" }
-lindera-binding-core = { version = "5.3.0", path = "lindera-binding-core" }
-lindera-crf = { version = "5.3.0", path = "lindera-crf" }
-lindera-cc-cedict = { version = "5.3.0", path = "lindera-cc-cedict" }
-lindera-cli = { version = "5.3.0", path = "lindera-cli" }
-lindera-dictionary = { version = "5.3.0", path = "lindera-dictionary" }
-lindera-trainer = { version = "5.3.0", path = "lindera-trainer" }
-lindera-ipadic = { version = "5.3.0", path = "lindera-ipadic" }
-lindera-ipadic-neologd = { version = "5.3.0", path = "lindera-ipadic-neologd" }
-lindera-jieba = { version = "5.3.0", path = "lindera-jieba" }
-lindera-ko-dic = { version = "5.3.0", path = "lindera-ko-dic" }
-lindera-nodejs = { version = "5.3.0", path = "lindera-nodejs" }
-lindera-sudachidict = { version = "5.3.0", path = "lindera-sudachidict" }
-lindera-python = { version = "5.3.0", path = "lindera-python" }
-lindera-ruby = { version = "5.3.0", path = "lindera-ruby" }
-lindera-unidic = { version = "5.3.0", path = "lindera-unidic" }
-lindera-php = { version = "5.3.0", path = "lindera-php" }
-lindera-wasm = { version = "5.3.0", path = "lindera-wasm" }
+lindera = { version = "6.0.0", path = "lindera" }
+lindera-analysis = { version = "6.0.0", path = "lindera-analysis" }
+lindera-binding-core = { version = "6.0.0", path = "lindera-binding-core" }
+lindera-crf = { version = "6.0.0", path = "lindera-crf" }
+lindera-cc-cedict = { version = "6.0.0", path = "lindera-cc-cedict" }
+lindera-cli = { version = "6.0.0", path = "lindera-cli" }
+lindera-dictionary = { version = "6.0.0", path = "lindera-dictionary" }
+lindera-trainer = { version = "6.0.0", path = "lindera-trainer" }
+lindera-ipadic = { version = "6.0.0", path = "lindera-ipadic" }
+lindera-ipadic-neologd = { version = "6.0.0", path = "lindera-ipadic-neologd" }
+lindera-jieba = { version = "6.0.0", path = "lindera-jieba" }
+lindera-ko-dic = { version = "6.0.0", path = "lindera-ko-dic" }
+lindera-nodejs = { version = "6.0.0", path = "lindera-nodejs" }
+lindera-sudachidict = { version = "6.0.0", path = "lindera-sudachidict" }
+lindera-python = { version = "6.0.0", path = "lindera-python" }
+lindera-ruby = { version = "6.0.0", path = "lindera-ruby" }
+lindera-unidic = { version = "6.0.0", path = "lindera-unidic" }
+lindera-php = { version = "6.0.0", path = "lindera-php" }
+lindera-wasm = { version = "6.0.0", path = "lindera-wasm" }
 log = "0.4.33"
 num_cpus = "1.17.0"
 once_cell = "1.21.4"

--- a/docs/ja/src/lindera-wasm/tokenizer_api.md
+++ b/docs/ja/src/lindera-wasm/tokenizer_api.md
@@ -257,7 +257,7 @@ lindera-wasm パッケージのバージョン文字列を返します。
 ```javascript
 import { version } from 'lindera-wasm-ipadic';
 
-console.log(version()); // 例: "5.3.0"
+console.log(version()); // 例: "6.0.0"
 ```
 
 ## 列挙型とユーティリティクラス

--- a/docs/src/lindera-wasm/tokenizer_api.md
+++ b/docs/src/lindera-wasm/tokenizer_api.md
@@ -259,7 +259,7 @@ Returns the version string of the lindera-wasm package.
 ```javascript
 import { version } from 'lindera-wasm-ipadic';
 
-console.log(version()); // e.g., "5.3.0"
+console.log(version()); // e.g., "6.0.0"
 ```
 
 ## Enums and Utility Classes

--- a/lindera-nodejs/index.js
+++ b/lindera-nodejs/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('lindera-android-arm64')
         const bindingPackageVersion = require('lindera-android-arm64/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('lindera-android-arm-eabi')
         const bindingPackageVersion = require('lindera-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('lindera-win32-x64-gnu')
         const bindingPackageVersion = require('lindera-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('lindera-win32-x64-msvc')
         const bindingPackageVersion = require('lindera-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('lindera-win32-ia32-msvc')
         const bindingPackageVersion = require('lindera-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('lindera-win32-arm64-msvc')
         const bindingPackageVersion = require('lindera-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('lindera-darwin-universal')
       const bindingPackageVersion = require('lindera-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('lindera-darwin-x64')
         const bindingPackageVersion = require('lindera-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('lindera-darwin-arm64')
         const bindingPackageVersion = require('lindera-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('lindera-freebsd-x64')
         const bindingPackageVersion = require('lindera-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('lindera-freebsd-arm64')
         const bindingPackageVersion = require('lindera-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-x64-musl')
           const bindingPackageVersion = require('lindera-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-x64-gnu')
           const bindingPackageVersion = require('lindera-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-arm64-musl')
           const bindingPackageVersion = require('lindera-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-arm64-gnu')
           const bindingPackageVersion = require('lindera-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-arm-musleabihf')
           const bindingPackageVersion = require('lindera-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-arm-gnueabihf')
           const bindingPackageVersion = require('lindera-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-loong64-musl')
           const bindingPackageVersion = require('lindera-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-loong64-gnu')
           const bindingPackageVersion = require('lindera-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-riscv64-musl')
           const bindingPackageVersion = require('lindera-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('lindera-linux-riscv64-gnu')
           const bindingPackageVersion = require('lindera-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('lindera-linux-ppc64-gnu')
         const bindingPackageVersion = require('lindera-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('lindera-linux-s390x-gnu')
         const bindingPackageVersion = require('lindera-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('lindera-openharmony-arm64')
         const bindingPackageVersion = require('lindera-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('lindera-openharmony-x64')
         const bindingPackageVersion = require('lindera-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('lindera-openharmony-arm')
         const bindingPackageVersion = require('lindera-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '5.3.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '6.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('lindera-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '5.3.0') {
-            throw new Error(`WASI binding package version mismatch, expected 5.3.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '6.0.0') {
+            throw new Error(`WASI binding package version mismatch, expected 6.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('lindera-wasm32-wasi')

--- a/lindera-nodejs/package.json
+++ b/lindera-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "Node.js bindings for Lindera morphological analysis engine",
   "main": "index.js",
   "types": "index.d.ts",

--- a/lindera-ruby/lindera.gemspec
+++ b/lindera-ruby/lindera.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "lindera"
-  spec.version = "5.3.0"
+  spec.version = "6.0.0"
   spec.authors = ["Lindera contributors"]
   spec.summary = "Ruby bindings for Lindera morphological analysis engine"
   spec.description = "Ruby bindings for Lindera, a morphological analysis library for CJK text (Japanese, Korean, Chinese)."

--- a/lindera-wasm/example/package.json
+++ b/lindera-wasm/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lindera-wasm-example",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "Example project for Lindera WASM",
   "scripts": {
     "start": "webpack serve --config webpack.config.js",


### PR DESCRIPTION
## Summary

Bump the workspace version from 5.3.0 to 6.0.0 for the next major release.

## Changes

- `Cargo.toml`: workspace version and all internal crate dependency versions
- `Cargo.lock`: regenerated for the new versions
- `lindera-nodejs/package.json` + generated `index.js` (NAPI-RS version-check strings)
- `lindera-ruby/lindera.gemspec`
- `lindera-wasm/example/package.json`
- Docs: `version()` output examples in the wasm tokenizer API pages (en/ja)

## Verification

- `grep -r "5.3.0"` finds no remaining references outside `target/` and lockfiles
- `cargo metadata --locked` passes (lockfile consistent with the new versions)
- The `lindera-*` platform packages in `optionalDependencies` stay at their `0.0.0` placeholders (replaced at publish time by NAPI-RS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)